### PR TITLE
fix(web): redirect all pages to /setup when setup is incomplete

### DIFF
--- a/src/Feirb.Web/App.razor
+++ b/src/Feirb.Web/App.razor
@@ -1,12 +1,14 @@
-<CascadingAuthenticationState>
-    <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
-        <Found Context="routeData">
-            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
-                <NotAuthorized>
-                    <RedirectToLogin />
-                </NotAuthorized>
-            </AuthorizeRouteView>
-            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-        </Found>
-    </Router>
-</CascadingAuthenticationState>
+<SetupGuard>
+    <CascadingAuthenticationState>
+        <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+            <Found Context="routeData">
+                <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                    <NotAuthorized>
+                        <RedirectToLogin />
+                    </NotAuthorized>
+                </AuthorizeRouteView>
+                <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+            </Found>
+        </Router>
+    </CascadingAuthenticationState>
+</SetupGuard>

--- a/src/Feirb.Web/Components/SetupGuard.razor
+++ b/src/Feirb.Web/Components/SetupGuard.razor
@@ -1,0 +1,35 @@
+@using Feirb.Shared.Setup
+@inject HttpClient Http
+@inject NavigationManager Navigation
+
+@if (_checked)
+{
+    @ChildContent
+}
+
+@code {
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private bool _checked;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            var status = await Http.GetFromJsonAsync<SetupStatusResponse>("/api/setup/status");
+            if (status is { IsComplete: false })
+            {
+                var uri = new Uri(Navigation.Uri);
+                if (!uri.AbsolutePath.Equals("/setup", StringComparison.OrdinalIgnoreCase))
+                    Navigation.NavigateTo("/setup");
+            }
+        }
+        catch
+        {
+            // If setup status check fails, continue normally
+        }
+
+        _checked = true;
+    }
+}

--- a/src/Feirb.Web/Pages/Login.razor
+++ b/src/Feirb.Web/Pages/Login.razor
@@ -2,7 +2,6 @@
 @layout AuthLayout
 @attribute [AllowAnonymous]
 @using Feirb.Shared.Auth
-@using Feirb.Shared.Setup
 @using Feirb.Web.Services
 @inject HttpClient Http
 @inject NavigationManager Navigation
@@ -80,22 +79,11 @@
     private bool _showRegisteredMessage;
     private bool _showResetMessage;
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
         var uri = new Uri(Navigation.Uri);
         _showRegisteredMessage = uri.Query.Contains("registered=true");
         _showResetMessage = uri.Query.Contains("reset=true");
-
-        try
-        {
-            var status = await Http.GetFromJsonAsync<SetupStatusResponse>("/api/setup/status");
-            if (status is { IsComplete: false })
-                Navigation.NavigateTo("/setup");
-        }
-        catch
-        {
-            // If setup status check fails, continue to login
-        }
     }
 
     private async Task HandleLoginAsync()


### PR DESCRIPTION
## Summary
- Add central `SetupGuard` component wrapping the Router in `App.razor` — checks `/api/setup/status` on startup and redirects to `/setup` if no admin exists
- Removes duplicate per-page setup checks from `Login.razor` (and prevents the need to add them to every future page)
- `/setup` itself is excluded from the redirect so it can render normally

## Test plan
- [x] Navigate to `/` with fresh DB → redirects to `/setup`
- [x] Navigate to `/register` with fresh DB → redirects to `/setup`
- [x] Navigate to `/login` with fresh DB → redirects to `/setup`
- [x] `/setup` page renders and is usable
- [x] After setup complete, all pages work normally

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)