### PR TITLE
feat(api,web): add admin role with authorization policy (#19)

### DIFF
--- a/src/Feirb.Api/Endpoints/AdminEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/AdminEndpoints.cs
@@ -1,0 +1,19 @@
+using Feirb.Api.Data;
+using Feirb.Shared.Admin;
+using Microsoft.EntityFrameworkCore;
+
+namespace Feirb.Api.Endpoints;
+
+public static class AdminEndpoints
+{
+    public static RouteGroupBuilder MapAdminEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/users", GetUsersAsync);
+        return group;
+    }
+
+    private static async Task<IResult> GetUsersAsync(FeirbDbContext db) =>
+        Results.Ok(await db.Users
+            .Select(u => new AdminUserResponse(u.Id, u.Username, u.Email, u.IsAdmin, u.CreatedAt))
+            .ToListAsync());
+}

--- a/src/Feirb.Api/Program.cs
+++ b/src/Feirb.Api/Program.cs
@@ -36,7 +36,10 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             ClockSkew = TimeSpan.Zero,
         };
     });
-builder.Services.AddAuthorization();
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("RequireAdmin", policy => policy.RequireRole("Admin"));
+});
 
 // Data Protection API for credential encryption
 builder.Services.AddDataProtection();
@@ -86,6 +89,10 @@ authGroup.MapAuthEndpoints();
 // Setup endpoints are anonymous (guarded by admin-exists check)
 var setupGroup = app.MapGroup(ApiRoutes.Setup).AllowAnonymous();
 setupGroup.MapSetupEndpoints();
+
+// Admin endpoints require admin role
+var adminGroup = apiGroup.MapGroup("/admin").RequireAuthorization("RequireAdmin");
+adminGroup.MapAdminEndpoints();
 
 app.MapFallbackToFile("index.html");
 

--- a/src/Feirb.Api/Services/AuthService.cs
+++ b/src/Feirb.Api/Services/AuthService.cs
@@ -63,12 +63,15 @@ public class AuthService(IOptions<JwtSettings> jwtSettings) : IAuthService
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSettings.Key));
         var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
-        var claims = new[]
+        var claims = new List<Claim>
         {
-            new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
-            new Claim(ClaimTypes.Name, user.Username),
-            new Claim(ClaimTypes.Email, user.Email),
+            new(ClaimTypes.NameIdentifier, user.Id.ToString()),
+            new(ClaimTypes.Name, user.Username),
+            new(ClaimTypes.Email, user.Email),
         };
+
+        if (user.IsAdmin)
+            claims.Add(new Claim(ClaimTypes.Role, "Admin"));
 
         var token = new JwtSecurityToken(
             issuer: _jwtSettings.Issuer,

--- a/src/Feirb.Shared/Admin/AdminUserResponse.cs
+++ b/src/Feirb.Shared/Admin/AdminUserResponse.cs
@@ -1,0 +1,3 @@
+namespace Feirb.Shared.Admin;
+
+public record AdminUserResponse(Guid Id, string Username, string Email, bool IsAdmin, DateTime CreatedAt);

--- a/src/Feirb.Shared/ApiRoutes.cs
+++ b/src/Feirb.Shared/ApiRoutes.cs
@@ -11,4 +11,5 @@ public static class ApiRoutes
     public const string Ai = "/api/ai";
     public const string Auth = "/api/auth";
     public const string Setup = "/api/setup";
+    public const string Admin = "/api/admin";
 }

--- a/src/Feirb.Web/Layout/NavMenu.razor
+++ b/src/Feirb.Web/Layout/NavMenu.razor
@@ -16,5 +16,23 @@
                 <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> @L["NavHome"]
             </NavLink>
         </div>
+
+        <AuthorizeView Policy="RequireAdmin">
+            <Authorized>
+                <div class="nav-item px-3 mt-3">
+                    <h6 class="text-muted small fw-bold text-uppercase px-3">@L["NavAdmin"]</h6>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="admin/users">
+                        <span class="bi bi-people-fill-nav-menu" aria-hidden="true"></span> @L["NavAdminUsers"]
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="admin/settings">
+                        <span class="bi bi-gear-fill-nav-menu" aria-hidden="true"></span> @L["NavAdminSettings"]
+                    </NavLink>
+                </div>
+            </Authorized>
+        </AuthorizeView>
     </nav>
 </div>

--- a/src/Feirb.Web/Program.cs
+++ b/src/Feirb.Web/Program.cs
@@ -12,7 +12,10 @@ builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddLocalization();
-builder.Services.AddAuthorizationCore();
+builder.Services.AddAuthorizationCore(options =>
+{
+    options.AddPolicy("RequireAdmin", policy => policy.RequireRole("Admin"));
+});
 
 builder.Services.AddScoped<JwtAuthenticationStateProvider>();
 builder.Services.AddScoped<AuthenticationStateProvider>(sp =>

--- a/src/Feirb.Web/Resources/SharedResources.de-DE.resx
+++ b/src/Feirb.Web/Resources/SharedResources.de-DE.resx
@@ -273,4 +273,13 @@
   <data name="SuccessSetupComplete" xml:space="preserve">
     <value>Einrichtung erfolgreich abgeschlossen! Bitte melde dich an.</value>
   </data>
+  <data name="NavAdmin" xml:space="preserve">
+    <value>Administration</value>
+  </data>
+  <data name="NavAdminUsers" xml:space="preserve">
+    <value>Benutzer</value>
+  </data>
+  <data name="NavAdminSettings" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
+++ b/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
@@ -273,4 +273,13 @@
   <data name="SuccessSetupComplete" xml:space="preserve">
     <value>Configuration terminée avec succès ! Veuillez vous connecter.</value>
   </data>
+  <data name="NavAdmin" xml:space="preserve">
+    <value>Administration</value>
+  </data>
+  <data name="NavAdminUsers" xml:space="preserve">
+    <value>Utilisateurs</value>
+  </data>
+  <data name="NavAdminSettings" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.it-IT.resx
+++ b/src/Feirb.Web/Resources/SharedResources.it-IT.resx
@@ -273,4 +273,13 @@
   <data name="SuccessSetupComplete" xml:space="preserve">
     <value>Configurazione completata con successo! Effettua l'accesso.</value>
   </data>
+  <data name="NavAdmin" xml:space="preserve">
+    <value>Amministrazione</value>
+  </data>
+  <data name="NavAdminUsers" xml:space="preserve">
+    <value>Utenti</value>
+  </data>
+  <data name="NavAdminSettings" xml:space="preserve">
+    <value>Impostazioni</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.resx
+++ b/src/Feirb.Web/Resources/SharedResources.resx
@@ -273,4 +273,13 @@
   <data name="SuccessSetupComplete" xml:space="preserve">
     <value>Setup completed successfully! Please log in.</value>
   </data>
+  <data name="NavAdmin" xml:space="preserve">
+    <value>Administration</value>
+  </data>
+  <data name="NavAdminUsers" xml:space="preserve">
+    <value>Users</value>
+  </data>
+  <data name="NavAdminSettings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Services/JwtAuthenticationStateProvider.cs
+++ b/src/Feirb.Web/Services/JwtAuthenticationStateProvider.cs
@@ -21,7 +21,7 @@ public sealed class JwtAuthenticationStateProvider(IJSRuntime jsRuntime) : Authe
         if (claims is null)
             return _anonymousState;
 
-        var identity = new ClaimsIdentity(claims, "jwt");
+        var identity = new ClaimsIdentity(claims, "jwt", "name", "role");
         return new AuthenticationState(new ClaimsPrincipal(identity));
     }
 
@@ -30,7 +30,7 @@ public sealed class JwtAuthenticationStateProvider(IJSRuntime jsRuntime) : Authe
         ArgumentNullException.ThrowIfNull(tokens);
         await jsRuntime.InvokeVoidAsync("blazorAuth.setTokens", tokens.AccessToken, tokens.RefreshToken);
         var claims = ParseClaimsFromJwt(tokens.AccessToken);
-        var identity = new ClaimsIdentity(claims, "jwt");
+        var identity = new ClaimsIdentity(claims, "jwt", "name", "role");
         var user = new ClaimsPrincipal(identity);
         NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(user)));
     }

--- a/tests/Feirb.Api.Tests/Endpoints/AdminEndpointsTests.cs
+++ b/tests/Feirb.Api.Tests/Endpoints/AdminEndpointsTests.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Feirb.Api.Data;
+using Feirb.Shared.Admin;
+using Feirb.Shared.Auth;
+using Feirb.Shared.Setup;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Feirb.Api.Tests.Endpoints;
+
+public class AdminEndpointsTests : IDisposable
+{
+    private readonly string _dbName = $"TestDb-{Guid.NewGuid()}";
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    public AdminEndpointsTests()
+    {
+        var dbName = _dbName;
+        _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var dbDescriptors = services.Where(d =>
+                    d.ServiceType == typeof(DbContextOptions<FeirbDbContext>) ||
+                    d.ServiceType.FullName?.Contains("FeirbDbContext") == true ||
+                    d.ServiceType.FullName?.Contains("Npgsql") == true).ToList();
+                foreach (var d in dbDescriptors)
+                    services.Remove(d);
+
+                services.AddDbContext<FeirbDbContext>(options =>
+                    options.UseInMemoryDatabase(dbName));
+            });
+        });
+        _client = _factory.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task GetUsers_AsAdmin_ReturnsOkAsync()
+    {
+        var tokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+        var response = await _client.GetAsync("/api/admin/users");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var users = await response.Content.ReadFromJsonAsync<List<AdminUserResponse>>();
+        users.Should().NotBeNull();
+        users.Should().ContainSingle(u => u.IsAdmin);
+    }
+
+    [Fact]
+    public async Task GetUsers_AsNonAdmin_ReturnsForbiddenAsync()
+    {
+        // First create admin via setup so registration works
+        await SetupAndLoginAsAdminAsync();
+
+        // Register and login as non-admin user
+        var registerRequest = new RegisterRequest("regularuser", "regular@example.com", "Password123!");
+        await _client.PostAsJsonAsync("/api/auth/register", registerRequest);
+
+        var loginResponse = await _client.PostAsJsonAsync("/api/auth/login",
+            new LoginRequest("regularuser", "Password123!"));
+        var tokens = await loginResponse.Content.ReadFromJsonAsync<TokenResponse>();
+
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens!.AccessToken);
+
+        var response = await _client.GetAsync("/api/admin/users");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetUsers_Unauthenticated_ReturnsUnauthorizedAsync()
+    {
+        var response = await _client.GetAsync("/api/admin/users");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    private async Task<TokenResponse> SetupAndLoginAsAdminAsync()
+    {
+        var setupRequest = new CompleteSetupRequest(
+            "admin", "admin@example.com", "AdminPassword123!",
+            "smtp.example.com", 587, "smtp@example.com", "smtppass", true, true);
+        await _client.PostAsJsonAsync("/api/setup/complete", setupRequest);
+
+        var loginResponse = await _client.PostAsJsonAsync("/api/auth/login",
+            new LoginRequest("admin", "AdminPassword123!"));
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var tokens = await loginResponse.Content.ReadFromJsonAsync<TokenResponse>();
+        tokens.Should().NotBeNull();
+        return tokens!;
+    }
+}

--- a/tests/Feirb.Api.Tests/Services/AuthServiceTests.cs
+++ b/tests/Feirb.Api.Tests/Services/AuthServiceTests.cs
@@ -155,6 +155,34 @@ public class AuthServiceTests
         token1.Should().NotBe(token2);
     }
 
+    [Fact]
+    public void GenerateTokens_AdminUser_AccessTokenContainsAdminRoleClaim()
+    {
+        var user = CreateTestUser();
+        user.IsAdmin = true;
+
+        var result = _sut.GenerateTokens(user);
+
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.ReadJwtToken(result.AccessToken);
+
+        token.Claims.Should().Contain(c => c.Type == ClaimTypes.Role && c.Value == "Admin");
+    }
+
+    [Fact]
+    public void GenerateTokens_NonAdminUser_AccessTokenDoesNotContainAdminRoleClaim()
+    {
+        var user = CreateTestUser();
+        user.IsAdmin = false;
+
+        var result = _sut.GenerateTokens(user);
+
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.ReadJwtToken(result.AccessToken);
+
+        token.Claims.Should().NotContain(c => c.Type == ClaimTypes.Role && c.Value == "Admin");
+    }
+
     private static User CreateTestUser() => new()
     {
         Id = Guid.Parse("11111111-1111-1111-1111-111111111111"),


### PR DESCRIPTION
## Summary
- Include `ClaimTypes.Role = "Admin"` claim in JWT when `User.IsAdmin` is true
- Register `RequireAdmin` authorization policy on both API and Blazor WASM
- Add `/api/admin/users` endpoint (admin-only) listing all users
- Show admin navigation items (Users, Settings) conditionally via `AuthorizeView`
- Fix JWT role claim type mapping in `JwtAuthenticationStateProvider` for Blazor auth
- Add i18n strings for admin nav in all 4 locales (en-US, de-DE, fr-FR, it-IT)

## Test plan
- [x] Unit test: admin claim present in JWT for admin user
- [x] Unit test: admin claim absent in JWT for non-admin user
- [x] Integration test: `GET /api/admin/users` returns 200 for admin
- [x] Integration test: `GET /api/admin/users` returns 403 for non-admin
- [x] Integration test: `GET /api/admin/users` returns 401 for unauthenticated
- [x] All 50 tests pass, formatting clean

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)