### PR TITLE
feat: add /pr-review skill for comprehensive PR code review

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: pr-review
+description: Comprehensive code review on a pull request
+user_invocable: true
+args: pr_number
+---
+
+# PR Review — Comprehensive Pull Request Review
+
+Perform a thorough code review on a given pull request, covering correctness, conventions, security, tests, i18n, accessibility, and UX.
+
+## Steps
+
+### Phase 1: Quick Review (always)
+
+1. **Read the PR description** for context:
+   ```bash
+   gh pr view {pr_number} --json title,body,additions,deletions,changedFiles
+   ```
+
+2. **Get the changeset:**
+   ```bash
+   gh pr diff {pr_number}
+   ```
+
+3. **Analyze the diff** across these dimensions:
+   - **Correctness** — logic errors, edge cases, off-by-one, null safety, race conditions
+   - **CLAUDE.md conventions** — file-scoped namespaces, primary constructors, Minimal APIs (no controllers), record DTOs in `Feirb.Shared`, async suffix, expression-bodied members
+   - **Security** — injection, auth bypass, secrets in code, OWASP top 10
+   - **Test coverage** — are new/changed code paths covered by tests?
+   - **i18n** — are all user-facing strings in `.resx` files? All locales (`en-US`, `de-DE`, `fr-FR`, `it-IT`) covered?
+   - **WCAG/Accessibility** — semantic HTML, ARIA attributes, keyboard navigation, color contrast
+   - **UX design** — consistent patterns, responsive layout, loading/error states, form validation feedback
+
+4. **Determine if a deep review is needed** — complex logic, architectural changes, many files touched, or suspicious patterns warrant Phase 2.
+
+### Phase 2: Deep Review (if needed)
+
+1. **Check out the PR branch:**
+   ```bash
+   gh pr checkout {pr_number}
+   ```
+
+2. **Build the solution:**
+   ```bash
+   dotnet build Feirb.sln
+   ```
+
+3. **Run the tests:**
+   ```bash
+   dotnet test Feirb.sln --verbosity normal
+   ```
+
+4. **Check formatting:**
+   ```bash
+   dotnet format Feirb.sln --verify-no-changes
+   ```
+
+5. **Report build/test/format results** alongside code review findings.
+
+### Phase 3: Output
+
+1. **Present findings in the terminal**, grouped by category.
+
+2. **Use severity levels:**
+   - 🔴 **Blocker** — must fix before merge (bugs, security issues, broken tests)
+   - 🟡 **Suggestion** — should fix, improves quality (convention violations, missing tests, i18n gaps)
+   - 🟢 **Nitpick** — optional, minor improvements (style, naming preferences)
+
+3. **Reference specific files and lines** when pointing out issues.
+
+4. **On user request**, submit findings as a GitHub PR review:
+   ```bash
+   gh pr review {pr_number} --comment --body "..."
+   ```
+
+## Principles
+
+- Be thorough but not pedantic — focus on things that matter
+- Always read the PR description before reviewing the code
+- If the diff is small and straightforward, skip Phase 2
+- When in doubt about intent, check the linked issue or ask
+- Praise good patterns too — not just problems


### PR DESCRIPTION
## Summary

- Adds new `/pr-review` skill for thorough code reviews on pull requests
- Quick review phase: analyzes diff for correctness, conventions, security, tests, i18n, accessibility, and UX
- Deep review phase (when needed): checks out branch, runs build/test/format verification
- Findings grouped by category with severity levels (blocker, suggestion, nitpick)
- Can optionally submit findings as a GitHub PR review comment

Closes #30

## Test plan

- [ ] Invoke `/pr-review <number>` on an existing PR — verify it fetches and reviews the diff
- [ ] Verify the skill appears in the available skills list

🤖 Generated with [Claude Code](https://claude.com/claude-code)