### PR TITLE
feat(web): breadcrumb navigation, drill-down components & toolbar

### DIFF
--- a/src/Feirb.Web/Components/Breadcrumb.razor
+++ b/src/Feirb.Web/Components/Breadcrumb.razor
@@ -1,0 +1,83 @@
+@inject NavigationManager Navigation
+@inject IStringLocalizer<SharedResources> L
+@implements IDisposable
+
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb mb-0">
+        @foreach (var (segment, index) in _segments.Select((s, i) => (s, i)))
+        {
+            var isLast = index == _segments.Count - 1;
+            @if (isLast)
+            {
+                <li class="breadcrumb-item active" aria-current="page">@segment.Label</li>
+            }
+            else
+            {
+                <li class="breadcrumb-item">
+                    <a href="@segment.Href">@segment.Label</a>
+                </li>
+            }
+        }
+    </ol>
+</nav>
+
+@code {
+    private List<BreadcrumbSegment> _segments = [];
+
+    protected override void OnInitialized()
+    {
+        Navigation.LocationChanged += OnLocationChanged;
+        BuildSegments();
+    }
+
+    private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+    {
+        BuildSegments();
+        StateHasChanged();
+    }
+
+    private void BuildSegments()
+    {
+        _segments = [new BreadcrumbSegment(L["BreadcrumbDashboard"], "/")];
+
+        var relativePath = Navigation.ToBaseRelativePath(Navigation.Uri);
+        if (string.IsNullOrEmpty(relativePath))
+            return;
+
+        var parts = relativePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var currentPath = "";
+
+        foreach (var part in parts)
+        {
+            currentPath = string.IsNullOrEmpty(currentPath) ? part : $"{currentPath}/{part}";
+            var label = ResolveLabel(currentPath, part);
+            _segments.Add(new BreadcrumbSegment(label, $"/{currentPath}"));
+        }
+    }
+
+    private string ResolveLabel(string fullPath, string segment) =>
+        fullPath switch
+        {
+            "settings" => L["BreadcrumbSettings"],
+            "settings/personal-information" => L["BreadcrumbPersonalInformation"],
+            "settings/security" => L["BreadcrumbSecurity"],
+            "admin" => L["BreadcrumbAdmin"],
+            "admin/user-management" => L["BreadcrumbUserManagement"],
+            "admin/system-settings" => L["BreadcrumbSystemSettings"],
+            "admin/system-settings/outgoing-smtp" => L["BreadcrumbOutgoingSmtp"],
+            "admin/system-settings/jobs" => L["BreadcrumbJobs"],
+            "admin/llm-settings" => L["BreadcrumbLlmSettings"],
+            "admin/llm-settings/system-prompt" => L["BreadcrumbSystemPrompt"],
+            "admin/llm-settings/scheduling" => L["BreadcrumbScheduling"],
+            "inbox" => L["NavInbox"],
+            "sent" => L["NavSent"],
+            "drafts" => L["NavDrafts"],
+            "trash" => L["NavTrash"],
+            "archive" => L["NavArchive"],
+            _ => segment
+        };
+
+    public void Dispose() => Navigation.LocationChanged -= OnLocationChanged;
+
+    private sealed record BreadcrumbSegment(string Label, string Href);
+}

--- a/src/Feirb.Web/Components/ContentSection.razor
+++ b/src/Feirb.Web/Components/ContentSection.razor
@@ -1,0 +1,22 @@
+<div class="content-section">
+    <div class="content-section-header">
+        <span class="material-symbols-outlined content-section-icon">@Icon</span>
+        <div class="content-section-text">
+            <span class="content-section-title">@Title</span>
+            @if (!string.IsNullOrEmpty(Subtitle))
+            {
+                <span class="content-section-subtitle">@Subtitle</span>
+            }
+        </div>
+    </div>
+    <div class="content-section-body">
+        @ChildContent
+    </div>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public string Icon { get; set; } = default!;
+    [Parameter, EditorRequired] public string Title { get; set; } = default!;
+    [Parameter] public string? Subtitle { get; set; }
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+}

--- a/src/Feirb.Web/Components/ContentSection.razor.css
+++ b/src/Feirb.Web/Components/ContentSection.razor.css
@@ -1,0 +1,38 @@
+.content-section {
+    background: white;
+    border: 1px solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius);
+    overflow: hidden;
+}
+
+.content-section-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--bs-border-color);
+}
+
+.content-section-icon {
+    font-size: 1.5rem;
+    color: var(--bs-primary);
+}
+
+.content-section-text {
+    display: flex;
+    flex-direction: column;
+}
+
+.content-section-title {
+    font-weight: 600;
+    color: var(--bs-body-color);
+}
+
+.content-section-subtitle {
+    font-size: 0.875rem;
+    color: var(--bs-secondary-color);
+}
+
+.content-section-body {
+    padding: 1.25rem;
+}

--- a/src/Feirb.Web/Components/NavigationItem.razor
+++ b/src/Feirb.Web/Components/NavigationItem.razor
@@ -1,0 +1,24 @@
+@inject NavigationManager Navigation
+
+<div class="nav-item-card" @onclick="Navigate" role="button" tabindex="0">
+    <div class="nav-item-left">
+        <span class="material-symbols-outlined nav-item-icon">@Icon</span>
+        <div class="nav-item-text">
+            <span class="nav-item-title">@Title</span>
+            @if (!string.IsNullOrEmpty(Subtitle))
+            {
+                <span class="nav-item-subtitle">@Subtitle</span>
+            }
+        </div>
+    </div>
+    <span class="material-symbols-outlined nav-item-chevron">chevron_right</span>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public string Icon { get; set; } = default!;
+    [Parameter, EditorRequired] public string Title { get; set; } = default!;
+    [Parameter] public string? Subtitle { get; set; }
+    [Parameter, EditorRequired] public string Href { get; set; } = default!;
+
+    private void Navigate() => Navigation.NavigateTo(Href);
+}

--- a/src/Feirb.Web/Components/NavigationItem.razor.css
+++ b/src/Feirb.Web/Components/NavigationItem.razor.css
@@ -1,0 +1,47 @@
+.nav-item-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.25rem;
+    background: white;
+    border: 1px solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius);
+    cursor: pointer;
+    transition: box-shadow 0.15s, border-color 0.15s;
+}
+
+.nav-item-card:hover {
+    border-color: var(--bs-primary);
+    box-shadow: var(--feirb-shadow);
+}
+
+.nav-item-left {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.nav-item-icon {
+    font-size: 1.5rem;
+    color: var(--bs-primary);
+}
+
+.nav-item-text {
+    display: flex;
+    flex-direction: column;
+}
+
+.nav-item-title {
+    font-weight: 600;
+    color: var(--bs-body-color);
+}
+
+.nav-item-subtitle {
+    font-size: 0.875rem;
+    color: var(--bs-secondary-color);
+}
+
+.nav-item-chevron {
+    color: var(--bs-secondary-color);
+    font-size: 1.25rem;
+}

--- a/src/Feirb.Web/Components/Toolbar.razor
+++ b/src/Feirb.Web/Components/Toolbar.razor
@@ -1,0 +1,24 @@
+@inject ToolbarStateService ToolbarState
+@implements IDisposable
+
+@if (ToolbarState.Actions.Count > 0)
+{
+    <div class="toolbar-actions">
+        @foreach (var action in ToolbarState.Actions)
+        {
+            <button class="btn @action.CssClass btn-sm" @onclick="action.OnClickAsync">
+                @if (!string.IsNullOrEmpty(action.Icon))
+                {
+                    <span class="material-symbols-outlined me-1" style="font-size: 1rem; vertical-align: middle;">@action.Icon</span>
+                }
+                @action.Label
+            </button>
+        }
+    </div>
+}
+
+@code {
+    protected override void OnInitialized() => ToolbarState.OnChange += StateHasChanged;
+
+    public void Dispose() => ToolbarState.OnChange -= StateHasChanged;
+}

--- a/src/Feirb.Web/Layout/MainLayout.razor
+++ b/src/Feirb.Web/Layout/MainLayout.razor
@@ -3,6 +3,10 @@
 <div class="page">
     <NavMenu />
     <main>
+        <div class="top-bar">
+            <Feirb.Web.Components.Breadcrumb />
+            <Feirb.Web.Components.Toolbar />
+        </div>
         <article class="content">
             @Body
         </article>

--- a/src/Feirb.Web/Layout/MainLayout.razor.css
+++ b/src/Feirb.Web/Layout/MainLayout.razor.css
@@ -8,6 +8,18 @@ main {
     margin-left: 16rem;
 }
 
+.top-bar {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 2rem;
+    background-color: var(--bs-body-bg);
+    border-bottom: 1px solid var(--bs-border-color);
+}
+
 .content {
     padding: 2rem;
 }

--- a/src/Feirb.Web/Layout/NavMenu.razor
+++ b/src/Feirb.Web/Layout/NavMenu.razor
@@ -83,7 +83,7 @@
             <AuthorizeView Policy="RequireAdmin">
                 <Authorized>
                     <li>
-                        <NavLink class="nav-entry" href="admin/users">
+                        <NavLink class="nav-entry" href="admin">
                             <span class="material-symbols-outlined">admin_panel_settings</span>
                             <span>@L["NavAdmin"]</span>
                         </NavLink>

--- a/src/Feirb.Web/Pages/Admin/Index.razor
+++ b/src/Feirb.Web/Pages/Admin/Index.razor
@@ -1,0 +1,27 @@
+@page "/admin"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@inject IStringLocalizer<SharedResources> L
+
+<PageTitle>@L["PageTitleAdmin"]</PageTitle>
+
+<h1 class="mb-4">@L["NavAdmin"]</h1>
+
+<div class="d-flex flex-column gap-3">
+    <NavigationItem
+        Icon="group"
+        Title="@L["AdminUserMgmtTitle"]"
+        Subtitle="@L["AdminUserMgmtSubtitle"]"
+        Href="/admin/user-management" />
+
+    <NavigationItem
+        Icon="settings"
+        Title="@L["AdminSystemSettingsTitle"]"
+        Subtitle="@L["AdminSystemSettingsSubtitle"]"
+        Href="/admin/system-settings" />
+
+    <NavigationItem
+        Icon="smart_toy"
+        Title="@L["AdminLlmSettingsTitle"]"
+        Subtitle="@L["AdminLlmSettingsSubtitle"]"
+        Href="/admin/llm-settings" />
+</div>

--- a/src/Feirb.Web/Pages/Admin/LlmSettings/Index.razor
+++ b/src/Feirb.Web/Pages/Admin/LlmSettings/Index.razor
@@ -1,0 +1,21 @@
+@page "/admin/llm-settings"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@inject IStringLocalizer<SharedResources> L
+
+<PageTitle>@L["AdminLlmSettingsTitle"] - Feirb</PageTitle>
+
+<h1 class="mb-4">@L["AdminLlmSettingsTitle"]</h1>
+
+<div class="d-flex flex-column gap-3">
+    <NavigationItem
+        Icon="description"
+        Title="@L["AdminSystemPromptTitle"]"
+        Subtitle="@L["AdminSystemPromptSubtitle"]"
+        Href="/admin/llm-settings/system-prompt" />
+
+    <NavigationItem
+        Icon="event"
+        Title="@L["AdminSchedulingTitle"]"
+        Subtitle="@L["AdminSchedulingSubtitle"]"
+        Href="/admin/llm-settings/scheduling" />
+</div>

--- a/src/Feirb.Web/Pages/Admin/LlmSettings/Scheduling.razor
+++ b/src/Feirb.Web/Pages/Admin/LlmSettings/Scheduling.razor
@@ -1,0 +1,8 @@
+@page "/admin/llm-settings/scheduling"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@inject IStringLocalizer<SharedResources> L
+
+<PageTitle>@L["AdminSchedulingTitle"] - Feirb</PageTitle>
+
+<h1 class="mb-4">@L["AdminSchedulingTitle"]</h1>
+<p class="text-muted">@L["StubComingSoon"]</p>

--- a/src/Feirb.Web/Pages/Admin/LlmSettings/SystemPrompt.razor
+++ b/src/Feirb.Web/Pages/Admin/LlmSettings/SystemPrompt.razor
@@ -1,0 +1,8 @@
+@page "/admin/llm-settings/system-prompt"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@inject IStringLocalizer<SharedResources> L
+
+<PageTitle>@L["AdminSystemPromptTitle"] - Feirb</PageTitle>
+
+<h1 class="mb-4">@L["AdminSystemPromptTitle"]</h1>
+<p class="text-muted">@L["StubComingSoon"]</p>

--- a/src/Feirb.Web/Pages/Admin/SystemSettings/Index.razor
+++ b/src/Feirb.Web/Pages/Admin/SystemSettings/Index.razor
@@ -1,0 +1,21 @@
+@page "/admin/system-settings"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@inject IStringLocalizer<SharedResources> L
+
+<PageTitle>@L["AdminSystemSettingsTitle"] - Feirb</PageTitle>
+
+<h1 class="mb-4">@L["AdminSystemSettingsTitle"]</h1>
+
+<div class="d-flex flex-column gap-3">
+    <NavigationItem
+        Icon="outgoing_mail"
+        Title="@L["AdminOutgoingSmtpTitle"]"
+        Subtitle="@L["AdminOutgoingSmtpSubtitle"]"
+        Href="/admin/system-settings/outgoing-smtp" />
+
+    <NavigationItem
+        Icon="schedule"
+        Title="@L["AdminJobsTitle"]"
+        Subtitle="@L["AdminJobsSubtitle"]"
+        Href="/admin/system-settings/jobs" />
+</div>

--- a/src/Feirb.Web/Pages/Admin/SystemSettings/Jobs.razor
+++ b/src/Feirb.Web/Pages/Admin/SystemSettings/Jobs.razor
@@ -1,0 +1,8 @@
+@page "/admin/system-settings/jobs"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@inject IStringLocalizer<SharedResources> L
+
+<PageTitle>@L["AdminJobsTitle"] - Feirb</PageTitle>
+
+<h1 class="mb-4">@L["AdminJobsTitle"]</h1>
+<p class="text-muted">@L["StubComingSoon"]</p>

--- a/src/Feirb.Web/Pages/Admin/SystemSettings/OutgoingSmtp.razor
+++ b/src/Feirb.Web/Pages/Admin/SystemSettings/OutgoingSmtp.razor
@@ -1,0 +1,8 @@
+@page "/admin/system-settings/outgoing-smtp"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@inject IStringLocalizer<SharedResources> L
+
+<PageTitle>@L["AdminOutgoingSmtpTitle"] - Feirb</PageTitle>
+
+<h1 class="mb-4">@L["AdminOutgoingSmtpTitle"]</h1>
+<p class="text-muted">@L["StubComingSoon"]</p>

--- a/src/Feirb.Web/Pages/Admin/Users.razor
+++ b/src/Feirb.Web/Pages/Admin/Users.razor
@@ -1,4 +1,4 @@
-@page "/admin/users"
+@page "/admin/user-management"
 @attribute [Authorize(Policy = "RequireAdmin")]
 @using Feirb.Shared.Admin
 @using System.Security.Claims

--- a/src/Feirb.Web/Pages/Settings.razor
+++ b/src/Feirb.Web/Pages/Settings.razor
@@ -1,7 +1,0 @@
-@page "/settings"
-@attribute [Authorize]
-
-<PageTitle>Settings - Feirb</PageTitle>
-
-<h1>Settings</h1>
-<p class="text-muted">Coming soon.</p>

--- a/src/Feirb.Web/Pages/Settings/Index.razor
+++ b/src/Feirb.Web/Pages/Settings/Index.razor
@@ -1,0 +1,23 @@
+@page "/settings"
+@attribute [Authorize]
+@inject IStringLocalizer<SharedResources> L
+
+<PageTitle>@L["PageTitleSettings"]</PageTitle>
+
+<h1 class="mb-4">@L["NavSettings"]</h1>
+
+<div class="d-flex flex-column gap-3">
+    <h5 class="text-muted mb-0">@L["SettingsAccountTitle"]</h5>
+
+    <NavigationItem
+        Icon="person"
+        Title="@L["SettingsPersonalInfoTitle"]"
+        Subtitle="@L["SettingsPersonalInfoSubtitle"]"
+        Href="/settings/personal-information" />
+
+    <NavigationItem
+        Icon="lock"
+        Title="@L["SettingsSecurityTitle"]"
+        Subtitle="@L["SettingsSecuritySubtitle"]"
+        Href="/settings/security" />
+</div>

--- a/src/Feirb.Web/Pages/Settings/PersonalInformation.razor
+++ b/src/Feirb.Web/Pages/Settings/PersonalInformation.razor
@@ -1,0 +1,8 @@
+@page "/settings/personal-information"
+@attribute [Authorize]
+@inject IStringLocalizer<SharedResources> L
+
+<PageTitle>@L["SettingsPersonalInfoTitle"] - Feirb</PageTitle>
+
+<h1 class="mb-4">@L["SettingsPersonalInfoTitle"]</h1>
+<p class="text-muted">@L["StubComingSoon"]</p>

--- a/src/Feirb.Web/Pages/Settings/Security.razor
+++ b/src/Feirb.Web/Pages/Settings/Security.razor
@@ -1,0 +1,8 @@
+@page "/settings/security"
+@attribute [Authorize]
+@inject IStringLocalizer<SharedResources> L
+
+<PageTitle>@L["SettingsSecurityTitle"] - Feirb</PageTitle>
+
+<h1 class="mb-4">@L["SettingsSecurityTitle"]</h1>
+<p class="text-muted">@L["StubComingSoon"]</p>

--- a/src/Feirb.Web/Program.cs
+++ b/src/Feirb.Web/Program.cs
@@ -17,6 +17,7 @@ builder.Services.AddAuthorizationCore(options =>
     options.AddPolicy("RequireAdmin", policy => policy.RequireRole("Admin"));
 });
 
+builder.Services.AddScoped<ToolbarStateService>();
 builder.Services.AddScoped<JwtAuthenticationStateProvider>();
 builder.Services.AddScoped<AuthenticationStateProvider>(sp =>
     sp.GetRequiredService<JwtAuthenticationStateProvider>());

--- a/src/Feirb.Web/Resources/SharedResources.de-DE.resx
+++ b/src/Feirb.Web/Resources/SharedResources.de-DE.resx
@@ -396,4 +396,106 @@
   <data name="LoadingUsers" xml:space="preserve">
     <value>Benutzer werden geladen...</value>
   </data>
+  <data name="BreadcrumbDashboard" xml:space="preserve">
+    <value>Dashboard</value>
+  </data>
+  <data name="BreadcrumbSettings" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="BreadcrumbAdmin" xml:space="preserve">
+    <value>Admin</value>
+  </data>
+  <data name="BreadcrumbUserManagement" xml:space="preserve">
+    <value>Benutzerverwaltung</value>
+  </data>
+  <data name="BreadcrumbSystemSettings" xml:space="preserve">
+    <value>Systemeinstellungen</value>
+  </data>
+  <data name="BreadcrumbLlmSettings" xml:space="preserve">
+    <value>LLM-Einstellungen</value>
+  </data>
+  <data name="BreadcrumbPersonalInformation" xml:space="preserve">
+    <value>Persönliche Informationen</value>
+  </data>
+  <data name="BreadcrumbSecurity" xml:space="preserve">
+    <value>Sicherheit &amp; Passwort</value>
+  </data>
+  <data name="BreadcrumbOutgoingSmtp" xml:space="preserve">
+    <value>Ausgehender SMTP</value>
+  </data>
+  <data name="BreadcrumbJobs" xml:space="preserve">
+    <value>Aufgaben</value>
+  </data>
+  <data name="BreadcrumbSystemPrompt" xml:space="preserve">
+    <value>System-Prompt</value>
+  </data>
+  <data name="BreadcrumbScheduling" xml:space="preserve">
+    <value>Zeitplanung</value>
+  </data>
+  <data name="PageTitleSettings" xml:space="preserve">
+    <value>Einstellungen - Feirb</value>
+  </data>
+  <data name="PageTitleAdmin" xml:space="preserve">
+    <value>Admin - Feirb</value>
+  </data>
+  <data name="SettingsAccountTitle" xml:space="preserve">
+    <value>Kontoeinstellungen</value>
+  </data>
+  <data name="SettingsPersonalInfoTitle" xml:space="preserve">
+    <value>Persönliche Informationen</value>
+  </data>
+  <data name="SettingsPersonalInfoSubtitle" xml:space="preserve">
+    <value>Name und E-Mail-Adresse aktualisieren</value>
+  </data>
+  <data name="SettingsSecurityTitle" xml:space="preserve">
+    <value>Sicherheit &amp; Passwort</value>
+  </data>
+  <data name="SettingsSecuritySubtitle" xml:space="preserve">
+    <value>Passwort und Sicherheitseinstellungen ändern</value>
+  </data>
+  <data name="AdminUserMgmtTitle" xml:space="preserve">
+    <value>Benutzerverwaltung</value>
+  </data>
+  <data name="AdminUserMgmtSubtitle" xml:space="preserve">
+    <value>Benutzer und Berechtigungen verwalten</value>
+  </data>
+  <data name="AdminSystemSettingsTitle" xml:space="preserve">
+    <value>Systemeinstellungen</value>
+  </data>
+  <data name="AdminSystemSettingsSubtitle" xml:space="preserve">
+    <value>Mailserver und Hintergrundaufgaben konfigurieren</value>
+  </data>
+  <data name="AdminLlmSettingsTitle" xml:space="preserve">
+    <value>LLM-Einstellungen</value>
+  </data>
+  <data name="AdminLlmSettingsSubtitle" xml:space="preserve">
+    <value>KI-Modell und Zeitplanung konfigurieren</value>
+  </data>
+  <data name="AdminOutgoingSmtpTitle" xml:space="preserve">
+    <value>Ausgehender SMTP</value>
+  </data>
+  <data name="AdminOutgoingSmtpSubtitle" xml:space="preserve">
+    <value>Einstellungen für ausgehenden Mailserver konfigurieren</value>
+  </data>
+  <data name="AdminJobsTitle" xml:space="preserve">
+    <value>Aufgaben</value>
+  </data>
+  <data name="AdminJobsSubtitle" xml:space="preserve">
+    <value>Hintergrundverarbeitungsaufgaben verwalten</value>
+  </data>
+  <data name="AdminSystemPromptTitle" xml:space="preserve">
+    <value>System-Prompt</value>
+  </data>
+  <data name="AdminSystemPromptSubtitle" xml:space="preserve">
+    <value>KI-System-Prompt konfigurieren</value>
+  </data>
+  <data name="AdminSchedulingTitle" xml:space="preserve">
+    <value>Zeitplanung</value>
+  </data>
+  <data name="AdminSchedulingSubtitle" xml:space="preserve">
+    <value>KI-Verarbeitungszeitplan konfigurieren</value>
+  </data>
+  <data name="StubComingSoon" xml:space="preserve">
+    <value>Diese Seite befindet sich im Aufbau.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
+++ b/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
@@ -396,4 +396,106 @@
   <data name="LoadingUsers" xml:space="preserve">
     <value>Chargement des utilisateurs...</value>
   </data>
+  <data name="BreadcrumbDashboard" xml:space="preserve">
+    <value>Tableau de bord</value>
+  </data>
+  <data name="BreadcrumbSettings" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
+  <data name="BreadcrumbAdmin" xml:space="preserve">
+    <value>Admin</value>
+  </data>
+  <data name="BreadcrumbUserManagement" xml:space="preserve">
+    <value>Gestion des utilisateurs</value>
+  </data>
+  <data name="BreadcrumbSystemSettings" xml:space="preserve">
+    <value>Paramètres système</value>
+  </data>
+  <data name="BreadcrumbLlmSettings" xml:space="preserve">
+    <value>Paramètres LLM</value>
+  </data>
+  <data name="BreadcrumbPersonalInformation" xml:space="preserve">
+    <value>Informations personnelles</value>
+  </data>
+  <data name="BreadcrumbSecurity" xml:space="preserve">
+    <value>Sécurité &amp; Mot de passe</value>
+  </data>
+  <data name="BreadcrumbOutgoingSmtp" xml:space="preserve">
+    <value>SMTP sortant</value>
+  </data>
+  <data name="BreadcrumbJobs" xml:space="preserve">
+    <value>Tâches</value>
+  </data>
+  <data name="BreadcrumbSystemPrompt" xml:space="preserve">
+    <value>Invite système</value>
+  </data>
+  <data name="BreadcrumbScheduling" xml:space="preserve">
+    <value>Planification</value>
+  </data>
+  <data name="PageTitleSettings" xml:space="preserve">
+    <value>Paramètres - Feirb</value>
+  </data>
+  <data name="PageTitleAdmin" xml:space="preserve">
+    <value>Admin - Feirb</value>
+  </data>
+  <data name="SettingsAccountTitle" xml:space="preserve">
+    <value>Paramètres du compte</value>
+  </data>
+  <data name="SettingsPersonalInfoTitle" xml:space="preserve">
+    <value>Informations personnelles</value>
+  </data>
+  <data name="SettingsPersonalInfoSubtitle" xml:space="preserve">
+    <value>Modifier votre nom et adresse e-mail</value>
+  </data>
+  <data name="SettingsSecurityTitle" xml:space="preserve">
+    <value>Sécurité &amp; Mot de passe</value>
+  </data>
+  <data name="SettingsSecuritySubtitle" xml:space="preserve">
+    <value>Modifier votre mot de passe et les paramètres de sécurité</value>
+  </data>
+  <data name="AdminUserMgmtTitle" xml:space="preserve">
+    <value>Gestion des utilisateurs</value>
+  </data>
+  <data name="AdminUserMgmtSubtitle" xml:space="preserve">
+    <value>Gérer les utilisateurs et les permissions</value>
+  </data>
+  <data name="AdminSystemSettingsTitle" xml:space="preserve">
+    <value>Paramètres système</value>
+  </data>
+  <data name="AdminSystemSettingsSubtitle" xml:space="preserve">
+    <value>Configurer le serveur de messagerie et les tâches en arrière-plan</value>
+  </data>
+  <data name="AdminLlmSettingsTitle" xml:space="preserve">
+    <value>Paramètres LLM</value>
+  </data>
+  <data name="AdminLlmSettingsSubtitle" xml:space="preserve">
+    <value>Configurer le modèle IA et la planification</value>
+  </data>
+  <data name="AdminOutgoingSmtpTitle" xml:space="preserve">
+    <value>SMTP sortant</value>
+  </data>
+  <data name="AdminOutgoingSmtpSubtitle" xml:space="preserve">
+    <value>Configurer les paramètres du serveur de messagerie sortant</value>
+  </data>
+  <data name="AdminJobsTitle" xml:space="preserve">
+    <value>Tâches</value>
+  </data>
+  <data name="AdminJobsSubtitle" xml:space="preserve">
+    <value>Gérer les tâches de traitement en arrière-plan</value>
+  </data>
+  <data name="AdminSystemPromptTitle" xml:space="preserve">
+    <value>Invite système</value>
+  </data>
+  <data name="AdminSystemPromptSubtitle" xml:space="preserve">
+    <value>Configurer l'invite système de l'IA</value>
+  </data>
+  <data name="AdminSchedulingTitle" xml:space="preserve">
+    <value>Planification</value>
+  </data>
+  <data name="AdminSchedulingSubtitle" xml:space="preserve">
+    <value>Configurer le planning de traitement IA</value>
+  </data>
+  <data name="StubComingSoon" xml:space="preserve">
+    <value>Cette page est en cours de construction.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.it-IT.resx
+++ b/src/Feirb.Web/Resources/SharedResources.it-IT.resx
@@ -396,4 +396,106 @@
   <data name="LoadingUsers" xml:space="preserve">
     <value>Caricamento utenti...</value>
   </data>
+  <data name="BreadcrumbDashboard" xml:space="preserve">
+    <value>Dashboard</value>
+  </data>
+  <data name="BreadcrumbSettings" xml:space="preserve">
+    <value>Impostazioni</value>
+  </data>
+  <data name="BreadcrumbAdmin" xml:space="preserve">
+    <value>Admin</value>
+  </data>
+  <data name="BreadcrumbUserManagement" xml:space="preserve">
+    <value>Gestione utenti</value>
+  </data>
+  <data name="BreadcrumbSystemSettings" xml:space="preserve">
+    <value>Impostazioni di sistema</value>
+  </data>
+  <data name="BreadcrumbLlmSettings" xml:space="preserve">
+    <value>Impostazioni LLM</value>
+  </data>
+  <data name="BreadcrumbPersonalInformation" xml:space="preserve">
+    <value>Informazioni personali</value>
+  </data>
+  <data name="BreadcrumbSecurity" xml:space="preserve">
+    <value>Sicurezza &amp; Password</value>
+  </data>
+  <data name="BreadcrumbOutgoingSmtp" xml:space="preserve">
+    <value>SMTP in uscita</value>
+  </data>
+  <data name="BreadcrumbJobs" xml:space="preserve">
+    <value>Attività</value>
+  </data>
+  <data name="BreadcrumbSystemPrompt" xml:space="preserve">
+    <value>Prompt di sistema</value>
+  </data>
+  <data name="BreadcrumbScheduling" xml:space="preserve">
+    <value>Pianificazione</value>
+  </data>
+  <data name="PageTitleSettings" xml:space="preserve">
+    <value>Impostazioni - Feirb</value>
+  </data>
+  <data name="PageTitleAdmin" xml:space="preserve">
+    <value>Admin - Feirb</value>
+  </data>
+  <data name="SettingsAccountTitle" xml:space="preserve">
+    <value>Impostazioni account</value>
+  </data>
+  <data name="SettingsPersonalInfoTitle" xml:space="preserve">
+    <value>Informazioni personali</value>
+  </data>
+  <data name="SettingsPersonalInfoSubtitle" xml:space="preserve">
+    <value>Aggiorna nome e indirizzo e-mail</value>
+  </data>
+  <data name="SettingsSecurityTitle" xml:space="preserve">
+    <value>Sicurezza &amp; Password</value>
+  </data>
+  <data name="SettingsSecuritySubtitle" xml:space="preserve">
+    <value>Modifica password e impostazioni di sicurezza</value>
+  </data>
+  <data name="AdminUserMgmtTitle" xml:space="preserve">
+    <value>Gestione utenti</value>
+  </data>
+  <data name="AdminUserMgmtSubtitle" xml:space="preserve">
+    <value>Gestisci utenti e permessi</value>
+  </data>
+  <data name="AdminSystemSettingsTitle" xml:space="preserve">
+    <value>Impostazioni di sistema</value>
+  </data>
+  <data name="AdminSystemSettingsSubtitle" xml:space="preserve">
+    <value>Configura server mail e attività in background</value>
+  </data>
+  <data name="AdminLlmSettingsTitle" xml:space="preserve">
+    <value>Impostazioni LLM</value>
+  </data>
+  <data name="AdminLlmSettingsSubtitle" xml:space="preserve">
+    <value>Configura modello IA e pianificazione</value>
+  </data>
+  <data name="AdminOutgoingSmtpTitle" xml:space="preserve">
+    <value>SMTP in uscita</value>
+  </data>
+  <data name="AdminOutgoingSmtpSubtitle" xml:space="preserve">
+    <value>Configura le impostazioni del server di posta in uscita</value>
+  </data>
+  <data name="AdminJobsTitle" xml:space="preserve">
+    <value>Attività</value>
+  </data>
+  <data name="AdminJobsSubtitle" xml:space="preserve">
+    <value>Gestisci le attività di elaborazione in background</value>
+  </data>
+  <data name="AdminSystemPromptTitle" xml:space="preserve">
+    <value>Prompt di sistema</value>
+  </data>
+  <data name="AdminSystemPromptSubtitle" xml:space="preserve">
+    <value>Configura il prompt di sistema dell'IA</value>
+  </data>
+  <data name="AdminSchedulingTitle" xml:space="preserve">
+    <value>Pianificazione</value>
+  </data>
+  <data name="AdminSchedulingSubtitle" xml:space="preserve">
+    <value>Configura la pianificazione dell'elaborazione IA</value>
+  </data>
+  <data name="StubComingSoon" xml:space="preserve">
+    <value>Questa pagina è in costruzione.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.resx
+++ b/src/Feirb.Web/Resources/SharedResources.resx
@@ -396,4 +396,106 @@
   <data name="LoadingUsers" xml:space="preserve">
     <value>Loading users...</value>
   </data>
+  <data name="BreadcrumbDashboard" xml:space="preserve">
+    <value>Dashboard</value>
+  </data>
+  <data name="BreadcrumbSettings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="BreadcrumbAdmin" xml:space="preserve">
+    <value>Admin</value>
+  </data>
+  <data name="BreadcrumbUserManagement" xml:space="preserve">
+    <value>User Management</value>
+  </data>
+  <data name="BreadcrumbSystemSettings" xml:space="preserve">
+    <value>System Settings</value>
+  </data>
+  <data name="BreadcrumbLlmSettings" xml:space="preserve">
+    <value>LLM Settings</value>
+  </data>
+  <data name="BreadcrumbPersonalInformation" xml:space="preserve">
+    <value>Personal Information</value>
+  </data>
+  <data name="BreadcrumbSecurity" xml:space="preserve">
+    <value>Security &amp; Password</value>
+  </data>
+  <data name="BreadcrumbOutgoingSmtp" xml:space="preserve">
+    <value>Outgoing SMTP</value>
+  </data>
+  <data name="BreadcrumbJobs" xml:space="preserve">
+    <value>Jobs</value>
+  </data>
+  <data name="BreadcrumbSystemPrompt" xml:space="preserve">
+    <value>System Prompt</value>
+  </data>
+  <data name="BreadcrumbScheduling" xml:space="preserve">
+    <value>Scheduling</value>
+  </data>
+  <data name="PageTitleSettings" xml:space="preserve">
+    <value>Settings - Feirb</value>
+  </data>
+  <data name="PageTitleAdmin" xml:space="preserve">
+    <value>Admin - Feirb</value>
+  </data>
+  <data name="SettingsAccountTitle" xml:space="preserve">
+    <value>Account Settings</value>
+  </data>
+  <data name="SettingsPersonalInfoTitle" xml:space="preserve">
+    <value>Personal Information</value>
+  </data>
+  <data name="SettingsPersonalInfoSubtitle" xml:space="preserve">
+    <value>Update your name and email address</value>
+  </data>
+  <data name="SettingsSecurityTitle" xml:space="preserve">
+    <value>Security &amp; Password</value>
+  </data>
+  <data name="SettingsSecuritySubtitle" xml:space="preserve">
+    <value>Change your password and security settings</value>
+  </data>
+  <data name="AdminUserMgmtTitle" xml:space="preserve">
+    <value>User Management</value>
+  </data>
+  <data name="AdminUserMgmtSubtitle" xml:space="preserve">
+    <value>Manage users and permissions</value>
+  </data>
+  <data name="AdminSystemSettingsTitle" xml:space="preserve">
+    <value>System Settings</value>
+  </data>
+  <data name="AdminSystemSettingsSubtitle" xml:space="preserve">
+    <value>Configure mail server and background jobs</value>
+  </data>
+  <data name="AdminLlmSettingsTitle" xml:space="preserve">
+    <value>LLM Settings</value>
+  </data>
+  <data name="AdminLlmSettingsSubtitle" xml:space="preserve">
+    <value>Configure AI model and scheduling</value>
+  </data>
+  <data name="AdminOutgoingSmtpTitle" xml:space="preserve">
+    <value>Outgoing SMTP</value>
+  </data>
+  <data name="AdminOutgoingSmtpSubtitle" xml:space="preserve">
+    <value>Configure outgoing mail server settings</value>
+  </data>
+  <data name="AdminJobsTitle" xml:space="preserve">
+    <value>Jobs</value>
+  </data>
+  <data name="AdminJobsSubtitle" xml:space="preserve">
+    <value>Manage background processing tasks</value>
+  </data>
+  <data name="AdminSystemPromptTitle" xml:space="preserve">
+    <value>System Prompt</value>
+  </data>
+  <data name="AdminSystemPromptSubtitle" xml:space="preserve">
+    <value>Configure the AI system prompt</value>
+  </data>
+  <data name="AdminSchedulingTitle" xml:space="preserve">
+    <value>Scheduling</value>
+  </data>
+  <data name="AdminSchedulingSubtitle" xml:space="preserve">
+    <value>Configure AI processing schedule</value>
+  </data>
+  <data name="StubComingSoon" xml:space="preserve">
+    <value>This page is under construction.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Services/ToolbarStateService.cs
+++ b/src/Feirb.Web/Services/ToolbarStateService.cs
@@ -1,0 +1,31 @@
+namespace Feirb.Web.Services;
+
+public sealed class ToolbarAction(string label, string cssClass, Func<Task> onClickAsync, string? icon = null)
+{
+    public string Label { get; } = label;
+    public string CssClass { get; } = cssClass;
+    public Func<Task> OnClickAsync { get; } = onClickAsync;
+    public string? Icon { get; } = icon;
+}
+
+public sealed class ToolbarStateService
+{
+    private readonly List<ToolbarAction> _actions = [];
+
+    public IReadOnlyList<ToolbarAction> Actions => _actions;
+
+    public event Action? OnChange;
+
+    public void SetActions(IEnumerable<ToolbarAction> actions)
+    {
+        _actions.Clear();
+        _actions.AddRange(actions);
+        OnChange?.Invoke();
+    }
+
+    public void Clear()
+    {
+        _actions.Clear();
+        OnChange?.Invoke();
+    }
+}

--- a/src/Feirb.Web/_Imports.razor
+++ b/src/Feirb.Web/_Imports.razor
@@ -13,3 +13,4 @@
 @using Feirb.Web.Components
 @using Feirb.Web.Layout
 @using Feirb.Web.Resources
+@using Feirb.Web.Services


### PR DESCRIPTION
## Summary

- Add reusable **Breadcrumb**, **NavigationItem**, **ContentSection**, and **Toolbar** components
- Add **ToolbarStateService** for page-specific toolbar actions (register/clear on navigate)
- Wire up **Settings** page hierarchy: Account Settings → Personal Information (stub), Security (stub)
- Wire up **Admin** page hierarchy: User Management, System Settings → Outgoing SMTP (stub) / Jobs (stub), LLM Settings → System Prompt (stub) / Scheduling (stub)
- Sticky top bar with breadcrumb + toolbar in MainLayout
- Move user management route from `/admin/users` to `/admin/user-management`
- All new strings localized in 4 locales (en-US, de-DE, fr-FR, it-IT)

Closes #38

## Test plan

- [x] Build succeeds (`dotnet build`)
- [x] All 58 tests pass (`dotnet test`)
- [x] Formatting clean (`dotnet format --verify-no-changes`)
- [x] Manual testing: breadcrumb renders on all pages, drill-down navigation works, stub pages display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)