### PR TITLE
feat(api): send password reset email via SMTP

### DIFF
--- a/src/Feirb.Api/Endpoints/AuthEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/AuthEndpoints.cs
@@ -97,8 +97,10 @@ public static class AuthEndpoints
 
     private static async Task<IResult> RequestResetAsync(
         RequestResetRequest request,
+        HttpContext httpContext,
         FeirbDbContext db,
         IAuthService authService,
+        IEmailService emailService,
         ILogger<Program> logger,
         IStringLocalizer<ApiMessages> localizer)
     {
@@ -119,7 +121,16 @@ public static class AuthEndpoints
             });
             await db.SaveChangesAsync();
 
-            logger.LogInformation("Password reset token for {Email}: {Token}", user.Email, token);
+            var baseUrl = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}";
+            var resetLink = $"{baseUrl}/reset-password/{token}";
+            var subject = localizer["ResetEmailSubject"].Value;
+            var htmlBody = EmailTemplates.BuildPasswordResetEmail(user.Username, resetLink, localizer);
+
+            var sent = await emailService.SendAsync(user.Email, subject, htmlBody);
+            if (!sent)
+            {
+                logger.LogInformation("Password reset token for {Email}: {Token}", user.Email, token);
+            }
         }
 
         // Always return OK to not reveal whether the email exists

--- a/src/Feirb.Api/Program.cs
+++ b/src/Feirb.Api/Program.cs
@@ -72,6 +72,7 @@ builder.Services.AddLocalization();
 
 // Services
 builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddScoped<IEmailService, EmailService>();
 
 var app = builder.Build();
 

--- a/src/Feirb.Api/Resources/ApiMessages.de-DE.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.de-DE.resx
@@ -99,4 +99,22 @@
   <data name="SmtpSettingsNotFound" xml:space="preserve">
     <value>System-SMTP-Einstellungen nicht gefunden.</value>
   </data>
+  <data name="ResetEmailSubject" xml:space="preserve">
+    <value>Setze dein Feirb-Passwort zurück</value>
+  </data>
+  <data name="ResetEmailGreeting" xml:space="preserve">
+    <value>Hallo {0},</value>
+  </data>
+  <data name="ResetEmailBody" xml:space="preserve">
+    <value>Wir haben eine Anfrage zum Zurücksetzen deines Passworts erhalten. Klicke auf die Schaltfläche unten, um ein neues Passwort zu wählen.</value>
+  </data>
+  <data name="ResetEmailButtonText" xml:space="preserve">
+    <value>Passwort zurücksetzen</value>
+  </data>
+  <data name="ResetEmailExpiry" xml:space="preserve">
+    <value>Dieser Link läuft in 1 Stunde ab.</value>
+  </data>
+  <data name="ResetEmailDisclaimer" xml:space="preserve">
+    <value>Falls du diese Anfrage nicht gestellt hast, kannst du diese E-Mail ignorieren.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.fr-FR.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.fr-FR.resx
@@ -99,4 +99,22 @@
   <data name="SmtpSettingsNotFound" xml:space="preserve">
     <value>Paramètres SMTP système introuvables.</value>
   </data>
+  <data name="ResetEmailSubject" xml:space="preserve">
+    <value>Réinitialisez votre mot de passe Feirb</value>
+  </data>
+  <data name="ResetEmailGreeting" xml:space="preserve">
+    <value>Bonjour {0},</value>
+  </data>
+  <data name="ResetEmailBody" xml:space="preserve">
+    <value>Nous avons reçu une demande de réinitialisation de votre mot de passe. Cliquez sur le bouton ci-dessous pour choisir un nouveau mot de passe.</value>
+  </data>
+  <data name="ResetEmailButtonText" xml:space="preserve">
+    <value>Réinitialiser le mot de passe</value>
+  </data>
+  <data name="ResetEmailExpiry" xml:space="preserve">
+    <value>Ce lien expire dans 1 heure.</value>
+  </data>
+  <data name="ResetEmailDisclaimer" xml:space="preserve">
+    <value>Si vous n'avez pas fait cette demande, vous pouvez ignorer cet e-mail.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.it-IT.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.it-IT.resx
@@ -99,4 +99,22 @@
   <data name="SmtpSettingsNotFound" xml:space="preserve">
     <value>Impostazioni SMTP di sistema non trovate.</value>
   </data>
+  <data name="ResetEmailSubject" xml:space="preserve">
+    <value>Reimposta la tua password Feirb</value>
+  </data>
+  <data name="ResetEmailGreeting" xml:space="preserve">
+    <value>Ciao {0},</value>
+  </data>
+  <data name="ResetEmailBody" xml:space="preserve">
+    <value>Abbiamo ricevuto una richiesta di reimpostazione della tua password. Clicca il pulsante qui sotto per scegliere una nuova password.</value>
+  </data>
+  <data name="ResetEmailButtonText" xml:space="preserve">
+    <value>Reimposta password</value>
+  </data>
+  <data name="ResetEmailExpiry" xml:space="preserve">
+    <value>Questo link scade tra 1 ora.</value>
+  </data>
+  <data name="ResetEmailDisclaimer" xml:space="preserve">
+    <value>Se non hai fatto questa richiesta, puoi ignorare questa e-mail.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.resx
@@ -99,4 +99,22 @@
   <data name="SmtpSettingsNotFound" xml:space="preserve">
     <value>System SMTP settings not found.</value>
   </data>
+  <data name="ResetEmailSubject" xml:space="preserve">
+    <value>Reset your Feirb password</value>
+  </data>
+  <data name="ResetEmailGreeting" xml:space="preserve">
+    <value>Hi {0},</value>
+  </data>
+  <data name="ResetEmailBody" xml:space="preserve">
+    <value>We received a request to reset your password. Click the button below to choose a new password.</value>
+  </data>
+  <data name="ResetEmailButtonText" xml:space="preserve">
+    <value>Reset Password</value>
+  </data>
+  <data name="ResetEmailExpiry" xml:space="preserve">
+    <value>This link expires in 1 hour.</value>
+  </data>
+  <data name="ResetEmailDisclaimer" xml:space="preserve">
+    <value>If you didn't request this, you can safely ignore this email.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Services/EmailService.cs
+++ b/src/Feirb.Api/Services/EmailService.cs
@@ -1,0 +1,53 @@
+using Feirb.Api.Data;
+using MailKit.Net.Smtp;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using MimeKit;
+
+namespace Feirb.Api.Services;
+
+public class EmailService(
+    FeirbDbContext db,
+    IDataProtectionProvider dataProtection,
+    ILogger<EmailService> logger) : IEmailService
+{
+    public async Task<bool> SendAsync(string to, string subject, string htmlBody)
+    {
+        var settings = await db.SmtpSettings.FirstOrDefaultAsync();
+        if (settings is null)
+        {
+            logger.LogWarning("No SMTP settings configured — cannot send email");
+            return false;
+        }
+
+        var message = new MimeMessage();
+        message.From.Add(new MailboxAddress(settings.FromName ?? "Feirb", settings.FromAddress ?? "noreply@feirb.local"));
+        message.To.Add(MailboxAddress.Parse(to));
+        message.Subject = subject;
+        message.Body = new TextPart("html") { Text = htmlBody };
+
+        using var client = new SmtpClient();
+        try
+        {
+            await client.ConnectAsync(settings.Host, settings.Port, settings.UseTls);
+
+            if (settings.RequiresAuth && settings.Username is not null && settings.EncryptedPassword is not null)
+            {
+                var protector = dataProtection.CreateProtector(DataProtectionPurposes.SmtpPassword);
+                var password = protector.Unprotect(settings.EncryptedPassword);
+                await client.AuthenticateAsync(settings.Username, password);
+            }
+
+            await client.SendAsync(message);
+            await client.DisconnectAsync(quit: true);
+
+            logger.LogInformation("Email sent to {To} with subject '{Subject}'", to, subject);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send email to {To}", to);
+            return false;
+        }
+    }
+}

--- a/src/Feirb.Api/Services/EmailTemplates.cs
+++ b/src/Feirb.Api/Services/EmailTemplates.cs
@@ -1,0 +1,64 @@
+using Feirb.Api.Resources;
+using Microsoft.Extensions.Localization;
+
+namespace Feirb.Api.Services;
+
+public static class EmailTemplates
+{
+    public static string BuildPasswordResetEmail(
+        string username,
+        string resetLink,
+        IStringLocalizer<ApiMessages> localizer)
+    {
+        ArgumentNullException.ThrowIfNull(localizer);
+        return $"""
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset="utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        </head>
+        <body style="margin:0; padding:0; background-color:#f5f5f5; font-family:Arial, Helvetica, sans-serif;">
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5; padding:32px 0;">
+                <tr>
+                    <td align="center">
+                        <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="background-color:#ffffff; border-radius:8px; overflow:hidden;">
+                            <tr>
+                                <td style="background-color:#0d6efd; padding:24px 32px;">
+                                    <h1 style="margin:0; color:#ffffff; font-size:24px; font-weight:700;">Feirb</h1>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="padding:32px;">
+                                    <p style="margin:0 0 16px; font-size:16px; color:#333333;">
+                                        {localizer["ResetEmailGreeting", username]}
+                                    </p>
+                                    <p style="margin:0 0 24px; font-size:16px; color:#333333;">
+                                        {localizer["ResetEmailBody"]}
+                                    </p>
+                                    <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
+                                        <tr>
+                                            <td style="background-color:#0d6efd; border-radius:6px;">
+                                                <a href="{resetLink}" style="display:inline-block; padding:12px 24px; color:#ffffff; text-decoration:none; font-size:16px; font-weight:600;">
+                                                    {localizer["ResetEmailButtonText"]}
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                    <p style="margin:0 0 16px; font-size:14px; color:#666666;">
+                                        {localizer["ResetEmailExpiry"]}
+                                    </p>
+                                    <p style="margin:0; font-size:14px; color:#666666;">
+                                        {localizer["ResetEmailDisclaimer"]}
+                                    </p>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </body>
+        </html>
+        """;
+    }
+}

--- a/src/Feirb.Api/Services/IEmailService.cs
+++ b/src/Feirb.Api/Services/IEmailService.cs
@@ -1,0 +1,6 @@
+namespace Feirb.Api.Services;
+
+public interface IEmailService
+{
+    Task<bool> SendAsync(string to, string subject, string htmlBody);
+}

--- a/tests/Feirb.Api.Tests/Services/EmailServiceTests.cs
+++ b/tests/Feirb.Api.Tests/Services/EmailServiceTests.cs
@@ -1,0 +1,41 @@
+using Feirb.Api.Data;
+using Feirb.Api.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Feirb.Api.Tests.Services;
+
+public class EmailServiceTests : IDisposable
+{
+    private readonly FeirbDbContext _db;
+    private readonly EmailService _service;
+
+    public EmailServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<FeirbDbContext>()
+            .UseInMemoryDatabase($"EmailServiceTest-{Guid.NewGuid()}")
+            .Options;
+        _db = new FeirbDbContext(options);
+
+        var dataProtection = DataProtectionProvider.Create("Tests");
+        var logger = NullLogger<EmailService>.Instance;
+
+        _service = new EmailService(_db, dataProtection, logger);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task SendAsync_NoSmtpSettings_ReturnsFalseAsync()
+    {
+        var result = await _service.SendAsync("test@example.com", "Test", "<p>Test</p>");
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `IEmailService` / `EmailService` using MailKit to send emails via the configured SMTP server
- Add localized HTML password reset email template with Feirb branding (en, de, fr, it)
- Modify `POST /api/auth/request-reset` to send reset email, falling back to console logging when SMTP is not configured

Closes #21

## Test plan

- [ ] Run `dotnet run --project src/Feirb.AppHost` and request a password reset
- [ ] Verify email appears in Mailpit UI at localhost:8025
- [ ] Verify reset link in email is correct and clickable
- [ ] Verify fallback to console logging when no SMTP settings exist
- [ ] Verify email subject/body localization by changing request culture

🤖 Generated with [Claude Code](https://claude.com/claude-code)