### PR TITLE
feat: GreenMail as dev mail server (IMAP + SMTP)

### DIFF
--- a/.claude/skills/aspire-run/SKILL.md
+++ b/.claude/skills/aspire-run/SKILL.md
@@ -19,11 +19,11 @@ Start the Feirb application via .NET Aspire. This is the primary way to run all 
    - **Aspire Dashboard:** https://localhost:18888
    - **Blazor Frontend:** https://localhost:7100
    - **API Backend:** https://localhost:7200
-   - **Mailpit:** http://localhost:8025
+   - **GreenMail API:** http://localhost:8080
 
 3. If the command fails, check:
    - Docker is running (`docker info`)
-   - No port conflicts on 7100, 7200, 8025, 11434, 18888
+   - No port conflicts on 3025, 3143, 7100, 7200, 8080, 11434, 18888
    - .NET 10 SDK is installed (`dotnet --version`)
 
 4. On first run, note that the Ollama qwen3:4b model download (~2.6GB) may take several minutes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ dotnet format
 
 - **Aspire Dashboard:** https://localhost:18888
 - **PostgreSQL:** Managed by Aspire, localhost:5432
-- **Mailpit (dev mail server):** http://localhost:8025 (UI), localhost:1025 (SMTP)
+- **GreenMail (dev mail server):** SMTP localhost:3025, IMAP localhost:3143, REST API / OpenAPI UI http://localhost:8080
 - **Ollama:** Managed by Aspire, model `qwen3:4b` pulled automatically (~2.6GB on first run)
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Pronounced like "fire-bee", the name is simply "Brief" (German for *letter*) spe
 ## Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download) (10.0.100+)
-- [Docker](https://www.docker.com/) (for Aspire, Ollama, and Mailpit containers)
+- [Docker](https://www.docker.com/) (for Aspire, Ollama, and GreenMail containers)
 - Git
 
 ## Quick Start
@@ -57,7 +57,7 @@ This starts all services via Aspire:
 - **Aspire Dashboard:** https://localhost:18888
 - **Blazor Frontend:** https://localhost:7100
 - **API Backend:** https://localhost:7200
-- **Mailpit (dev):** http://localhost:8025
+- **GreenMail API (dev):** http://localhost:8080
 
 > **Note:** On first run, the Ollama qwen3:4b model (~2.6GB) will be downloaded automatically.
 
@@ -70,8 +70,10 @@ FEIRB_SEED_DATA=true dotnet run --project src/Feirb.AppHost
 ```
 
 This seeds the database with:
-- **Admin user:** `admin@feirb.local` / `admin` (password)
-- **SMTP settings:** Mailpit on `localhost:1025` (no TLS, no auth), from address `noreply@feirb.local`
+- **Admin user:** `admin@feirb.local` / `admin@feirb.local` (password)
+- **Alice user:** `alice@feirb.local` / `alice@feirb.local` (password)
+- **SMTP settings:** GreenMail on `localhost:3025` (no TLS, no auth), from address `noreply@feirb.local`
+- **Mailboxes:** One per user, IMAP on `localhost:3143`, SMTP on `localhost:3025`
 
 The seeding is idempotent — it checks whether the data already exists and skips if so.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,7 +58,7 @@ graph TB
         API[Feirb.Api\nMinimal APIs]
         OLLAMA[Ollama Container\nqwen3:4b model]
         DB[(PostgreSQL)]
-        MAILPIT[Mailpit\ndev only]
+        GREENMAIL[GreenMail\ndev only\nSMTP+IMAP+API]
     end
 
     subgraph External
@@ -69,7 +69,7 @@ graph TB
     API -->|MailKit| IMAP
     API -->|OllamaSharp| OLLAMA
     API -->|EF Core| DB
-    API -.->|dev SMTP| MAILPIT
+    API -.->|dev SMTP/IMAP| GREENMAIL
 ```
 
 ## Components
@@ -78,7 +78,7 @@ graph TB
 
 Aspire orchestration project and main entry point. Registers and configures all services, manages service discovery, and provides the Aspire dashboard.
 
-Manages: PostgreSQL (with pgAdmin), Ollama (via `CommunityToolkit.Aspire.Hosting.Ollama`), Mailpit (dev).
+Manages: PostgreSQL (with pgAdmin), Ollama (via `CommunityToolkit.Aspire.Hosting.Ollama`), GreenMail (dev SMTP/IMAP/API).
 
 ### Feirb.ServiceDefaults
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -19,13 +19,13 @@ This starts:
 - **API backend** — https://localhost:7200
 - **PostgreSQL** — localhost:5432 (Aspire-managed container)
 - **Ollama** — with qwen3:4b model (Aspire-managed container)
-- **Mailpit** — http://localhost:8025 (dev mail server)
+- **GreenMail** — SMTP localhost:3025, IMAP localhost:3143, API http://localhost:8080 (dev mail server)
 - **Aspire Dashboard** — https://localhost:18888
 
 ### Requirements
 
 - .NET 10 SDK (10.0.100+)
-- Docker (for PostgreSQL, Ollama, and Mailpit containers)
+- Docker (for PostgreSQL, Ollama, and GreenMail containers)
 
 See [Developer Setup](SETUP.md) for detailed instructions.
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -5,7 +5,7 @@
 | Tool | Version | Purpose |
 |------|---------|---------|
 | [.NET SDK](https://dotnet.microsoft.com/download) | 10.0.100+ | Build and run the solution |
-| [Docker](https://www.docker.com/) | Latest | Aspire containers (PostgreSQL, Ollama, Mailpit) |
+| [Docker](https://www.docker.com/) | Latest | Aspire containers (PostgreSQL, Ollama, GreenMail) |
 | [Git](https://git-scm.com/) | Latest | Version control |
 
 **Recommended IDE (pick one):**
@@ -37,7 +37,7 @@ On first run, Aspire will:
 2. Start the API and Web projects
 3. Pull and start the Ollama Docker container
 4. Download the `qwen3:4b` model (~2.6GB — this takes a while on first run)
-5. Start Mailpit for development email testing
+5. Start GreenMail for development email testing (SMTP + IMAP)
 
 ## Development Services
 
@@ -49,14 +49,15 @@ Once running, these services are available:
 | Blazor Frontend | https://localhost:7100 | The mail client UI |
 | API Backend | https://localhost:7200 | REST API |
 | PostgreSQL | localhost:5432 | Database |
-| Mailpit Web UI | http://localhost:8025 | View test emails |
-| Mailpit SMTP | localhost:1025 | Send test emails |
+| GreenMail API / OpenAPI UI | http://localhost:8080 | View and manage test emails |
+| GreenMail SMTP | localhost:3025 | Send test emails |
+| GreenMail IMAP | localhost:3143 | Fetch test emails |
 
 ## Helper Scripts
 
 | Script | Purpose |
 |--------|---------|
-| `./run.sh` | Start Feirb with database seeding (admin user + Mailpit SMTP) |
+| `./run.sh` | Start Feirb with database seeding (admin + alice users, mailboxes, GreenMail SMTP) |
 | `./run.sh --no-seeding` | Start Feirb without seeding |
 | `./stop-aspire-containers.sh` | Stop and remove Aspire containers and orphaned volumes |
 
@@ -67,10 +68,14 @@ When started via `./run.sh` (or with `FEIRB_SEED_DATA=true`), the following data
 | Data | Value |
 |------|-------|
 | Admin email | `admin@feirb.local` |
-| Admin password | `admin` |
-| SMTP host | `localhost:1025` (Mailpit) |
+| Admin password | `admin@feirb.local` |
+| Alice email | `alice@feirb.local` |
+| Alice password | `alice@feirb.local` |
+| System SMTP | `localhost:3025` (GreenMail) |
 | SMTP from address | `noreply@feirb.local` |
 | TLS / Auth | disabled |
+| IMAP host | `localhost:3143` (GreenMail) |
+| Mailbox credentials | email address as both username and password |
 
 The seeding is idempotent — it checks whether the data already exists and skips if so.
 
@@ -130,13 +135,15 @@ docker stop ollama && docker rm ollama
 
 The Aspire configuration uses a persistent volume, so the model is only downloaded once.
 
-## Mailpit (Dev Mail Server)
+## GreenMail (Dev Mail Server)
 
-Mailpit acts as a catch-all SMTP server for development. No real emails are sent.
+GreenMail provides SMTP, IMAP, and a REST API in a single container for development. No real emails are sent.
 
-- **Send test emails** to any address — they all arrive in Mailpit
-- **Web UI** at http://localhost:8025 shows all captured emails
-- **SMTP** at localhost:1025 — configure test accounts to use this
+- **SMTP** at localhost:3025 — system and per-mailbox outgoing mail
+- **IMAP** at localhost:3143 — mail fetching for inbox sync
+- **REST API / OpenAPI UI** at http://localhost:8080 — inspect and manage test emails
+- **Preloaded mail** — 30 .eml files (10 per account) are mounted from `seeding/mails/` and loaded on startup
+- **Test accounts:** admin@feirb.local, alice@feirb.local, bob@feirb.local (bob has mail but no Feirb account)
 
 ## Configuration
 
@@ -160,7 +167,7 @@ Never commit passwords or secrets to the repository.
 
 ### Docker not running
 
-Aspire requires Docker for Ollama and Mailpit containers. Ensure Docker Desktop is running:
+Aspire requires Docker for Ollama and GreenMail containers. Ensure Docker Desktop is running:
 
 ```bash
 docker info

--- a/seeding/mails/admin@feirb.local/INBOX/01-welcome.eml
+++ b/seeding/mails/admin@feirb.local/INBOX/01-welcome.eml
@@ -1,0 +1,16 @@
+From: system@feirb.local
+To: admin@feirb.local
+Subject: Welcome to Feirb
+Date: Mon, 10 Mar 2026 09:00:00 +0100
+Message-ID: <admin-01@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Welcome to Feirb, your self-hosted mail client!
+
+You are now set up as the system administrator. From here you can
+manage users, configure mail accounts, and explore AI-powered
+features like mail summarization and smart replies.
+
+Happy mailing!
+The Feirb Team

--- a/seeding/mails/admin@feirb.local/INBOX/02-meeting.eml
+++ b/seeding/mails/admin@feirb.local/INBOX/02-meeting.eml
@@ -1,0 +1,18 @@
+From: alice@feirb.local
+To: admin@feirb.local
+Subject: Team meeting this Thursday
+Date: Mon, 10 Mar 2026 10:15:00 +0100
+Message-ID: <admin-02@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hi Admin,
+
+Just a reminder that we have our weekly team meeting this Thursday
+at 2 PM. I would like to discuss the new deployment pipeline and
+the status of the user management module.
+
+Please let me know if you have any agenda items to add.
+
+Best,
+Alice

--- a/seeding/mails/admin@feirb.local/INBOX/03-server-alert.eml
+++ b/seeding/mails/admin@feirb.local/INBOX/03-server-alert.eml
@@ -1,0 +1,19 @@
+From: monitoring@infra.local
+To: admin@feirb.local
+Subject: Server health check passed
+Date: Tue, 11 Mar 2026 06:00:00 +0100
+Message-ID: <admin-03@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Daily Health Check Report
+=========================
+
+All systems operational.
+
+- CPU usage: 23%
+- Memory usage: 41%
+- Disk usage: 58%
+- Uptime: 45 days
+
+No action required.

--- a/seeding/mails/admin@feirb.local/INBOX/04-backup-report.eml
+++ b/seeding/mails/admin@feirb.local/INBOX/04-backup-report.eml
@@ -1,0 +1,19 @@
+From: backup@infra.local
+To: admin@feirb.local
+Subject: Weekly backup completed successfully
+Date: Wed, 12 Mar 2026 03:30:00 +0100
+Message-ID: <admin-04@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Backup Summary
+==============
+
+Job: Weekly Full Backup
+Status: Completed
+Duration: 2h 14m
+Size: 128.4 GB
+Destination: /mnt/backup/weekly/2026-03-12
+
+All databases and file shares backed up successfully.
+Next scheduled backup: 2026-03-19 01:00 UTC

--- a/seeding/mails/admin@feirb.local/INBOX/05-user-request.eml
+++ b/seeding/mails/admin@feirb.local/INBOX/05-user-request.eml
@@ -1,0 +1,18 @@
+From: bob@external.example
+To: admin@feirb.local
+Subject: Account access request
+Date: Wed, 12 Mar 2026 11:20:00 +0100
+Message-ID: <admin-05@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hi,
+
+My name is Bob and I work in the marketing department. I would like
+to request access to the Feirb mail system. Could you please create
+an account for me?
+
+My preferred email would be bob@feirb.local.
+
+Thanks in advance,
+Bob

--- a/seeding/mails/admin@feirb.local/INBOX/06-security-update.eml
+++ b/seeding/mails/admin@feirb.local/INBOX/06-security-update.eml
@@ -1,0 +1,18 @@
+From: security@infra.local
+To: admin@feirb.local
+Subject: Security patches available
+Date: Thu, 13 Mar 2026 08:00:00 +0100
+Message-ID: <admin-06@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Security Advisory
+=================
+
+3 new security patches are available for your system:
+
+1. openssl 3.2.1 - fixes CVE-2026-1234 (medium severity)
+2. nginx 1.27.3 - fixes request smuggling issue (high severity)
+3. postgresql 17.3 - minor security hardening (low severity)
+
+Please schedule a maintenance window to apply these updates.

--- a/seeding/mails/admin@feirb.local/INBOX/07-disk-warning.eml
+++ b/seeding/mails/admin@feirb.local/INBOX/07-disk-warning.eml
@@ -1,0 +1,15 @@
+From: monitoring@infra.local
+To: admin@feirb.local
+Subject: Disk space warning on storage pool
+Date: Fri, 14 Mar 2026 14:45:00 +0100
+Message-ID: <admin-07@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Warning: Storage pool "data" is at 78% capacity.
+
+Current usage: 3.12 TB of 4.0 TB
+Growth rate: ~50 GB/week
+
+At this rate, the pool will reach 90% in approximately 5 weeks.
+Consider expanding the pool or archiving old data.

--- a/seeding/mails/admin@feirb.local/INBOX/08-feature-request.eml
+++ b/seeding/mails/admin@feirb.local/INBOX/08-feature-request.eml
@@ -1,0 +1,19 @@
+From: alice@feirb.local
+To: admin@feirb.local
+Subject: Feature request - dark mode
+Date: Fri, 14 Mar 2026 16:30:00 +0100
+Message-ID: <admin-08@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hey,
+
+Would it be possible to add a dark mode to the Feirb UI? Several
+of us work late hours and the bright interface is a bit straining
+on the eyes.
+
+It does not need to be fancy, just inverting the color scheme
+would already help a lot.
+
+Thanks!
+Alice

--- a/seeding/mails/admin@feirb.local/INBOX/09-certificate-expiry.eml
+++ b/seeding/mails/admin@feirb.local/INBOX/09-certificate-expiry.eml
@@ -1,0 +1,18 @@
+From: certbot@infra.local
+To: admin@feirb.local
+Subject: TLS certificate expires in 14 days
+Date: Sat, 15 Mar 2026 00:00:00 +0100
+Message-ID: <admin-09@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Reminder: The TLS certificate for *.feirb.local expires on
+2026-03-29.
+
+Certificate details:
+- Domain: *.feirb.local
+- Issuer: Local CA
+- Serial: 4A:2B:9C:DE:F0:12
+
+Auto-renewal is configured but please verify that the renewal
+hook is still functional.

--- a/seeding/mails/admin@feirb.local/INBOX/10-weekly-summary.eml
+++ b/seeding/mails/admin@feirb.local/INBOX/10-weekly-summary.eml
@@ -1,0 +1,19 @@
+From: system@feirb.local
+To: admin@feirb.local
+Subject: Weekly system summary
+Date: Sun, 16 Mar 2026 08:00:00 +0100
+Message-ID: <admin-10@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Weekly Summary (2026-03-10 to 2026-03-16)
+=========================================
+
+Users: 2 active
+Emails processed: 147
+Storage used: 3.14 TB / 4.0 TB
+Uptime: 99.98%
+
+Top senders: monitoring@infra.local (42), alice@feirb.local (18)
+
+No critical incidents this week.

--- a/seeding/mails/alice@feirb.local/INBOX/01-project-update.eml
+++ b/seeding/mails/alice@feirb.local/INBOX/01-project-update.eml
@@ -1,0 +1,21 @@
+From: admin@feirb.local
+To: alice@feirb.local
+Subject: Project status update
+Date: Mon, 10 Mar 2026 09:30:00 +0100
+Message-ID: <alice-01@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hi Alice,
+
+Here is a quick update on the current project status:
+
+- Authentication module: completed
+- Mail fetching: in progress (70%)
+- AI integration: scheduled for next sprint
+- UI polish: backlog
+
+Let me know if you have any questions.
+
+Best,
+Admin

--- a/seeding/mails/alice@feirb.local/INBOX/02-question.eml
+++ b/seeding/mails/alice@feirb.local/INBOX/02-question.eml
@@ -1,0 +1,18 @@
+From: bob@external.example
+To: alice@feirb.local
+Subject: Quick question about the API docs
+Date: Mon, 10 Mar 2026 14:00:00 +0100
+Message-ID: <alice-02@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hey Alice,
+
+I was looking at the API documentation and noticed that the
+endpoint for fetching mailbox settings returns different fields
+than what the create endpoint expects.
+
+Is that intentional or should I file a bug?
+
+Cheers,
+Bob

--- a/seeding/mails/alice@feirb.local/INBOX/03-lunch-plan.eml
+++ b/seeding/mails/alice@feirb.local/INBOX/03-lunch-plan.eml
@@ -1,0 +1,16 @@
+From: carol@external.example
+To: alice@feirb.local
+Subject: Lunch on Wednesday?
+Date: Tue, 11 Mar 2026 10:00:00 +0100
+Message-ID: <alice-03@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hi Alice,
+
+Are you free for lunch on Wednesday? There is a new Italian place
+near the office that I have been wanting to try. They supposedly
+have great pasta.
+
+Let me know!
+Carol

--- a/seeding/mails/alice@feirb.local/INBOX/04-code-review.eml
+++ b/seeding/mails/alice@feirb.local/INBOX/04-code-review.eml
@@ -1,0 +1,21 @@
+From: admin@feirb.local
+To: alice@feirb.local
+Subject: Code review requested - PR #42
+Date: Tue, 11 Mar 2026 15:20:00 +0100
+Message-ID: <alice-04@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hi Alice,
+
+I just opened PR #42 for the mailbox CRUD endpoints. Could you
+take a look when you get a chance? It includes the data protection
+encryption for stored passwords.
+
+The changes are in:
+- MailboxEndpoints.cs
+- Mailbox.cs (entity)
+- Two new migrations
+
+Thanks!
+Admin

--- a/seeding/mails/alice@feirb.local/INBOX/05-newsletter.eml
+++ b/seeding/mails/alice@feirb.local/INBOX/05-newsletter.eml
@@ -1,0 +1,21 @@
+From: news@dotnetweekly.example
+To: alice@feirb.local
+Subject: .NET Weekly - Issue 312
+Date: Wed, 12 Mar 2026 07:00:00 +0100
+Message-ID: <alice-05@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+.NET Weekly - Issue 312
+=======================
+
+Top stories this week:
+
+1. .NET 10 Preview 3 released with improved AOT support
+2. Blazor WebAssembly performance improvements in preview
+3. New EF Core bulk operations API announced
+4. Community spotlight: Building mail clients with MailKit
+
+Read more at dotnetweekly.example/312
+
+To unsubscribe, reply with UNSUBSCRIBE in the subject line.

--- a/seeding/mails/alice@feirb.local/INBOX/06-deployment-notice.eml
+++ b/seeding/mails/alice@feirb.local/INBOX/06-deployment-notice.eml
@@ -1,0 +1,22 @@
+From: ci@infra.local
+To: alice@feirb.local
+Subject: Deployment to staging completed
+Date: Wed, 12 Mar 2026 18:45:00 +0100
+Message-ID: <alice-06@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Deployment Report
+=================
+
+Environment: staging
+Branch: feature/mail-sync
+Commit: a1b2c3d
+Status: Success
+
+Changes deployed:
+- IMAP folder sync service
+- Mail list API endpoint
+- Blazor inbox component (WIP)
+
+Please verify the deployment at staging.feirb.local.

--- a/seeding/mails/alice@feirb.local/INBOX/07-meeting-notes.eml
+++ b/seeding/mails/alice@feirb.local/INBOX/07-meeting-notes.eml
@@ -1,0 +1,22 @@
+From: admin@feirb.local
+To: alice@feirb.local
+Subject: Meeting notes - Thursday standup
+Date: Thu, 13 Mar 2026 15:00:00 +0100
+Message-ID: <alice-07@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Meeting Notes - 2026-03-13
+==========================
+
+Attendees: Admin, Alice
+
+Discussion:
+- Mail sync is working for single folders
+- Next step: recursive folder sync
+- AI summarization spike planned for next week
+- Bob requested an account, will set up next week
+
+Action items:
+- Alice: finish folder tree component by Friday
+- Admin: review PR #42, set up Bob's account

--- a/seeding/mails/alice@feirb.local/INBOX/08-conference.eml
+++ b/seeding/mails/alice@feirb.local/INBOX/08-conference.eml
@@ -1,0 +1,22 @@
+From: events@techconf.example
+To: alice@feirb.local
+Subject: Registration confirmed - TechConf 2026
+Date: Fri, 14 Mar 2026 09:00:00 +0100
+Message-ID: <alice-08@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hi Alice,
+
+Your registration for TechConf 2026 has been confirmed!
+
+Event: TechConf 2026
+Date: April 15-17, 2026
+Location: Convention Center, Berlin
+Track: Cloud Native & DevOps
+
+Your ticket ID is TC2026-4821. Please bring this email
+or your QR code to the registration desk.
+
+See you there!
+TechConf Team

--- a/seeding/mails/alice@feirb.local/INBOX/09-feedback.eml
+++ b/seeding/mails/alice@feirb.local/INBOX/09-feedback.eml
@@ -1,0 +1,18 @@
+From: carol@external.example
+To: alice@feirb.local
+Subject: Re: Lunch on Wednesday?
+Date: Fri, 14 Mar 2026 12:30:00 +0100
+Message-ID: <alice-09@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+That was such a great find! The carbonara was incredible.
+We should definitely go back. Maybe next week with the
+whole team?
+
+By the way, I tried out the Feirb demo you showed me and
+the UI looks really clean. The AI reply suggestions are
+a cool idea.
+
+Talk soon,
+Carol

--- a/seeding/mails/alice@feirb.local/INBOX/10-weekend-reading.eml
+++ b/seeding/mails/alice@feirb.local/INBOX/10-weekend-reading.eml
@@ -1,0 +1,21 @@
+From: digest@blazordigest.example
+To: alice@feirb.local
+Subject: Blazor Digest - Weekend Edition
+Date: Sat, 15 Mar 2026 10:00:00 +0100
+Message-ID: <alice-10@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Blazor Digest - Weekend Edition
+================================
+
+Featured articles:
+
+1. Understanding Blazor WASM lazy loading
+2. State management patterns in Blazor
+3. Building reusable Razor class libraries
+4. Testing Blazor components with bUnit
+5. Blazor and SignalR: real-time updates
+
+Happy reading!
+The Blazor Digest Team

--- a/seeding/mails/bob@feirb.local/INBOX/01-newsletter.eml
+++ b/seeding/mails/bob@feirb.local/INBOX/01-newsletter.eml
@@ -1,0 +1,22 @@
+From: news@marketingweekly.example
+To: bob@feirb.local
+Subject: Marketing Weekly - Top trends for Q2
+Date: Mon, 10 Mar 2026 08:00:00 +0100
+Message-ID: <bob-01@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Marketing Weekly - Q2 Trends
+=============================
+
+Hello Bob,
+
+Here are the top marketing trends to watch in Q2 2026:
+
+1. AI-generated content reaches mainstream adoption
+2. Short-form video continues to dominate engagement
+3. Privacy-first analytics tools gaining market share
+4. Community-driven brand building on the rise
+5. Email marketing ROI still highest among channels
+
+Read the full analysis at marketingweekly.example/q2-2026

--- a/seeding/mails/bob@feirb.local/INBOX/02-receipt.eml
+++ b/seeding/mails/bob@feirb.local/INBOX/02-receipt.eml
@@ -1,0 +1,26 @@
+From: billing@cloudhost.example
+To: bob@feirb.local
+Subject: Invoice #INV-2026-0312 - March hosting
+Date: Mon, 10 Mar 2026 12:00:00 +0100
+Message-ID: <bob-02@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Invoice #INV-2026-0312
+======================
+
+Customer: Bob
+Date: 2026-03-10
+Due: 2026-03-25
+
+Items:
+- Cloud Hosting Basic Plan    EUR 9.99
+- Domain renewal (1 year)     EUR 12.00
+- SSL certificate             EUR 0.00
+
+Total: EUR 21.99
+
+Payment method: Credit card ending in 4242
+Status: Paid
+
+Thank you for your business!

--- a/seeding/mails/bob@feirb.local/INBOX/03-team-event.eml
+++ b/seeding/mails/bob@feirb.local/INBOX/03-team-event.eml
@@ -1,0 +1,25 @@
+From: hr@company.example
+To: bob@feirb.local
+Subject: Team building event next Friday
+Date: Tue, 11 Mar 2026 09:00:00 +0100
+Message-ID: <bob-03@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hi Bob,
+
+We are organizing a team building event next Friday afternoon
+(March 21). The plan is to do an escape room followed by dinner
+at the riverside restaurant.
+
+Please confirm your attendance by Wednesday so we can finalize
+the reservation.
+
+Details:
+- Date: Friday, March 21, 2026
+- Time: 14:00 - 20:00
+- Location: Escape Room Central, then River Bistro
+- Cost: covered by the company
+
+Looking forward to seeing you there!
+HR Team

--- a/seeding/mails/bob@feirb.local/INBOX/04-alice-reply.eml
+++ b/seeding/mails/bob@feirb.local/INBOX/04-alice-reply.eml
@@ -1,0 +1,17 @@
+From: alice@feirb.local
+To: bob@feirb.local
+Subject: Re: Quick question about the API docs
+Date: Tue, 11 Mar 2026 16:00:00 +0100
+Message-ID: <bob-04@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hi Bob,
+
+Good catch! That is indeed a bug in the documentation. The create
+endpoint was updated last week but the docs were not regenerated.
+
+I have filed an issue for it. Should be fixed in the next update.
+
+Thanks for reporting it!
+Alice

--- a/seeding/mails/bob@feirb.local/INBOX/05-social-notification.eml
+++ b/seeding/mails/bob@feirb.local/INBOX/05-social-notification.eml
@@ -1,0 +1,20 @@
+From: notifications@devforum.example
+To: bob@feirb.local
+Subject: New reply to your post "Best NAS software 2026"
+Date: Wed, 12 Mar 2026 11:30:00 +0100
+Message-ID: <bob-05@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hi Bob,
+
+Someone replied to your post "Best NAS software 2026":
+
+user_techfan42 wrote:
+"Have you tried Feirb? It is a new self-hosted mail client
+designed specifically for NAS systems. Still in early development
+but the AI features look promising."
+
+View the full thread at devforum.example/posts/nas-software-2026
+
+You are receiving this because you subscribed to thread updates.

--- a/seeding/mails/bob@feirb.local/INBOX/06-shipping.eml
+++ b/seeding/mails/bob@feirb.local/INBOX/06-shipping.eml
@@ -1,0 +1,20 @@
+From: orders@techshop.example
+To: bob@feirb.local
+Subject: Your order has shipped - NAS hard drive
+Date: Wed, 12 Mar 2026 14:15:00 +0100
+Message-ID: <bob-06@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Order Confirmation
+==================
+
+Order #TS-88421 has shipped!
+
+Item: Seagate IronWolf 8TB NAS HDD
+Quantity: 2
+Tracking: DHL 1234567890
+
+Estimated delivery: March 15-17, 2026
+
+You can track your package at dhl.example/track/1234567890

--- a/seeding/mails/bob@feirb.local/INBOX/07-reminder.eml
+++ b/seeding/mails/bob@feirb.local/INBOX/07-reminder.eml
@@ -1,0 +1,18 @@
+From: calendar@workspace.example
+To: bob@feirb.local
+Subject: Reminder - Dentist appointment tomorrow
+Date: Thu, 13 Mar 2026 18:00:00 +0100
+Message-ID: <bob-07@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Reminder
+========
+
+You have an upcoming appointment:
+
+What: Dentist - regular checkup
+When: Friday, March 14, 2026 at 10:00
+Where: Dr. Mueller, Hauptstrasse 15
+
+This is an automated reminder from your calendar.

--- a/seeding/mails/bob@feirb.local/INBOX/08-webinar.eml
+++ b/seeding/mails/bob@feirb.local/INBOX/08-webinar.eml
@@ -1,0 +1,26 @@
+From: learn@digitalacademy.example
+To: bob@feirb.local
+Subject: Free webinar - Introduction to self-hosting
+Date: Fri, 14 Mar 2026 07:00:00 +0100
+Message-ID: <bob-08@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hi Bob,
+
+Join our free webinar on self-hosting!
+
+Topic: Getting Started with Self-Hosting
+Date: March 20, 2026 at 19:00 CET
+Duration: 90 minutes
+
+What you will learn:
+- Choosing the right hardware
+- Setting up Docker and Compose
+- Essential self-hosted services
+- Security best practices
+- Backup strategies
+
+Register at digitalacademy.example/webinar/self-hosting
+
+Seats are limited!

--- a/seeding/mails/bob@feirb.local/INBOX/09-admin-reply.eml
+++ b/seeding/mails/bob@feirb.local/INBOX/09-admin-reply.eml
@@ -1,0 +1,19 @@
+From: admin@feirb.local
+To: bob@feirb.local
+Subject: Re: Account access request
+Date: Fri, 14 Mar 2026 10:00:00 +0100
+Message-ID: <bob-09@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hi Bob,
+
+Thanks for reaching out. I will set up your account next week
+after the maintenance window. You will receive a welcome email
+once everything is ready.
+
+In the meantime, feel free to check out the documentation at
+docs.feirb.local to get familiar with the system.
+
+Best,
+Admin

--- a/seeding/mails/bob@feirb.local/INBOX/10-weather.eml
+++ b/seeding/mails/bob@feirb.local/INBOX/10-weather.eml
@@ -1,0 +1,21 @@
+From: alerts@weather.example
+To: bob@feirb.local
+Subject: Weather alert - Heavy rain expected Sunday
+Date: Sat, 15 Mar 2026 06:00:00 +0100
+Message-ID: <bob-10@feirb.local>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Weather Alert for your area
+============================
+
+Heavy rain expected on Sunday, March 16.
+
+Forecast:
+- Saturday: Cloudy, 12C, light wind
+- Sunday: Heavy rain, 8C, strong gusts up to 60 km/h
+- Monday: Partly cloudy, 10C, calm
+
+Rainfall expected: 25-35 mm over 12 hours.
+
+Stay safe and plan accordingly.

--- a/src/Feirb.Api/Data/DatabaseSeeder.cs
+++ b/src/Feirb.Api/Data/DatabaseSeeder.cs
@@ -1,32 +1,30 @@
 using Feirb.Api.Data.Entities;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 
 namespace Feirb.Api.Data;
 
 internal static class DatabaseSeeder
 {
-    public static async Task SeedAsync(FeirbDbContext db, ILogger logger)
+    private const string _imapPasswordPurpose = "MailboxImapPassword";
+    private const string _smtpPasswordPurpose = "MailboxSmtpPassword";
+
+    public static async Task SeedAsync(FeirbDbContext db, ILogger logger, IDataProtectionProvider dataProtection)
     {
         ArgumentNullException.ThrowIfNull(db);
         ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(dataProtection);
 
         var seeded = false;
 
-        if (!await db.Users.AnyAsync(u => u.Email == "admin@feirb.local"))
-        {
-            db.Users.Add(new User
-            {
-                Id = Guid.NewGuid(),
-                Username = "admin",
-                Email = "admin@feirb.local",
-                PasswordHash = BCrypt.Net.BCrypt.HashPassword("admin"),
-                IsAdmin = true,
-                CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow,
-            });
-            seeded = true;
-            logger.LogInformation("Seeded admin user admin@feirb.local");
-        }
+        var adminUser = await SeedUserAsync(db, logger, "admin", "admin@feirb.local", "admin@feirb.local", isAdmin: true);
+        seeded |= adminUser.created;
+
+        var aliceUser = await SeedUserAsync(db, logger, "alice", "alice@feirb.local", "alice@feirb.local", isAdmin: false);
+        seeded |= aliceUser.created;
+
+        seeded |= await SeedMailboxAsync(db, logger, dataProtection, adminUser.user, "#4A90D9");
+        seeded |= await SeedMailboxAsync(db, logger, dataProtection, aliceUser.user, "#E67E22");
 
         if (!await db.SmtpSettings.AnyAsync())
         {
@@ -34,7 +32,7 @@ internal static class DatabaseSeeder
             {
                 Id = Guid.NewGuid(),
                 Host = "localhost",
-                Port = 1025,
+                Port = 3025,
                 UseTls = false,
                 RequiresAuth = false,
                 FromAddress = "noreply@feirb.local",
@@ -42,10 +40,67 @@ internal static class DatabaseSeeder
                 UpdatedAt = DateTime.UtcNow,
             });
             seeded = true;
-            logger.LogInformation("Seeded system SMTP settings for Mailpit");
+            logger.LogInformation("Seeded system SMTP settings for GreenMail");
         }
 
         if (seeded)
             await db.SaveChangesAsync();
+    }
+
+    private static async Task<(User user, bool created)> SeedUserAsync(
+        FeirbDbContext db, ILogger logger, string username, string email, string password, bool isAdmin)
+    {
+        var existing = await db.Users.FirstOrDefaultAsync(u => u.Email == email);
+        if (existing is not null)
+            return (existing, false);
+
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Username = username,
+            Email = email,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword(password),
+            IsAdmin = isAdmin,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.Users.Add(user);
+        logger.LogInformation("Seeded user {Email}", email);
+        return (user, true);
+    }
+
+    private static async Task<bool> SeedMailboxAsync(
+        FeirbDbContext db, ILogger logger, IDataProtectionProvider dataProtection,
+        User user, string badgeColor)
+    {
+        if (await db.Mailboxes.AnyAsync(m => m.UserId == user.Id))
+            return false;
+
+        var imapProtector = dataProtection.CreateProtector(_imapPasswordPurpose);
+        var smtpProtector = dataProtection.CreateProtector(_smtpPasswordPurpose);
+
+        db.Mailboxes.Add(new Mailbox
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            Name = user.Email,
+            EmailAddress = user.Email,
+            DisplayName = user.Username[0..1].ToUpperInvariant() + user.Username[1..],
+            ImapHost = "localhost",
+            ImapPort = 3143,
+            ImapUsername = user.Email,
+            ImapEncryptedPassword = imapProtector.Protect(user.Email),
+            ImapUseTls = false,
+            SmtpHost = "localhost",
+            SmtpPort = 3025,
+            SmtpUsername = user.Email,
+            SmtpEncryptedPassword = smtpProtector.Protect(user.Email),
+            SmtpUseTls = false,
+            SmtpRequiresAuth = false,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        logger.LogInformation("Seeded mailbox for {Email}", user.Email);
+        return true;
     }
 }

--- a/src/Feirb.Api/Endpoints/MailTestEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/MailTestEndpoints.cs
@@ -23,7 +23,8 @@ public static class MailTestEndpoints
 
             try
             {
-                await client.ConnectAsync(request.Host, request.Port, request.UseTls);
+                var tlsOptions = request.UseTls ? SecureSocketOptions.SslOnConnect : SecureSocketOptions.None;
+                await client.ConnectAsync(request.Host, request.Port, tlsOptions);
             }
             catch (Exception ex) when (ex is SocketException or IOException)
             {
@@ -61,7 +62,8 @@ public static class MailTestEndpoints
 
             try
             {
-                await client.ConnectAsync(request.Host, request.Port, request.UseTls);
+                var tlsOptions = request.UseTls ? SecureSocketOptions.SslOnConnect : SecureSocketOptions.None;
+                await client.ConnectAsync(request.Host, request.Port, tlsOptions);
             }
             catch (Exception ex) when (ex is SocketException or IOException)
             {

--- a/src/Feirb.Api/Program.cs
+++ b/src/Feirb.Api/Program.cs
@@ -89,7 +89,8 @@ using (var scope = app.Services.CreateScope())
     if (string.Equals(app.Configuration["FEIRB_SEED_DATA"], "true", StringComparison.OrdinalIgnoreCase))
     {
         var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("DatabaseSeeder");
-        await DatabaseSeeder.SeedAsync(db, logger);
+        var dataProtection = scope.ServiceProvider.GetRequiredService<IDataProtectionProvider>();
+        await DatabaseSeeder.SeedAsync(db, logger, dataProtection);
     }
 }
 

--- a/src/Feirb.AppHost/AppHost.cs
+++ b/src/Feirb.AppHost/AppHost.cs
@@ -9,12 +9,36 @@ var ollama = builder.AddOllama("feirb-ollama")
     .WithDataVolume()
     .AddModel("qwen3:4b");
 
-var mailpit = builder.AddMailPit("feirb-mailpit", httpPort: 8025, smtpPort: 1025);
+var greenmail = builder.AddContainer("feirb-greenmail", "docker.io/greenmail/standalone")
+    .WithHttpEndpoint(port: 8080, targetPort: 8080, name: "api")
+    .WithEndpoint("smtp", endpoint =>
+    {
+        endpoint.Port = 3025;
+        endpoint.TargetPort = 3025;
+        endpoint.Protocol = System.Net.Sockets.ProtocolType.Tcp;
+        endpoint.Transport = "tcp";
+        endpoint.IsProxied = false;
+    })
+    .WithEndpoint("imap", endpoint =>
+    {
+        endpoint.Port = 3143;
+        endpoint.TargetPort = 3143;
+        endpoint.Protocol = System.Net.Sockets.ProtocolType.Tcp;
+        endpoint.Transport = "tcp";
+        endpoint.IsProxied = false;
+    })
+    .WithBindMount("../../seeding/mails", "/preload", isReadOnly: true)
+    .WithEnvironment("GREENMAIL_OPTS",
+        "-Dgreenmail.preload.dir=/preload " +
+        "-Dgreenmail.setup.test.all " +
+        "-Dgreenmail.hostname=0.0.0.0 " +
+        "-Dgreenmail.api.port=8080 " +
+        "-Dgreenmail.api.hostname=0.0.0.0");
 
 builder.AddProject<Projects.Feirb_Api>("api")
     .WithReference(postgres)
     .WithReference(ollama)
-    .WithReference(mailpit)
-    .WaitFor(postgres);
+    .WaitFor(postgres)
+    .WaitFor(greenmail);
 
 builder.Build().Run();

--- a/src/Feirb.AppHost/Feirb.AppHost.csproj
+++ b/src/Feirb.AppHost/Feirb.AppHost.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.1.3" />
-    <PackageReference Include="CommunityToolkit.Aspire.Hosting.MailPit" Version="13.1.1" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.1.1" />
   </ItemGroup>
 

--- a/tests/Feirb.Api.Tests/Data/DatabaseSeederTests.cs
+++ b/tests/Feirb.Api.Tests/Data/DatabaseSeederTests.cs
@@ -1,6 +1,7 @@
 using Feirb.Api.Data;
 using Feirb.Api.Data.Entities;
 using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -21,29 +22,51 @@ public class DatabaseSeederTests
     private static ILogger CreateLogger() =>
         LoggerFactory.Create(_ => { }).CreateLogger("DatabaseSeeder");
 
+    private static IDataProtectionProvider CreateDataProtection() =>
+        DataProtectionProvider.Create("Tests");
+
     [Fact]
-    public async Task SeedAsync_EmptyDatabase_CreatesAdminUserAndSmtpSettingsAsync()
+    public async Task SeedAsync_EmptyDatabase_CreatesUsersMailboxesAndSmtpSettingsAsync()
     {
         using var db = CreateInMemoryContext();
 
-        await DatabaseSeeder.SeedAsync(db, CreateLogger());
+        await DatabaseSeeder.SeedAsync(db, CreateLogger(), CreateDataProtection());
 
-        var user = await db.Users.SingleAsync();
-        user.Email.Should().Be("admin@feirb.local");
-        user.Username.Should().Be("admin");
-        user.IsAdmin.Should().BeTrue();
-        BCrypt.Net.BCrypt.Verify("admin", user.PasswordHash).Should().BeTrue();
+        var users = await db.Users.OrderBy(u => u.Username).ToListAsync();
+        users.Should().HaveCount(2);
+
+        users[0].Email.Should().Be("admin@feirb.local");
+        users[0].Username.Should().Be("admin");
+        users[0].IsAdmin.Should().BeTrue();
+        BCrypt.Net.BCrypt.Verify("admin@feirb.local", users[0].PasswordHash).Should().BeTrue();
+
+        users[1].Email.Should().Be("alice@feirb.local");
+        users[1].Username.Should().Be("alice");
+        users[1].IsAdmin.Should().BeFalse();
+        BCrypt.Net.BCrypt.Verify("alice@feirb.local", users[1].PasswordHash).Should().BeTrue();
+
+        var mailboxes = await db.Mailboxes.OrderBy(m => m.Name).ToListAsync();
+        mailboxes.Should().HaveCount(2);
+        mailboxes[0].EmailAddress.Should().Be("admin@feirb.local");
+        mailboxes[0].ImapHost.Should().Be("localhost");
+        mailboxes[0].ImapPort.Should().Be(3143);
+        mailboxes[0].ImapUseTls.Should().BeFalse();
+        mailboxes[0].SmtpHost.Should().Be("localhost");
+        mailboxes[0].SmtpPort.Should().Be(3025);
+        mailboxes[0].ImapEncryptedPassword.Should().NotBeNullOrEmpty();
+
+        mailboxes[1].EmailAddress.Should().Be("alice@feirb.local");
 
         var smtp = await db.SmtpSettings.SingleAsync();
         smtp.Host.Should().Be("localhost");
-        smtp.Port.Should().Be(1025);
+        smtp.Port.Should().Be(3025);
         smtp.UseTls.Should().BeFalse();
         smtp.RequiresAuth.Should().BeFalse();
         smtp.FromAddress.Should().Be("noreply@feirb.local");
     }
 
     [Fact]
-    public async Task SeedAsync_AdminAlreadyExists_DoesNotCreateDuplicateAsync()
+    public async Task SeedAsync_UsersAlreadyExist_DoesNotCreateDuplicatesAsync()
     {
         using var db = CreateInMemoryContext();
         db.Users.Add(new User
@@ -56,12 +79,22 @@ public class DatabaseSeederTests
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow,
         });
+        db.Users.Add(new User
+        {
+            Id = Guid.NewGuid(),
+            Username = "alice",
+            Email = "alice@feirb.local",
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("existing"),
+            IsAdmin = false,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
         await db.SaveChangesAsync();
 
-        await DatabaseSeeder.SeedAsync(db, CreateLogger());
+        await DatabaseSeeder.SeedAsync(db, CreateLogger(), CreateDataProtection());
 
         var users = await db.Users.ToListAsync();
-        users.Should().HaveCount(1);
+        users.Should().HaveCount(2);
     }
 
     [Fact]
@@ -78,7 +111,7 @@ public class DatabaseSeederTests
         });
         await db.SaveChangesAsync();
 
-        await DatabaseSeeder.SeedAsync(db, CreateLogger());
+        await DatabaseSeeder.SeedAsync(db, CreateLogger(), CreateDataProtection());
 
         var settings = await db.SmtpSettings.ToListAsync();
         settings.Should().HaveCount(1);
@@ -89,11 +122,29 @@ public class DatabaseSeederTests
     public async Task SeedAsync_CalledTwice_IsIdempotentAsync()
     {
         using var db = CreateInMemoryContext();
+        var dp = CreateDataProtection();
 
-        await DatabaseSeeder.SeedAsync(db, CreateLogger());
-        await DatabaseSeeder.SeedAsync(db, CreateLogger());
+        await DatabaseSeeder.SeedAsync(db, CreateLogger(), dp);
+        await DatabaseSeeder.SeedAsync(db, CreateLogger(), dp);
 
-        (await db.Users.CountAsync()).Should().Be(1);
+        (await db.Users.CountAsync()).Should().Be(2);
+        (await db.Mailboxes.CountAsync()).Should().Be(2);
         (await db.SmtpSettings.CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SeedAsync_MailboxAlreadyExists_DoesNotCreateDuplicateAsync()
+    {
+        using var db = CreateInMemoryContext();
+        var dp = CreateDataProtection();
+
+        // First seed creates everything
+        await DatabaseSeeder.SeedAsync(db, CreateLogger(), dp);
+
+        // Second seed should not duplicate mailboxes
+        await DatabaseSeeder.SeedAsync(db, CreateLogger(), dp);
+
+        var mailboxes = await db.Mailboxes.ToListAsync();
+        mailboxes.Should().HaveCount(2);
     }
 }


### PR DESCRIPTION
## Summary

- **Replace Mailpit with GreenMail** (`greenmail/standalone`) as the single development mail server, providing SMTP (3025), IMAP (3143), and REST API / OpenAPI UI (8080) in one container
- **Seed 30 preloaded .eml files** (10 each for admin, alice, bob) mounted read-only into GreenMail for instant inbox content on startup
- **Seed alice user + mailboxes** for both admin and alice with encrypted IMAP/SMTP credentials (Data Protection API), system SMTP pointing to GreenMail
- **Fix MailKit TLS handling** — use `SecureSocketOptions.None` instead of `Auto` when TLS is disabled, preventing failed STARTTLS attempts against plain-text servers
- **Update all documentation** — CLAUDE.md, README, SETUP, ARCHITECTURE, DEPLOYMENT, aspire-run skill

## Acceptance Criteria

- [x] Mailpit fully removed (container, NuGet package, all references)
- [x] GreenMail container starts via Aspire with SMTP, IMAP, and API ports
- [x] OpenAPI UI accessible at port 8080 from Aspire dashboard
- [x] 30 preloaded `.eml` files loaded into GreenMail on startup
- [x] DB seeder creates admin + alice users with mailbox entities pointing to GreenMail
- [x] System SMTP settings point to GreenMail
- [x] Bob's mail exists in GreenMail but not accessible in Feirb (no account)
- [x] Credentials stored encrypted via Data Protection API
- [x] All documentation updated

## Test plan

- [x] `dotnet build` — no errors
- [x] `dotnet test` — 97 tests pass
- [x] `dotnet format --verify-no-changes` — clean
- [x] Manual test: GreenMail REST API lists all 3 users
- [x] Manual test: IMAP/SMTP connection without TLS succeeds

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)