### PR TITLE
fix(api): avoid decoding attachments in EstimateAttachmentSize

### DIFF
--- a/src/Feirb.Api/Services/ImapSyncService.cs
+++ b/src/Feirb.Api/Services/ImapSyncService.cs
@@ -181,19 +181,18 @@ public class ImapSyncService(
                 {
                     Id = Guid.NewGuid(),
                     Filename = a is MimePart part ? part.FileName ?? "unnamed" : "unnamed",
-                    Size = EstimateAttachmentSize(a),
+                    Size = a is MimePart mp ? EstimateAttachmentSize(mp) : 0,
                     MimeType = a.ContentType.MimeType,
                 })
                 .ToList(),
         };
 
-    private static long EstimateAttachmentSize(MimeEntity attachment)
+    private static long EstimateAttachmentSize(MimePart part)
     {
-        if (attachment is not MimePart part || part.Content is null)
-            return 0;
+        var stream = part.Content?.Stream;
+        if (stream is { CanSeek: true })
+            return stream.Length;
 
-        using var stream = new MemoryStream();
-        part.Content.DecodeTo(stream);
-        return stream.Length;
+        return 0;
     }
 }


### PR DESCRIPTION
## Summary
- Read `MimePart.Content.Stream.Length` directly instead of decoding the full attachment content into a `MemoryStream`
- Falls back to `0` when the stream is not seekable
- Moves `MimePart` type check to the caller for cleaner separation

Closes #75

## Test plan
- [x] All 107 existing tests pass
- [x] `dotnet format --verify-no-changes` clean
- [ ] Manual sync with mailbox containing large attachments to verify sizes are still populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)