### PR TITLE
fix(web): add language selector to login and setup pages

### DIFF
--- a/src/Feirb.Web/Layout/AuthLayout.razor
+++ b/src/Feirb.Web/Layout/AuthLayout.razor
@@ -1,6 +1,9 @@
 @inherits LayoutComponentBase
 
 <Feirb.Web.Components.ToastContainer />
-<div class="d-flex align-items-center justify-content-center" style="min-height: 100vh; background-color: #f8f9fa;">
+<div class="position-relative d-flex align-items-center justify-content-center" style="min-height: 100vh; background-color: #f8f9fa;">
+    <div class="position-absolute top-0 end-0 p-3">
+        <Feirb.Web.Components.LanguageSwitcher ButtonClass="btn-outline-secondary btn-sm" />
+    </div>
     @Body
 </div>


### PR DESCRIPTION
## Summary

- Add `LanguageSwitcher` component to `AuthLayout` so users can change the language on `/login` and `/setup` pages
- Positioned in the top-right corner, consistent with the sidebar placement in `MainLayout`

Closes #88

## Test plan

- [x] Language selector visible on `/login` page
- [x] Language selector visible on `/setup` page
- [x] Changing language reloads the page with the selected locale
- [x] All tests pass (156/156)

Generated with [Claude Code](https://claude.com/claude-code)