### PR TITLE
feat(test): Bruno API collection with full endpoint coverage

### DIFF
--- a/tests/bruno/01-auth/login-invalid-credentials.bru
+++ b/tests/bruno/01-auth/login-invalid-credentials.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Login - Invalid Credentials
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/auth/login
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "username": "admin",
+    "password": "wrong-password"
+  }
+}
+
+tests {
+  test("should return 401", function() {
+    expect(res.status).to.equal(401);
+  });
+}

--- a/tests/bruno/01-auth/login.bru
+++ b/tests/bruno/01-auth/login.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Login
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/auth/login
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "username": "{{adminUsername}}",
+    "password": "{{adminPassword}}"
+  }
+}
+
+script:post-response {
+  if (res.status === 200) {
+    bru.setVar("accessToken", res.body.accessToken);
+    bru.setVar("refreshToken", res.body.refreshToken);
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return access token", function() {
+    expect(res.body.accessToken).to.be.a("string");
+  });
+
+  test("should return refresh token", function() {
+    expect(res.body.refreshToken).to.be.a("string");
+  });
+
+  test("should return expiry", function() {
+    expect(res.body.expiresAt).to.be.a("string");
+  });
+}

--- a/tests/bruno/01-auth/refresh-invalid-token.bru
+++ b/tests/bruno/01-auth/refresh-invalid-token.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Refresh - Invalid Token
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/api/auth/refresh
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "refreshToken": "invalid-refresh-token"
+  }
+}
+
+tests {
+  test("should return 401", function() {
+    expect(res.status).to.equal(401);
+  });
+}

--- a/tests/bruno/01-auth/refresh.bru
+++ b/tests/bruno/01-auth/refresh.bru
@@ -1,0 +1,38 @@
+meta {
+  name: Refresh Token
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/api/auth/refresh
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "refreshToken": "{{refreshToken}}"
+  }
+}
+
+script:post-response {
+  if (res.status === 200) {
+    bru.setVar("accessToken", res.body.accessToken);
+    bru.setVar("refreshToken", res.body.refreshToken);
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return new access token", function() {
+    expect(res.body.accessToken).to.be.a("string");
+  });
+
+  test("should return new refresh token", function() {
+    expect(res.body.refreshToken).to.be.a("string");
+  });
+}

--- a/tests/bruno/01-auth/register-validation-error.bru
+++ b/tests/bruno/01-auth/register-validation-error.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Register - Duplicate Username
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/api/auth/register
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "username": "admin",
+    "email": "duplicate-test@feirb.local",
+    "password": "Test123!"
+  }
+}
+
+tests {
+  test("should return 409 conflict", function() {
+    expect(res.status).to.equal(409);
+  });
+
+  test("should return error message", function() {
+    expect(res.body.message).to.be.a("string");
+  });
+}

--- a/tests/bruno/01-auth/register.bru
+++ b/tests/bruno/01-auth/register.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Register
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/auth/register
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "username": "brunotest",
+    "email": "brunotest@feirb.local",
+    "password": "brunotest@feirb.local"
+  }
+}
+
+script:post-response {
+  if (res.status === 201) {
+    bru.setVar("registeredUserId", res.body.id);
+  }
+}
+
+tests {
+  test("should return 201 or 409 (idempotent)", function() {
+    expect([201, 409]).to.include(res.status);
+  });
+
+  test("should return user data on success", function() {
+    if (res.status === 201) {
+      expect(res.body.username).to.equal("brunotest");
+      expect(res.body.email).to.equal("brunotest@feirb.local");
+      expect(res.body.id).to.be.a("string");
+    }
+  });
+}

--- a/tests/bruno/01-auth/request-reset-unknown-email.bru
+++ b/tests/bruno/01-auth/request-reset-unknown-email.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Request Reset - Unknown Email
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/api/auth/request-reset
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "email": "nonexistent@feirb.local"
+  }
+}
+
+tests {
+  test("should return 200 (does not reveal existence)", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return message", function() {
+    expect(res.body.message).to.be.a("string");
+  });
+}

--- a/tests/bruno/01-auth/request-reset.bru
+++ b/tests/bruno/01-auth/request-reset.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Request Password Reset
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/api/auth/request-reset
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "email": "admin@feirb.local"
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return message", function() {
+    expect(res.body.message).to.be.a("string");
+  });
+}

--- a/tests/bruno/01-auth/validate-reset-token-invalid.bru
+++ b/tests/bruno/01-auth/validate-reset-token-invalid.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Validate Reset Token - Invalid
+  type: http
+  seq: 9
+}
+
+get {
+  url: {{baseUrl}}/api/auth/validate-reset-token/invalid-token-value
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 404", function() {
+    expect(res.status).to.equal(404);
+  });
+}

--- a/tests/bruno/02-setup/complete-setup-already-done.bru
+++ b/tests/bruno/02-setup/complete-setup-already-done.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Complete Setup - Already Done
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/setup/complete
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "username": "newadmin",
+    "email": "newadmin@feirb.local",
+    "password": "Test123!",
+    "smtpHost": "localhost",
+    "smtpPort": 3025,
+    "smtpUseTls": false,
+    "smtpRequiresAuth": false
+  }
+}
+
+tests {
+  test("should return 409 (setup already complete)", function() {
+    expect(res.status).to.equal(409);
+  });
+
+  test("should return error message", function() {
+    expect(res.body.message).to.be.a("string");
+  });
+}

--- a/tests/bruno/02-setup/get-status.bru
+++ b/tests/bruno/02-setup/get-status.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Get Setup Status
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/setup/status
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return isComplete boolean", function() {
+    expect(res.body.isComplete).to.be.a("boolean");
+  });
+
+  test("should be complete (seeded database)", function() {
+    expect(res.body.isComplete).to.equal(true);
+  });
+}

--- a/tests/bruno/02-setup/test-smtp.bru
+++ b/tests/bruno/02-setup/test-smtp.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Test SMTP Connection
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/setup/test-smtp
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "host": "localhost",
+    "port": 3025,
+    "useTls": false,
+    "requiresAuth": false
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return success", function() {
+    expect(res.body.success).to.equal(true);
+  });
+}

--- a/tests/bruno/03-admin-users/cleanup-test-users.bru
+++ b/tests/bruno/03-admin-users/cleanup-test-users.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Cleanup Test Users
+  type: http
+  seq: 0
+}
+
+get {
+  url: {{baseUrl}}/api/admin/users
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+script:post-response {
+  if (res.status === 200) {
+    const testUsernames = ["brunotest", "bruno-testuser"];
+    const testUsers = res.body.filter(u => testUsernames.includes(u.username));
+    const baseUrl = bru.getEnvVar("baseUrl") || bru.getVar("baseUrl");
+    const token = bru.getVar("accessToken");
+
+    for (const user of testUsers) {
+      try {
+        await axios.delete(baseUrl + "/api/admin/users/" + user.id, {
+          headers: { "Authorization": "Bearer " + token }
+        });
+      } catch (e) {
+        // Ignore cleanup errors
+      }
+    }
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/tests/bruno/03-admin-users/create-user.bru
+++ b/tests/bruno/03-admin-users/create-user.bru
@@ -1,0 +1,44 @@
+meta {
+  name: Create User
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/admin/users
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+body:json {
+  {
+    "username": "bruno-testuser",
+    "email": "bruno-testuser@feirb.local",
+    "password": "bruno-testuser@feirb.local",
+    "isAdmin": false
+  }
+}
+
+script:post-response {
+  if (res.status === 201) {
+    bru.setVar("testUserId", res.body.id);
+  }
+}
+
+tests {
+  test("should return 201 or 409 (idempotent)", function() {
+    expect([201, 409]).to.include(res.status);
+  });
+
+  test("should return user data on success", function() {
+    if (res.status === 201) {
+      expect(res.body.username).to.equal("bruno-testuser");
+      expect(res.body.email).to.equal("bruno-testuser@feirb.local");
+      expect(res.body.isAdmin).to.equal(false);
+    }
+  });
+}

--- a/tests/bruno/03-admin-users/delete-user-not-found.bru
+++ b/tests/bruno/03-admin-users/delete-user-not-found.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Delete User - Not Found
+  type: http
+  seq: 7
+}
+
+delete {
+  url: {{baseUrl}}/api/admin/users/00000000-0000-0000-0000-000000000000
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+tests {
+  test("should return 404", function() {
+    expect(res.status).to.equal(404);
+  });
+}

--- a/tests/bruno/03-admin-users/delete-user.bru
+++ b/tests/bruno/03-admin-users/delete-user.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Delete User
+  type: http
+  seq: 6
+}
+
+delete {
+  url: {{baseUrl}}/api/admin/users/{{testUserId}}
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return confirmation message", function() {
+    expect(res.body.message).to.be.a("string");
+  });
+}

--- a/tests/bruno/03-admin-users/list-users-unauthorized.bru
+++ b/tests/bruno/03-admin-users/list-users-unauthorized.bru
@@ -1,0 +1,17 @@
+meta {
+  name: List Users - Unauthorized
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/admin/users
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 401", function() {
+    expect(res.status).to.equal(401);
+  });
+}

--- a/tests/bruno/03-admin-users/list-users.bru
+++ b/tests/bruno/03-admin-users/list-users.bru
@@ -1,0 +1,34 @@
+meta {
+  name: List Users
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/admin/users
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return array of users", function() {
+    expect(res.body).to.be.an("array");
+    expect(res.body.length).to.be.greaterThan(0);
+  });
+
+  test("should include user details", function() {
+    const user = res.body[0];
+    expect(user.id).to.be.a("string");
+    expect(user.username).to.be.a("string");
+    expect(user.email).to.be.a("string");
+    expect(user).to.have.property("isAdmin");
+  });
+}

--- a/tests/bruno/03-admin-users/reset-user-password.bru
+++ b/tests/bruno/03-admin-users/reset-user-password.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Reset User Password
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/api/admin/users/{{testUserId}}/reset-password
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return reset token", function() {
+    expect(res.body.resetToken).to.be.a("string");
+  });
+
+  test("should return reset link", function() {
+    expect(res.body.resetLink).to.be.a("string");
+  });
+}

--- a/tests/bruno/03-admin-users/update-user.bru
+++ b/tests/bruno/03-admin-users/update-user.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Update User
+  type: http
+  seq: 4
+}
+
+put {
+  url: {{baseUrl}}/api/admin/users/{{testUserId}}
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+body:json {
+  {
+    "email": "bruno-testuser-updated@feirb.local",
+    "isAdmin": false
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return updated email", function() {
+    expect(res.body.email).to.equal("bruno-testuser-updated@feirb.local");
+  });
+}

--- a/tests/bruno/04-admin-settings/get-smtp-settings.bru
+++ b/tests/bruno/04-admin-settings/get-smtp-settings.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Get SMTP Settings
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/admin/system-settings/smtp
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return SMTP settings", function() {
+    expect(res.body.host).to.be.a("string");
+    expect(res.body.port).to.be.a("number");
+    expect(res.body).to.have.property("useTls");
+    expect(res.body).to.have.property("requiresAuth");
+  });
+}

--- a/tests/bruno/04-admin-settings/update-smtp-settings.bru
+++ b/tests/bruno/04-admin-settings/update-smtp-settings.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Update SMTP Settings
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{baseUrl}}/api/admin/system-settings/smtp
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+body:json {
+  {
+    "host": "localhost",
+    "port": 3025,
+    "useTls": false,
+    "requiresAuth": false,
+    "fromAddress": "noreply@feirb.local",
+    "fromName": "Feirb"
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return updated settings", function() {
+    expect(res.body.host).to.equal("localhost");
+    expect(res.body.port).to.equal(3025);
+  });
+}

--- a/tests/bruno/05-mail/get-message-not-found.bru
+++ b/tests/bruno/05-mail/get-message-not-found.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get Message - Not Found
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/mail/messages/00000000-0000-0000-0000-000000000000
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+tests {
+  test("should return 404", function() {
+    expect(res.status).to.equal(404);
+  });
+}

--- a/tests/bruno/05-mail/list-messages-unauthorized.bru
+++ b/tests/bruno/05-mail/list-messages-unauthorized.bru
@@ -1,0 +1,17 @@
+meta {
+  name: List Messages - Unauthorized
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/api/mail/messages
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 401", function() {
+    expect(res.status).to.equal(401);
+  });
+}

--- a/tests/bruno/05-mail/list-messages.bru
+++ b/tests/bruno/05-mail/list-messages.bru
@@ -1,0 +1,29 @@
+meta {
+  name: List Messages
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/mail/messages?page=1&pageSize=25
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return paginated response", function() {
+    expect(res.body).to.have.property("items");
+    expect(res.body).to.have.property("page");
+    expect(res.body).to.have.property("pageSize");
+    expect(res.body).to.have.property("totalCount");
+    expect(res.body.items).to.be.an("array");
+  });
+}

--- a/tests/bruno/05-mail/test-imap.bru
+++ b/tests/bruno/05-mail/test-imap.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Test IMAP Connection
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/mail/test/imap
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+body:json {
+  {
+    "host": "localhost",
+    "port": 3143,
+    "username": "admin@feirb.local",
+    "password": "admin@feirb.local",
+    "useTls": false
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return success", function() {
+    expect(res.body.success).to.equal(true);
+  });
+}

--- a/tests/bruno/05-mail/test-smtp.bru
+++ b/tests/bruno/05-mail/test-smtp.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Test SMTP Connection
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/api/mail/test/smtp
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+body:json {
+  {
+    "host": "localhost",
+    "port": 3025,
+    "useTls": false,
+    "requiresAuth": false
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return success", function() {
+    expect(res.body.success).to.equal(true);
+  });
+}

--- a/tests/bruno/06-settings-mailboxes/create-mailbox.bru
+++ b/tests/bruno/06-settings-mailboxes/create-mailbox.bru
@@ -1,0 +1,52 @@
+meta {
+  name: Create Mailbox
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/settings/mailboxes
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+body:json {
+  {
+    "name": "Bruno Test Mailbox",
+    "emailAddress": "brunotest-mailbox@feirb.local",
+    "displayName": "Bruno Test",
+    "imapHost": "localhost",
+    "imapPort": 3143,
+    "imapUsername": "brunotest-mailbox@feirb.local",
+    "imapPassword": "brunotest-mailbox@feirb.local",
+    "imapUseTls": false,
+    "smtpHost": "localhost",
+    "smtpPort": 3025,
+    "smtpUsername": "brunotest-mailbox@feirb.local",
+    "smtpPassword": "brunotest-mailbox@feirb.local",
+    "smtpUseTls": false,
+    "smtpRequiresAuth": false
+  }
+}
+
+script:post-response {
+  if (res.status === 201) {
+    bru.setVar("testMailboxId", res.body.id);
+  }
+}
+
+tests {
+  test("should return 201", function() {
+    expect(res.status).to.equal(201);
+  });
+
+  test("should return mailbox data", function() {
+    expect(res.body.name).to.equal("Bruno Test Mailbox");
+    expect(res.body.emailAddress).to.equal("brunotest-mailbox@feirb.local");
+    expect(res.body.id).to.be.a("string");
+  });
+}

--- a/tests/bruno/06-settings-mailboxes/delete-mailbox.bru
+++ b/tests/bruno/06-settings-mailboxes/delete-mailbox.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Delete Mailbox
+  type: http
+  seq: 5
+}
+
+delete {
+  url: {{baseUrl}}/api/settings/mailboxes/{{testMailboxId}}
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return confirmation message", function() {
+    expect(res.body.message).to.be.a("string");
+  });
+}

--- a/tests/bruno/06-settings-mailboxes/get-mailbox-not-found.bru
+++ b/tests/bruno/06-settings-mailboxes/get-mailbox-not-found.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get Mailbox - Not Found
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/api/settings/mailboxes/00000000-0000-0000-0000-000000000000
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+tests {
+  test("should return 404", function() {
+    expect(res.status).to.equal(404);
+  });
+}

--- a/tests/bruno/06-settings-mailboxes/get-mailbox.bru
+++ b/tests/bruno/06-settings-mailboxes/get-mailbox.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Get Mailbox
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/settings/mailboxes/{{testMailboxId}}
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return mailbox details", function() {
+    expect(res.body.id).to.equal(bru.getVar("testMailboxId"));
+    expect(res.body.name).to.be.a("string");
+    expect(res.body.emailAddress).to.be.a("string");
+    expect(res.body.imapHost).to.be.a("string");
+    expect(res.body.smtpHost).to.be.a("string");
+  });
+}

--- a/tests/bruno/06-settings-mailboxes/list-mailboxes-unauthorized.bru
+++ b/tests/bruno/06-settings-mailboxes/list-mailboxes-unauthorized.bru
@@ -1,0 +1,17 @@
+meta {
+  name: List Mailboxes - Unauthorized
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{baseUrl}}/api/settings/mailboxes
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 401", function() {
+    expect(res.status).to.equal(401);
+  });
+}

--- a/tests/bruno/06-settings-mailboxes/list-mailboxes.bru
+++ b/tests/bruno/06-settings-mailboxes/list-mailboxes.bru
@@ -1,0 +1,33 @@
+meta {
+  name: List Mailboxes
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/settings/mailboxes
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return array of mailboxes", function() {
+    expect(res.body).to.be.an("array");
+  });
+
+  test("should include seeded mailbox", function() {
+    expect(res.body.length).to.be.greaterThan(0);
+    const mailbox = res.body[0];
+    expect(mailbox.id).to.be.a("string");
+    expect(mailbox.name).to.be.a("string");
+    expect(mailbox.emailAddress).to.be.a("string");
+  });
+}

--- a/tests/bruno/06-settings-mailboxes/update-mailbox.bru
+++ b/tests/bruno/06-settings-mailboxes/update-mailbox.bru
@@ -1,0 +1,44 @@
+meta {
+  name: Update Mailbox
+  type: http
+  seq: 4
+}
+
+put {
+  url: {{baseUrl}}/api/settings/mailboxes/{{testMailboxId}}
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+body:json {
+  {
+    "name": "Bruno Test Mailbox Updated",
+    "emailAddress": "brunotest-mailbox@feirb.local",
+    "displayName": "Bruno Test Updated",
+    "imapHost": "localhost",
+    "imapPort": 3143,
+    "imapUsername": "brunotest-mailbox@feirb.local",
+    "imapPassword": "brunotest-mailbox@feirb.local",
+    "imapUseTls": false,
+    "smtpHost": "localhost",
+    "smtpPort": 3025,
+    "smtpUsername": "brunotest-mailbox@feirb.local",
+    "smtpPassword": "brunotest-mailbox@feirb.local",
+    "smtpUseTls": false,
+    "smtpRequiresAuth": false
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return updated name", function() {
+    expect(res.body.name).to.equal("Bruno Test Mailbox Updated");
+  });
+}

--- a/tests/bruno/07-settings-profile/change-password-wrong-current.bru
+++ b/tests/bruno/07-settings-profile/change-password-wrong-current.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Change Password - Wrong Current
+  type: http
+  seq: 3
+}
+
+put {
+  url: {{baseUrl}}/api/settings/profile/password
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+body:json {
+  {
+    "currentPassword": "wrong-password",
+    "newPassword": "NewPassword123!"
+  }
+}
+
+tests {
+  test("should return 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("should return error message", function() {
+    expect(res.body.message).to.be.a("string");
+  });
+}

--- a/tests/bruno/07-settings-profile/change-password.bru
+++ b/tests/bruno/07-settings-profile/change-password.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Change Password
+  type: http
+  seq: 5
+}
+
+put {
+  url: {{baseUrl}}/api/settings/profile/password
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+body:json {
+  {
+    "currentPassword": "{{adminPassword}}",
+    "newPassword": "{{adminPassword}}"
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return confirmation message", function() {
+    expect(res.body.message).to.be.a("string");
+  });
+}

--- a/tests/bruno/07-settings-profile/get-profile-unauthorized.bru
+++ b/tests/bruno/07-settings-profile/get-profile-unauthorized.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Get Profile - Unauthorized
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/settings/profile
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 401", function() {
+    expect(res.status).to.equal(401);
+  });
+}

--- a/tests/bruno/07-settings-profile/get-profile.bru
+++ b/tests/bruno/07-settings-profile/get-profile.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Profile
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/settings/profile
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return profile data", function() {
+    expect(res.body.username).to.be.a("string");
+    expect(res.body.email).to.be.a("string");
+  });
+}

--- a/tests/bruno/07-settings-profile/logout-all.bru
+++ b/tests/bruno/07-settings-profile/logout-all.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Logout All Sessions
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/api/settings/profile/logout-all
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return confirmation message", function() {
+    expect(res.body.message).to.be.a("string");
+  });
+}

--- a/tests/bruno/07-settings-profile/re-login.bru
+++ b/tests/bruno/07-settings-profile/re-login.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Re-Login After Password Change
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/api/auth/login
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "username": "{{adminUsername}}",
+    "password": "{{adminPassword}}"
+  }
+}
+
+script:post-response {
+  if (res.status === 200) {
+    bru.setVar("accessToken", res.body.accessToken);
+    bru.setVar("refreshToken", res.body.refreshToken);
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return new access token", function() {
+    expect(res.body.accessToken).to.be.a("string");
+  });
+}

--- a/tests/bruno/07-settings-profile/update-profile.bru
+++ b/tests/bruno/07-settings-profile/update-profile.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Update Profile
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{baseUrl}}/api/settings/profile
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+body:json {
+  {
+    "username": "admin",
+    "email": "admin@feirb.local"
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return updated profile", function() {
+    expect(res.body.username).to.equal("admin");
+    expect(res.body.email).to.equal("admin@feirb.local");
+  });
+}

--- a/tests/bruno/bruno.json
+++ b/tests/bruno/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "Feirb API",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/tests/bruno/collection.bru
+++ b/tests/bruno/collection.bru
@@ -1,0 +1,4 @@
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}

--- a/tests/bruno/environments/local.bru
+++ b/tests/bruno/environments/local.bru
@@ -1,0 +1,7 @@
+vars {
+  baseUrl: https://localhost:7272
+  adminUsername: admin
+  adminPassword: admin@feirb.local
+  aliceUsername: alice
+  alicePassword: alice@feirb.local
+}


### PR DESCRIPTION
## Summary

- Initialize Bruno collection in `tests/bruno/` with 35 requests covering all API endpoint groups
- Auth, setup, admin (users + system settings), mail, mailboxes, and profile endpoints tested
- Happy paths and error cases (401, 404, 409, 400) for each endpoint group
- Token fetched once via login and reused across all authenticated requests
- Tests are idempotent: cleanup step removes test users, create tests accept 201/409

## Test plan

- [x] `bru run --env local` passes against running Aspire stack
- [x] All API endpoints covered with at least one happy path test
- [x] Error cases covered (401, 404, validation errors)
- [x] Tests are idempotent (repeatable without DB reset)
- [x] Token fetched once and reused across all requests

Closes #95