### PR TITLE
Button Restyling: Pill-shape with Electric Iris colors

### DIFF
--- a/src/Feirb.Web/wwwroot/css/app.css
+++ b/src/Feirb.Web/wwwroot/css/app.css
@@ -48,7 +48,7 @@ a:hover, .btn-link:hover {
 
 /* Buttons */
 .btn {
-    border-radius: var(--feirb-radius-input);
+    border-radius: 9999px;
     font-weight: 500;
 }
 
@@ -72,6 +72,30 @@ a:hover, .btn-link:hover {
 .btn-outline-primary:hover {
     background-color: var(--bs-primary);
     color: #fff;
+}
+
+.btn-secondary {
+    color: #fff;
+    background-color: var(--feirb-on-surface);
+    border-color: var(--feirb-on-surface);
+}
+
+.btn-secondary:hover {
+    background-color: var(--feirb-surface-container);
+    border-color: var(--feirb-on-surface);
+    color: var(--feirb-on-surface);
+}
+
+.btn-outline-secondary {
+    color: var(--feirb-on-surface);
+    border-color: var(--feirb-on-surface);
+    background-color: transparent;
+}
+
+.btn-outline-secondary:hover {
+    background-color: var(--feirb-surface-container);
+    border-color: var(--feirb-on-surface);
+    color: var(--feirb-on-surface);
 }
 
 /* Cards */


### PR DESCRIPTION
## Summary

- All buttons now use `border-radius: 9999px` for pill-shaped design
- Added `.btn-secondary` and `.btn-outline-secondary` styles using Electric Iris `on_surface` / `surface_container` tokens
- Primary button styling was already correct from #102

Closes #103

## Test plan

- [x] Verify all buttons render as pill-shaped across the app
- [x] Check primary button has correct `#b6004f` background and white text
- [x] Check secondary/outline buttons use `on_surface` border and text
- [x] Verify hover states: primary darkens, secondary/outline gets `surface_container` background
- [x] Confirm widget edit-mode circle buttons are unaffected

Generated with [Claude Code](https://claude.com/claude-code)