### PR TITLE
Sidebar Redesign: Navigation styling and Compose placeholder

### DIFF
--- a/src/Feirb.Web/Components/Breadcrumb.razor
+++ b/src/Feirb.Web/Components/Breadcrumb.razor
@@ -92,6 +92,7 @@
             "mail/drafts" => L["BreadcrumbDrafts"],
             "mail/trash" => L["BreadcrumbTrash"],
             "mail/archive" => L["BreadcrumbArchive"],
+            "compose" => L["BreadcrumbCompose"],
             _ => segment
         };
 

--- a/src/Feirb.Web/Layout/NavMenu.razor
+++ b/src/Feirb.Web/Layout/NavMenu.razor
@@ -19,6 +19,14 @@
         </Authorized>
     </AuthorizeView>
 
+    <!-- Compose Button -->
+    <div class="sidebar-compose">
+        <NavLink class="btn btn-primary" href="compose">
+            <i class="bi bi-pencil-fill"></i>
+            <span>@L["NavCompose"]</span>
+        </NavLink>
+    </div>
+
     <!-- Navigation -->
     <nav class="sidebar-nav">
         <!-- Dashboard -->
@@ -55,12 +63,6 @@
                         <span>@L["NavDrafts"]</span>
                     </NavLink>
                 </li>
-            </ul>
-        </div>
-
-        <!-- Folders Section -->
-        <div class="nav-section">
-            <ul class="nav-list">
                 <li>
                     <NavLink class="nav-entry" href="mail/trash">
                         <i class="bi bi-trash"></i>
@@ -79,11 +81,6 @@
 
     <!-- Bottom Section -->
     <div class="sidebar-bottom">
-        <div class="sidebar-lang">
-            <i class="bi bi-translate"></i>
-            <Feirb.Web.Components.LanguageSwitcher ButtonClass="btn-outline-secondary btn-sm" />
-        </div>
-
         <ul class="nav-list">
             <li>
                 <NavLink class="nav-entry" href="settings">

--- a/src/Feirb.Web/Layout/NavMenu.razor.css
+++ b/src/Feirb.Web/Layout/NavMenu.razor.css
@@ -61,6 +61,20 @@
     text-overflow: ellipsis;
 }
 
+/* Compose Button */
+.sidebar-compose {
+    margin-bottom: 1.5rem;
+}
+
+::deep .sidebar-compose .btn {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+}
+
 /* Navigation */
 .sidebar-nav {
     flex: 1;
@@ -76,7 +90,7 @@
     font-size: 0.625rem;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: #6c757d;
+    color: var(--feirb-on-surface-variant);
     margin-bottom: 0.5rem;
     font-weight: 600;
 }
@@ -96,9 +110,9 @@
     align-items: center;
     gap: 0.75rem;
     padding: 0.5rem 0.75rem;
-    color: #6c757d;
+    color: var(--feirb-on-surface-variant);
     text-decoration: none;
-    border-radius: 0.5rem;
+    border-radius: 0;
     transition: all 0.15s ease;
     cursor: pointer;
     width: 100%;
@@ -115,7 +129,7 @@
 
 ::deep .nav-entry.active {
     color: var(--bs-primary);
-    background-color: rgba(var(--bs-primary-rgb), 0.06);
+    background-color: var(--feirb-navbar-select-background);
     border-right: 3px solid var(--bs-primary);
 }
 
@@ -130,15 +144,3 @@
     border-top: 1px solid rgba(0, 0, 0, 0.08);
 }
 
-.sidebar-lang {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    margin-bottom: 0.5rem;
-    color: #6c757d;
-}
-
-.sidebar-lang .bi {
-    font-size: 1.25rem;
-}

--- a/src/Feirb.Web/Pages/Compose.razor
+++ b/src/Feirb.Web/Pages/Compose.razor
@@ -1,0 +1,8 @@
+@page "/compose"
+@attribute [Authorize]
+@inject IStringLocalizer<SharedResources> L
+
+<PageTitle>@L["NavCompose"]</PageTitle>
+
+<h1>@L["NavCompose"]</h1>
+<p class="text-muted">@L["StubComingSoon"]</p>

--- a/src/Feirb.Web/Resources/SharedResources.de-DE.resx
+++ b/src/Feirb.Web/Resources/SharedResources.de-DE.resx
@@ -726,8 +726,14 @@
   <data name="BreadcrumbArchive" xml:space="preserve">
     <value>Archiv</value>
   </data>
+  <data name="BreadcrumbCompose" xml:space="preserve">
+    <value>Verfassen</value>
+  </data>
   <data name="NavDashboard" xml:space="preserve">
     <value>Dashboard</value>
+  </data>
+  <data name="NavCompose" xml:space="preserve">
+    <value>Verfassen</value>
   </data>
   <data name="PageTitleDashboard" xml:space="preserve">
     <value>Dashboard - Feirb</value>

--- a/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
+++ b/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
@@ -726,8 +726,14 @@
   <data name="BreadcrumbArchive" xml:space="preserve">
     <value>Archives</value>
   </data>
+  <data name="BreadcrumbCompose" xml:space="preserve">
+    <value>Composer</value>
+  </data>
   <data name="NavDashboard" xml:space="preserve">
     <value>Tableau de bord</value>
+  </data>
+  <data name="NavCompose" xml:space="preserve">
+    <value>Composer</value>
   </data>
   <data name="PageTitleDashboard" xml:space="preserve">
     <value>Tableau de bord - Feirb</value>

--- a/src/Feirb.Web/Resources/SharedResources.it-IT.resx
+++ b/src/Feirb.Web/Resources/SharedResources.it-IT.resx
@@ -726,8 +726,14 @@
   <data name="BreadcrumbArchive" xml:space="preserve">
     <value>Archivio</value>
   </data>
+  <data name="BreadcrumbCompose" xml:space="preserve">
+    <value>Componi</value>
+  </data>
   <data name="NavDashboard" xml:space="preserve">
     <value>Dashboard</value>
+  </data>
+  <data name="NavCompose" xml:space="preserve">
+    <value>Componi</value>
   </data>
   <data name="PageTitleDashboard" xml:space="preserve">
     <value>Dashboard - Feirb</value>

--- a/src/Feirb.Web/Resources/SharedResources.resx
+++ b/src/Feirb.Web/Resources/SharedResources.resx
@@ -726,8 +726,14 @@
   <data name="BreadcrumbArchive" xml:space="preserve">
     <value>Archive</value>
   </data>
+  <data name="BreadcrumbCompose" xml:space="preserve">
+    <value>Compose</value>
+  </data>
   <data name="NavDashboard" xml:space="preserve">
     <value>Dashboard</value>
+  </data>
+  <data name="NavCompose" xml:space="preserve">
+    <value>Compose</value>
   </data>
   <data name="PageTitleDashboard" xml:space="preserve">
     <value>Dashboard - Feirb</value>

--- a/src/Feirb.Web/wwwroot/css/app.css
+++ b/src/Feirb.Web/wwwroot/css/app.css
@@ -18,6 +18,7 @@
     --feirb-surface: #F4F5FB;
     --feirb-surface-container: #e8e5ff;
     --feirb-outline: #75748e;
+    --feirb-navbar-select-background: rgba(255, 113, 149, 0.15);
     --feirb-outline-variant: #acaac6;
     --feirb-error: #b31b25;
     --bs-border-radius: 1rem;


### PR DESCRIPTION
## Summary
- Redesign sidebar navigation to match Electric Iris design system: removed border-radius, updated active state with subtle pink background (`--feirb-navbar-select-background`) and right border
- Added Compose button placeholder (pill-shaped primary button) below user profile, linking to a new `/compose` coming-soon page
- Removed language selector from sidebar (to be moved to Settings page)
- Merged Folders section into Main section to eliminate visual gap
- Updated section label and nav entry colors to use `on_surface_variant` token
- Added i18n keys for Compose in all 4 locales (en, de, fr, it)

Closes #104

## Test plan
- [x] Active navigation state renders with subtle pink background and right border
- [x] Compose button is visible, spans full sidebar width, and links to /compose
- [x] Compose placeholder page shows "Coming Soon" message
- [x] Language selector no longer appears in sidebar
- [x] Section labels use correct `on_surface_variant` color
- [x] No visual gap between Drafts and Trash items

Generated with [Claude Code](https://claude.com/claude-code)