### PR TITLE
Widget styling and edit-mode controls overhaul

### DIFF
--- a/src/Feirb.Web/Components/Widgets/MailsPerDayWidget.razor
+++ b/src/Feirb.Web/Components/Widgets/MailsPerDayWidget.razor
@@ -4,6 +4,8 @@
 @implements IAsyncDisposable
 
 <WidgetCard InstanceId="@InstanceId"
+            EditMode="EditMode"
+            OnRemove="OnRemove"
             OnConfigLoaded="OnConfigLoadedAsync"
             GetPendingConfig="GetPendingConfig">
     <Content>
@@ -45,6 +47,8 @@
     private int _pendingDays = 7;
 
     [Parameter, EditorRequired] public string InstanceId { get; set; } = "";
+    [Parameter] public bool EditMode { get; set; }
+    [Parameter] public EventCallback OnRemove { get; set; }
 
     private async Task OnConfigLoadedAsync(string? config)
     {

--- a/src/Feirb.Web/Components/Widgets/TotalMailCountWidget.razor
+++ b/src/Feirb.Web/Components/Widgets/TotalMailCountWidget.razor
@@ -1,7 +1,7 @@
 @inject HttpClient Http
 @inject IStringLocalizer<SharedResources> L
 
-<WidgetCard InstanceId="@InstanceId">
+<WidgetCard InstanceId="@InstanceId" EditMode="EditMode" OnRemove="OnRemove">
     <Content>
         <div class="h-100 d-flex flex-column align-items-center justify-content-center">
             <span class="text-muted small">@L["WidgetMailCountName"]</span>
@@ -11,7 +11,7 @@
             }
             else
             {
-                <span class="display-3 fw-bold text-primary">@_totalCount</span>
+                <span class="fw-bold text-primary" style="font-size: 6rem; line-height: 1;">@_totalCount</span>
             }
         </div>
     </Content>
@@ -22,6 +22,8 @@
     private bool _loading = true;
 
     [Parameter, EditorRequired] public string InstanceId { get; set; } = "";
+    [Parameter] public bool EditMode { get; set; }
+    [Parameter] public EventCallback OnRemove { get; set; }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/Feirb.Web/Components/Widgets/WidgetCard.razor
+++ b/src/Feirb.Web/Components/Widgets/WidgetCard.razor
@@ -2,13 +2,20 @@
 @inject IStringLocalizer<SharedResources> L
 
 <div class="widget-card h-100 d-flex flex-column p-3 position-relative">
-    @if (ConfigDialog is not null)
+    @if (EditMode)
     {
-        <button class="btn btn-sm btn-outline-secondary position-absolute top-0 end-0 m-1 widget-config-btn"
-                @onclick="OpenSettings"
-                @onclick:stopPropagation="true">
-            <i class="bi bi-gear"></i>
-        </button>
+        <div class="widget-edit-controls">
+            <button class="widget-corner-btn widget-settings-btn"
+                    @onclick="OpenSettings"
+                    @onclick:stopPropagation="true">
+                <i class="bi bi-gear"></i>
+            </button>
+            <button class="widget-corner-btn widget-close-btn"
+                    @onclick="OnRemove"
+                    @onclick:stopPropagation="true">
+                <i class="bi bi-x"></i>
+            </button>
+        </div>
     }
     @Content
 </div>
@@ -29,6 +36,8 @@
 
     [Parameter, EditorRequired] public string InstanceId { get; set; } = "";
     [Parameter, EditorRequired] public RenderFragment Content { get; set; } = null!;
+    [Parameter] public bool EditMode { get; set; }
+    [Parameter] public EventCallback OnRemove { get; set; }
     [Parameter] public RenderFragment? ConfigDialog { get; set; }
     [Parameter] public EventCallback<string?> OnConfigLoaded { get; set; }
     [Parameter] public Func<string?>? GetPendingConfig { get; set; }

--- a/src/Feirb.Web/Components/Widgets/WidgetCatalogSidebar.razor
+++ b/src/Feirb.Web/Components/Widgets/WidgetCatalogSidebar.razor
@@ -10,6 +10,7 @@
     {
         <div class="card mb-2 widget-catalog-item" role="button" @onclick="() => OnWidgetSelected.InvokeAsync(widget)">
             <div class="card-body p-2">
+                <i class="bi @widget.Icon d-block mb-1" style="font-size: 2rem; color: var(--feirb-on-surface);"></i>
                 <div class="fw-semibold small">@L[widget.NameKey]</div>
                 <div class="text-muted" style="font-size: 0.75rem;">@L[widget.DescriptionKey]</div>
             </div>

--- a/src/Feirb.Web/Components/Widgets/WidgetDefinition.cs
+++ b/src/Feirb.Web/Components/Widgets/WidgetDefinition.cs
@@ -5,6 +5,7 @@ public sealed record WidgetDefinition(
     string NameKey,
     string DescriptionKey,
     Type ComponentType,
+    string Icon = "bi-puzzle",
     int DefaultWidth = 4,
     int DefaultHeight = 2,
     string? DefaultConfig = null);

--- a/src/Feirb.Web/Components/Widgets/WidgetRegistry.cs
+++ b/src/Feirb.Web/Components/Widgets/WidgetRegistry.cs
@@ -4,8 +4,8 @@ public static class WidgetRegistry
 {
     public static IReadOnlyList<WidgetDefinition> All { get; } =
     [
-        new WidgetDefinition("mail-count", "WidgetMailCountName", "WidgetMailCountDescription", typeof(TotalMailCountWidget), DefaultWidth: 3, DefaultHeight: 2),
-        new WidgetDefinition("mails-per-day", "WidgetMailsPerDayName", "WidgetMailsPerDayDescription", typeof(MailsPerDayWidget), DefaultWidth: 6, DefaultHeight: 3, DefaultConfig: "7"),
+        new WidgetDefinition("mail-count", "WidgetMailCountName", "WidgetMailCountDescription", typeof(TotalMailCountWidget), Icon: "bi-envelope", DefaultWidth: 3, DefaultHeight: 2),
+        new WidgetDefinition("mails-per-day", "WidgetMailsPerDayName", "WidgetMailsPerDayDescription", typeof(MailsPerDayWidget), Icon: "bi-bar-chart", DefaultWidth: 6, DefaultHeight: 3, DefaultConfig: "7"),
     ];
 
     public static WidgetDefinition? GetById(string id) =>

--- a/src/Feirb.Web/Pages/Home.razor
+++ b/src/Feirb.Web/Pages/Home.razor
@@ -13,21 +13,12 @@
         <div class="grid-stack" id="dashboard-grid">
             @foreach (var widget in _activeWidgets)
             {
-                <div class="grid-stack-item" gs-id="@widget.InstanceId"
+                <div @key="widget.InstanceId" class="grid-stack-item" gs-id="@widget.InstanceId"
                      gs-w="@widget.W" gs-h="@widget.H"
                      gs-x="@widget.X" gs-y="@widget.Y">
-                    <div class="grid-stack-item-content">
-                        @if (_editMode)
-                        {
-                            <button class="btn btn-sm btn-outline-danger position-absolute top-0 end-0 m-1 widget-remove-btn"
-                                    style="z-index: 10; padding: 0.1rem 0.35rem; line-height: 1;"
-                                    @onclick="() => RemoveWidgetAsync(widget.InstanceId)"
-                                    @onclick:stopPropagation="true">
-                                <i class="bi bi-x"></i>
-                            </button>
-                        }
+                    <div class="grid-stack-item-content @(_editMode ? "edit-mode" : "")">
                         <DynamicComponent Type="widget.Definition.ComponentType"
-                                         Parameters="@(new Dictionary<string, object> { ["InstanceId"] = widget.InstanceId })" />
+                                         Parameters="@(new Dictionary<string, object> { ["InstanceId"] = widget.InstanceId, ["EditMode"] = _editMode, ["OnRemove"] = EventCallback.Factory.Create(this, () => RemoveWidgetAsync(widget.InstanceId)) })" />
                     </div>
                 </div>
             }

--- a/src/Feirb.Web/Pages/Home.razor.css
+++ b/src/Feirb.Web/Pages/Home.razor.css
@@ -1,31 +1,71 @@
 ::deep .grid-stack-item-content {
     background-color: #fff;
     border: 1px solid rgba(0, 0, 0, 0.05);
-    border-radius: 1rem;
+    border-radius: 2rem;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
     overflow: hidden;
     position: relative;
 }
 
+::deep .grid-stack-item-content.edit-mode {
+    cursor: grab;
+}
+
+::deep .grid-stack-item-content.edit-mode:active {
+    cursor: grabbing;
+}
+
 ::deep .widget-card {
     height: 100%;
+    overflow: hidden;
+    border-radius: 2rem;
 }
 
-::deep .widget-remove-btn {
-    border-radius: 50%;
-    width: 24px;
-    height: 24px;
-    font-size: 0.75rem;
-}
-
-::deep .widget-config-btn {
-    border-radius: 50%;
-    width: 24px;
-    height: 24px;
-    font-size: 0.75rem;
+/* Edit-mode controls container: top-right */
+::deep .widget-edit-controls {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    display: flex;
+    gap: 0.4rem;
     z-index: 10;
-    padding: 0.1rem 0.35rem;
-    line-height: 1;
+}
+
+/* Edit-mode circular buttons */
+::deep .widget-corner-btn {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.1rem;
+    cursor: pointer;
+    transition: opacity 0.15s;
+    padding: 0;
+}
+
+::deep .widget-corner-btn:hover {
+    opacity: 0.85;
+}
+
+/* Settings (gear) */
+::deep .widget-settings-btn {
+    background-color: var(--feirb-on-surface);
+    color: var(--feirb-surface);
+}
+
+/* Close/Remove */
+::deep .widget-close-btn {
+    background-color: var(--bs-primary);
+    color: #fff;
+    font-size: 1.3rem;
+}
+
+/* Hide GridStack native resize handle */
+::deep .grid-stack-item > .ui-resizable-handle {
+    display: none !important;
 }
 
 ::deep .widget-catalog-sidebar {

--- a/src/Feirb.Web/wwwroot/js/gridstack-interop.js
+++ b/src/Feirb.Web/wwwroot/js/gridstack-interop.js
@@ -17,7 +17,7 @@ window.gridstackInterop = {
             column: 12,
             animate: true,
             disableDrag: !isEditMode,
-            disableResize: !isEditMode,
+            disableResize: true,
             float: false,
         }, el);
 
@@ -33,13 +33,7 @@ window.gridstackInterop = {
 
     setEditMode: function (enabled) {
         if (!this._grid) return;
-        if (enabled) {
-            this._grid.enableMove(true);
-            this._grid.enableResize(true);
-        } else {
-            this._grid.enableMove(false);
-            this._grid.enableResize(false);
-        }
+        this._grid.enableMove(enabled);
     },
 
     serialize: function () {


### PR DESCRIPTION
## Summary

- Widget cards now use `border-radius: 2rem` and Total Emails widget uses `6rem` font-size
- Edit mode shows gear (settings) and close (remove) circular buttons top-right on each widget
- Drag cursors (`grab`/`grabbing`) active in edit mode, GridStack resize disabled
- Widget catalog items display configurable Bootstrap Icons (2rem, top-left)
- Fixed widget content flipping bug on add/remove by adding `@key` to foreach loop

Closes #106

## Test plan

- [x] Verify widget cards render with updated border-radius (2rem)
- [x] Verify Total Emails number displays at 6rem font-size
- [x] Enter edit mode and confirm gear + close buttons appear top-right on each widget
- [x] Click gear button to open widget settings dialog
- [x] Click close button to remove a widget
- [x] Drag widgets in edit mode and verify grab/grabbing cursors
- [x] Confirm no resize handles appear on widgets
- [x] Open widget catalog and verify icons display on each entry
- [x] Add and remove multiple widgets to confirm no content flipping

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>