### PR TITLE
feat(web): shared UI component library and /implement-ui skill (#128)

### DIFF
--- a/.claude/skills/designer-grill-me/SKILL.md
+++ b/.claude/skills/designer-grill-me/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: designer-grill-me
+description: UI/UX design exploration for responsive, accessible, and consistent interfaces
+user_invocable: true
+args: design_topic
+---
+
+# Designer Grill Me — UI/UX Design Exploration
+
+Explore UI/UX design decisions through focused questioning. Produces design decisions only — no code. Implementation is handled by `/implement-ui`.
+
+## Steps
+
+1. **Get the design topic:**
+   - If `{design_topic}` is provided, use it as the starting point
+   - Otherwise, ask the user what UI/UX area they want to explore
+
+2. **Read context:**
+   - Read `docs/component-library.md` for available primitives
+   - Read `docs/DESIGN.md` for design system tokens and rules
+   - Read relevant existing pages/components to understand current state
+
+3. **Explore design dimensions** (1-3 questions per message):
+
+   **Layout & Structure**
+   - Content hierarchy and information architecture
+   - Grid and spacing decisions
+   - Desktop vs. mobile layout differences
+
+   **Interaction Patterns**
+   - User flows and navigation
+   - Form behavior (inline edit, modal, page)
+   - Loading, empty, and error states
+   - Feedback mechanisms (toasts, inline messages, progress)
+
+   **Visual Design**
+   - Color usage within the existing token palette
+   - Typography choices
+   - Iconography and visual indicators
+   - Card/surface usage and elevation
+
+   **Accessibility**
+   - Keyboard navigation flow
+   - Screen reader experience
+   - Focus management
+   - Color contrast and non-color indicators
+
+   **Responsiveness**
+   - Desktop primary layout
+   - Mobile adaptations (NAS stats use case)
+   - Breakpoint behavior
+   - Touch targets
+
+   **Component Needs**
+   - Which existing primitives apply
+   - What new primitives might be needed
+   - Patterns that should become shared components
+
+4. **Keep it focused:**
+   - Work through one dimension at a time
+   - Skip dimensions that are obviously not relevant
+   - Challenge assumptions and point out inconsistencies
+   - Reference existing patterns in the codebase rather than asking the user
+   - Summarize decisions before moving on
+
+5. **Produce a design summary:**
+   - Decisions made, grouped by dimension
+   - Primitives to use / create
+   - Wireframe description (text-based layout sketch if helpful)
+   - Open questions (if any)
+
+6. **Offer next steps:**
+   - Implement with `/implement-ui`
+   - Create a GitHub issue for larger work
+   - Continue exploring another area
+
+## Principles
+
+- Design decisions, not code — `/implement-ui` handles implementation
+- Respect the existing design system (DESIGN.md tokens, Electric Iris palette)
+- Desktop-first but mobile-aware
+- WCAG AA is non-negotiable
+- Prefer existing primitives over new ones
+- Concise questions, specific trade-offs

--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -60,6 +60,7 @@ Start working on a feature tracked by a GitHub issue.
    - Minimal APIs grouped by feature
    - xUnit + FluentAssertions for tests
    - Async methods suffixed with `Async`
+   - **For any UI work:** use `/implement-ui` to ensure consistent styling with the shared component library
 
 10. **Verify the implementation:**
    ```bash

--- a/.claude/skills/implement-ui/SKILL.md
+++ b/.claude/skills/implement-ui/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: implement-ui
+description: Implement UI work using the shared component library with consistent styling enforcement
+user_invocable: true
+args: description_of_ui_work
+---
+
+# Implement UI
+
+Implement UI work using registered primitives from the component library. Enforces consistent styling across all pages.
+
+## Steps
+
+1. **Read the component registry:**
+   ```
+   docs/component-library.md
+   ```
+
+2. **Read the page/component context** — understand what exists, what needs to change.
+
+3. **Draft a short plan** for the UI work:
+   - Which primitives will be used
+   - Which elements need to change
+   - Any new primitives needed
+   - Ask the user to confirm before proceeding
+
+4. **Implement using registered primitives:**
+   - Replace raw Bootstrap button classes with `<Button>` or `<CircularButton>`
+   - Replace raw `<i class="bi bi-*">` with `<Icon>`
+   - Replace raw card markup with `<Card>`
+   - Follow existing page patterns for layout and structure
+
+5. **WCAG AA check:**
+   - All interactive elements are keyboard-focusable
+   - `aria-label` on icon-only buttons (CircularButton enforces this)
+   - Contrast meets 4.5:1 for text, 3:1 for large text and UI components
+   - Semantic HTML elements where appropriate
+   - No color-only indicators
+
+6. **Responsive check:**
+   - Desktop primary, mobile supported
+   - Use Bootstrap breakpoints (`col-sm-`, `col-md-`, `col-lg-`) for layout
+   - Test that content doesn't overflow on small screens
+
+7. **If a small primitive is missing** (e.g., a Badge, Divider, or similar):
+   - Pause implementation
+   - Propose the primitive with 2-3 design questions:
+     - What variants does it need?
+     - What sizes?
+     - Any accessibility requirements?
+   - After user confirms, create it in `src/Feirb.Web/Components/UI/`
+   - Add styles to `app.css` with `feirb-` prefix
+   - Update `docs/component-library.md`
+   - Continue implementation
+
+8. **If a large primitive is missing** (e.g., Modal, DataTable, Toolbar redesign):
+   - Propose a GitHub issue for the primitive
+   - User decides: create issue and defer, or build it now
+   - If building now, follow the same pattern as step 7 but with full design exploration
+
+9. **If UX exploration is needed** (interaction patterns, layout decisions, responsive behavior):
+   - Suggest using `/designer-grill-me` for design exploration
+   - Wait for design decisions before implementing
+
+## Hard Rules
+
+- **If a primitive exists, use it** — never emit raw Bootstrap classes for elements covered by the library
+- Non-covered elements (modals, forms, tables, menus): use Bootstrap classes but encourage componentization
+- If a non-covered pattern appears 2+ times, create a refactoring issue
+- All icon-only buttons MUST use `<CircularButton>` with `AriaLabel`
+- All icons MUST use `<Icon>` component
+- All standalone buttons MUST use `<Button>` component
+- Cards for content containers MUST use `<Card>` component
+
+## Conventions
+
+- Follow all conventions from CLAUDE.md (file-scoped namespaces, primary constructors, etc.)
+- Follow `/new-blazor-component` conventions for any new components
+- All user-facing strings through `IStringLocalizer<SharedResources>`
+- Add `.resx` keys to all locale files when adding new strings
+- Scoped CSS (`.razor.css`) for page-specific layout; global `app.css` for primitive styles only
+
+## After Implementation
+
+- List which primitives were used
+- List any new primitives created
+- List any `.resx` keys added
+- Note any migration opportunities spotted (existing pages using raw Bootstrap for covered elements)

--- a/docs/component-library.md
+++ b/docs/component-library.md
@@ -1,0 +1,108 @@
+# Feirb Component Library
+
+Shared UI primitives in `src/Feirb.Web/Components/UI/`.
+Global styles in `src/Feirb.Web/wwwroot/css/app.css` (prefixed `feirb-`).
+
+## Icon
+
+Renders a Bootstrap Icon with consistent sizing.
+
+```razor
+<Icon Name="gear" />
+<Icon Name="pencil" Size="IconSize.Small" />
+<Icon Name="envelope" Size="IconSize.Large" />
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `Name` | `string` (required) | — | Icon name without `bi-` prefix |
+| `Size` | `IconSize` | `Default` | `Small` (0.875rem), `Default` (1.25rem), `Large` (2rem) |
+| `Class` | `string?` | `null` | Extra CSS classes |
+
+## Button
+
+Standard button with optional icon.
+
+```razor
+<Button Variant="ButtonVariant.Primary" OnClick="Save">Save</Button>
+<Button Variant="ButtonVariant.Danger" Size="ButtonSize.Small" Icon="trash">Delete</Button>
+<Button Icon="download" IconPosition="IconPosition.Right">Export</Button>
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `Variant` | `ButtonVariant` | `Primary` | `Primary`, `Secondary`, `Danger`, `Warning` |
+| `Size` | `ButtonSize` | `Medium` | `Small`, `Medium`, `Large` |
+| `Icon` | `string?` | `null` | Icon name (without `bi-` prefix) |
+| `IconPosition` | `IconPosition` | `Left` | `Left` or `Right` |
+| `ChildContent` | `RenderFragment?` | — | Button text/content |
+| `OnClick` | `EventCallback<MouseEventArgs>` | — | Click handler |
+| `Disabled` | `bool` | `false` | Disabled state |
+| `Type` | `string` | `"button"` | HTML button type |
+| `Title` | `string?` | `null` | Tooltip |
+| `Class` | `string?` | `null` | Extra CSS classes |
+
+## CircularButton
+
+Icon-only circular button. Requires `AriaLabel` for WCAG AA.
+
+```razor
+<CircularButton AriaLabel="Settings" Variant="ButtonVariant.Primary" OnClick="OpenSettings">
+    <Icon Name="gear" />
+</CircularButton>
+<CircularButton AriaLabel="Delete" Variant="ButtonVariant.Danger" Size="ButtonSize.Small" OnClick="Remove">
+    <Icon Name="x" Size="IconSize.Small" />
+</CircularButton>
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `AriaLabel` | `string` (required) | — | Accessible name |
+| `Variant` | `ButtonVariant` | `Primary` | Visual variant |
+| `Size` | `ButtonSize` | `Medium` | `Small` (2rem), `Medium` (2.5rem), `Large` (3rem) |
+| `ChildContent` | `RenderFragment?` | — | Typically an `<Icon>` |
+| `OnClick` | `EventCallback<MouseEventArgs>` | — | Click handler |
+| `Disabled` | `bool` | `false` | Disabled state |
+| `Title` | `string?` | `null` | Tooltip (falls back to AriaLabel) |
+| `Class` | `string?` | `null` | Extra CSS classes |
+
+## Card
+
+Minimal card container.
+
+```razor
+<Card>
+    <h3>Title</h3>
+    <p>Content goes here.</p>
+</Card>
+<Card Class="p-4">
+    <p>Card with extra padding.</p>
+</Card>
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ChildContent` | `RenderFragment` (required) | — | Card content |
+| `Class` | `string?` | `null` | Extra CSS classes |
+
+## Enums
+
+Defined in `UIEnums.cs`:
+
+- **`IconSize`**: `Small`, `Default`, `Large`
+- **`ButtonVariant`**: `Primary`, `Secondary`, `Danger`, `Warning`
+- **`ButtonSize`**: `Small`, `Medium`, `Large`
+- **`IconPosition`**: `Left`, `Right`
+
+## Design Tokens
+
+All primitives use CSS custom properties from `app.css`. Key tokens:
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--bs-primary` | `#b6004f` | Primary actions |
+| `--feirb-on-surface` | `#2d2d43` | Secondary actions, text |
+| `--feirb-error` | `#b31b25` | Danger actions |
+| `--bs-warning` | `#FFE04A` | Warning actions |
+| `--feirb-shadow` | `0 8px 24px rgba(0,0,0,0.06)` | Card shadow |
+| `--bs-border-radius` | `1rem` | Card corners |

--- a/src/Feirb.Web/Components/UI/Button.razor
+++ b/src/Feirb.Web/Components/UI/Button.razor
@@ -1,0 +1,85 @@
+@namespace Feirb.Web.Components.UI
+
+@* Standard button with optional icon and consistent styling. *@
+<button type="@Type"
+        class="btn @VariantCss @SizeCss @Class"
+        disabled="@Disabled"
+        title="@Title"
+        @onclick="OnClick"
+        @attributes="AdditionalAttributes">
+    @if (!string.IsNullOrEmpty(Icon) && IconPosition == IconPosition.Left)
+    {
+        <Icon Name="@Icon" Size="IconSize.Small" Class="@IconSpacingCss" />
+    }
+    @ChildContent
+    @if (!string.IsNullOrEmpty(Icon) && IconPosition == IconPosition.Right)
+    {
+        <Icon Name="@Icon" Size="IconSize.Small" Class="@IconSpacingCss" />
+    }
+</button>
+
+@code {
+    /// <summary>Button visual variant.</summary>
+    [Parameter]
+    public ButtonVariant Variant { get; set; } = ButtonVariant.Primary;
+
+    /// <summary>Button size.</summary>
+    [Parameter]
+    public ButtonSize Size { get; set; } = ButtonSize.Medium;
+
+    /// <summary>Bootstrap Icon name (without "bi-" prefix). Renders alongside ChildContent.</summary>
+    [Parameter]
+    public string? Icon { get; set; }
+
+    /// <summary>Position of the icon relative to the text.</summary>
+    [Parameter]
+    public IconPosition IconPosition { get; set; } = IconPosition.Left;
+
+    /// <summary>Button content (text, markup).</summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>Click event callback.</summary>
+    [Parameter]
+    public EventCallback<MouseEventArgs> OnClick { get; set; }
+
+    /// <summary>Whether the button is disabled.</summary>
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    /// <summary>HTML button type attribute.</summary>
+    [Parameter]
+    public string Type { get; set; } = "button";
+
+    /// <summary>Tooltip text.</summary>
+    [Parameter]
+    public string? Title { get; set; }
+
+    /// <summary>Additional CSS classes.</summary>
+    [Parameter]
+    public string? Class { get; set; }
+
+    /// <summary>Any extra HTML attributes.</summary>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string VariantCss => Variant switch
+    {
+        ButtonVariant.Primary => "btn-primary",
+        ButtonVariant.Secondary => "btn-secondary",
+        ButtonVariant.Danger => "btn-danger",
+        ButtonVariant.Warning => "btn-warning",
+        _ => "btn-primary"
+    };
+
+    private string SizeCss => Size switch
+    {
+        ButtonSize.Small => "btn-sm",
+        ButtonSize.Large => "btn-lg",
+        _ => ""
+    };
+
+    private string IconSpacingCss => ChildContent is not null
+        ? (IconPosition == IconPosition.Left ? "me-1" : "ms-1")
+        : "";
+}

--- a/src/Feirb.Web/Components/UI/Card.razor
+++ b/src/Feirb.Web/Components/UI/Card.razor
@@ -1,0 +1,20 @@
+@namespace Feirb.Web.Components.UI
+
+@* Minimal card container with consistent styling. *@
+<div class="feirb-card @Class" @attributes="AdditionalAttributes">
+    @ChildContent
+</div>
+
+@code {
+    /// <summary>Card content.</summary>
+    [Parameter, EditorRequired]
+    public RenderFragment ChildContent { get; set; } = null!;
+
+    /// <summary>Additional CSS classes.</summary>
+    [Parameter]
+    public string? Class { get; set; }
+
+    /// <summary>Any extra HTML attributes.</summary>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+}

--- a/src/Feirb.Web/Components/UI/CircularButton.razor
+++ b/src/Feirb.Web/Components/UI/CircularButton.razor
@@ -1,0 +1,66 @@
+@namespace Feirb.Web.Components.UI
+
+@* Icon-only circular button with required accessible name. *@
+<button type="button"
+        class="feirb-circular-btn @VariantCss @SizeCss @Class"
+        aria-label="@AriaLabel"
+        title="@(Title ?? AriaLabel)"
+        disabled="@Disabled"
+        @onclick="OnClick"
+        @attributes="AdditionalAttributes">
+    @ChildContent
+</button>
+
+@code {
+    /// <summary>Accessible name for the button (WCAG AA required).</summary>
+    [Parameter, EditorRequired]
+    public string AriaLabel { get; set; } = "";
+
+    /// <summary>Button visual variant.</summary>
+    [Parameter]
+    public ButtonVariant Variant { get; set; } = ButtonVariant.Primary;
+
+    /// <summary>Button size.</summary>
+    [Parameter]
+    public ButtonSize Size { get; set; } = ButtonSize.Medium;
+
+    /// <summary>Button content (typically an Icon component).</summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>Click event callback.</summary>
+    [Parameter]
+    public EventCallback<MouseEventArgs> OnClick { get; set; }
+
+    /// <summary>Whether the button is disabled.</summary>
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    /// <summary>Tooltip text. Falls back to AriaLabel if not set.</summary>
+    [Parameter]
+    public string? Title { get; set; }
+
+    /// <summary>Additional CSS classes.</summary>
+    [Parameter]
+    public string? Class { get; set; }
+
+    /// <summary>Any extra HTML attributes.</summary>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string VariantCss => Variant switch
+    {
+        ButtonVariant.Primary => "feirb-circular-btn-primary",
+        ButtonVariant.Secondary => "feirb-circular-btn-secondary",
+        ButtonVariant.Danger => "feirb-circular-btn-danger",
+        ButtonVariant.Warning => "feirb-circular-btn-warning",
+        _ => "feirb-circular-btn-primary"
+    };
+
+    private string SizeCss => Size switch
+    {
+        ButtonSize.Small => "feirb-circular-btn-sm",
+        ButtonSize.Large => "feirb-circular-btn-lg",
+        _ => ""
+    };
+}

--- a/src/Feirb.Web/Components/UI/Icon.razor
+++ b/src/Feirb.Web/Components/UI/Icon.razor
@@ -1,0 +1,25 @@
+@namespace Feirb.Web.Components.UI
+
+@* Renders a Bootstrap Icon with consistent sizing. *@
+<i class="bi bi-@Name @SizeCss" aria-hidden="true"></i>
+
+@code {
+    /// <summary>Bootstrap Icon name without the "bi-" prefix (e.g., "gear", "pencil", "x-lg").</summary>
+    [Parameter, EditorRequired]
+    public string Name { get; set; } = "";
+
+    /// <summary>Icon size. Defaults to <see cref="IconSize.Default"/>.</summary>
+    [Parameter]
+    public IconSize Size { get; set; } = IconSize.Default;
+
+    /// <summary>Additional CSS classes to apply.</summary>
+    [Parameter]
+    public string? Class { get; set; }
+
+    private string SizeCss => Size switch
+    {
+        IconSize.Small => "feirb-icon-sm",
+        IconSize.Large => "feirb-icon-lg",
+        _ => "feirb-icon"
+    } + (string.IsNullOrEmpty(Class) ? "" : $" {Class}");
+}

--- a/src/Feirb.Web/Components/UI/UIEnums.cs
+++ b/src/Feirb.Web/Components/UI/UIEnums.cs
@@ -1,0 +1,33 @@
+namespace Feirb.Web.Components.UI;
+
+/// <summary>Size for Icon rendering.</summary>
+public enum IconSize
+{
+    Small,
+    Default,
+    Large
+}
+
+/// <summary>Visual variant for buttons.</summary>
+public enum ButtonVariant
+{
+    Primary,
+    Secondary,
+    Danger,
+    Warning
+}
+
+/// <summary>Size for button rendering.</summary>
+public enum ButtonSize
+{
+    Small,
+    Medium,
+    Large
+}
+
+/// <summary>Position of an icon relative to button text.</summary>
+public enum IconPosition
+{
+    Left,
+    Right
+}

--- a/src/Feirb.Web/_Imports.razor
+++ b/src/Feirb.Web/_Imports.razor
@@ -14,6 +14,7 @@
 @using Feirb.Web.Layout
 @using Feirb.Web.Resources
 @using Feirb.Web.Services
+@using Feirb.Web.Components.UI
 @using Feirb.Web.Components.Widgets
 @using Feirb.Shared.Dashboard
 @using Feirb.Shared.Mail

--- a/src/Feirb.Web/wwwroot/css/app.css
+++ b/src/Feirb.Web/wwwroot/css/app.css
@@ -107,6 +107,103 @@ a:hover, .btn-link:hover {
     box-shadow: var(--feirb-shadow);
 }
 
+/* Icon component sizes */
+.feirb-icon-sm {
+    font-size: 0.875rem;
+}
+
+.feirb-icon {
+    font-size: 1.25rem;
+}
+
+.feirb-icon-lg {
+    font-size: 2rem;
+}
+
+/* Circular icon button */
+.feirb-circular-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    transition: background-color 0.15s ease-in-out, opacity 0.15s ease-in-out;
+    font-size: 1.25rem;
+    line-height: 1;
+}
+
+.feirb-circular-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.feirb-circular-btn:focus-visible {
+    outline: 2px solid var(--bs-primary);
+    outline-offset: 2px;
+}
+
+.feirb-circular-btn-sm {
+    width: 2rem;
+    height: 2rem;
+    font-size: 0.875rem;
+}
+
+.feirb-circular-btn-lg {
+    width: 3rem;
+    height: 3rem;
+    font-size: 1.5rem;
+}
+
+.feirb-circular-btn-primary {
+    background-color: var(--bs-primary);
+    color: #fff;
+}
+
+.feirb-circular-btn-primary:hover:not(:disabled) {
+    background-color: #8a003c;
+}
+
+.feirb-circular-btn-secondary {
+    background-color: var(--feirb-on-surface);
+    color: #fff;
+}
+
+.feirb-circular-btn-secondary:hover:not(:disabled) {
+    background-color: var(--feirb-surface-container);
+    color: var(--feirb-on-surface);
+}
+
+.feirb-circular-btn-danger {
+    background-color: var(--feirb-error);
+    color: #fff;
+}
+
+.feirb-circular-btn-danger:hover:not(:disabled) {
+    opacity: 0.85;
+}
+
+.feirb-circular-btn-warning {
+    background-color: var(--bs-warning);
+    color: var(--feirb-on-surface);
+}
+
+.feirb-circular-btn-warning:hover:not(:disabled) {
+    opacity: 0.85;
+}
+
+/* Card component */
+.feirb-card {
+    background-color: #fff;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    border-radius: var(--bs-border-radius);
+    box-shadow: var(--feirb-shadow);
+    padding: 1rem;
+}
+
 /* Inputs */
 .form-control {
     border-radius: var(--feirb-radius-input);


### PR DESCRIPTION
## Summary

- Add shared UI component library with 4 initial primitives: `Icon`, `Button`, `CircularButton`, `Card` in `src/Feirb.Web/Components/UI/`
- Add global CSS styles for all primitives in `app.css` (prefixed `feirb-`)
- Create `/implement-ui` skill that enforces component library usage for all UI work
- Create `/designer-grill-me` skill for UI/UX design exploration (design decisions only, no code)
- Update `/implement-feature` skill to call `/implement-ui` for UI tasks
- Add component registry at `docs/component-library.md`

## Test plan

- [x] `dotnet build` passes with 0 errors
- [x] All 146 tests pass
- [x] `dotnet format --verify-no-changes` clean
- [x] Manual testing by user

Closes #128

Generated with [Claude Code](https://claude.com/claude-code)