### PR TITLE
feat(web): add CronInput component with Quartz validation

### DIFF
--- a/src/Feirb.Web/Components/UI/CronInput.razor
+++ b/src/Feirb.Web/Components/UI/CronInput.razor
@@ -1,0 +1,80 @@
+@namespace Feirb.Web.Components.UI
+@using System.Linq.Expressions
+@using Feirb.Web.Services
+@using Microsoft.AspNetCore.Components.Forms
+@inject IStringLocalizer<SharedResources> L
+
+<div class="@($"feirb-cron-input {Class}")">
+    <InputText id="@Id"
+               class="@InputCssClass"
+               @bind-Value="Value"
+               @bind-Value:after="OnValueChangedAsync"
+               placeholder="@(Placeholder ?? "0 */5 * * * ?")" />
+    @if (_validationError is not null)
+    {
+        <div class="invalid-feedback">@_validationError</div>
+    }
+    @if (_description is not null)
+    {
+        <div class="form-text text-success">
+            <i class="bi bi-check-circle me-1"></i>@_description
+        </div>
+    }
+</div>
+
+@code {
+    /// <summary>The cron expression value.</summary>
+    [Parameter]
+    public string? Value { get; set; }
+
+    /// <summary>Fires when the value changes.</summary>
+    [Parameter]
+    public EventCallback<string?> ValueChanged { get; set; }
+
+    /// <summary>Optional model field expression for EditContext change tracking.</summary>
+    [Parameter]
+    public Expression<Func<string?>>? For { get; set; }
+
+    /// <summary>HTML id attribute for the input.</summary>
+    [Parameter]
+    public string? Id { get; set; }
+
+    /// <summary>Placeholder text.</summary>
+    [Parameter]
+    public string? Placeholder { get; set; }
+
+    /// <summary>Additional CSS classes for the wrapper.</summary>
+    [Parameter]
+    public string? Class { get; set; }
+
+    [CascadingParameter]
+    private EditContext? EditContext { get; set; }
+
+    private string? _validationError;
+    private string? _description;
+
+    protected override void OnParametersSet() => Validate();
+
+    private async Task OnValueChangedAsync()
+    {
+        Validate();
+        await ValueChanged.InvokeAsync(Value);
+
+        if (EditContext is not null && For is not null)
+        {
+            EditContext.NotifyFieldChanged(FieldIdentifier.Create(For));
+        }
+    }
+
+    private void Validate()
+    {
+        var (isValid, description) = CronValidator.Validate(Value);
+        _validationError = isValid ? null : (string)L["CronInputInvalid"];
+        _description = description;
+    }
+
+    private string InputCssClass =>
+        string.IsNullOrWhiteSpace(Value) ? "form-control"
+        : _validationError is not null ? "form-control is-invalid"
+        : "form-control is-valid";
+}

--- a/src/Feirb.Web/Feirb.Web.csproj
+++ b/src/Feirb.Web/Feirb.Web.csproj
@@ -13,12 +13,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CronExpressionDescriptor" Version="2.45.0" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.0" />
+    <PackageReference Include="Quartz" Version="3.16.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
   </ItemGroup>
 

--- a/src/Feirb.Web/Pages/Admin/SystemSettings/JobDetail.razor
+++ b/src/Feirb.Web/Pages/Admin/SystemSettings/JobDetail.razor
@@ -45,13 +45,9 @@ else if (_model is not null)
             {
                 <div class="mb-3">
                     <label for="cronExpression" class="form-label">@L["JobsCronExpression"]</label>
-                    <InputText id="cronExpression"
-                               class="@CronInputCssClass"
-                               @bind-Value="_model.Cron" @bind-Value:after="ValidateCron" />
-                    @if (_cronValidationError is not null)
-                    {
-                        <div class="invalid-feedback">@_cronValidationError</div>
-                    }
+                    <CronInput Id="cronExpression"
+                               @bind-Value="_model.Cron"
+                               For="() => _model.Cron" />
                 </div>
             }
             <div class="form-check form-switch">
@@ -130,8 +126,6 @@ else if (_model is not null)
     private bool _isSaving;
     private string? _errorMessage;
     private string _selectedPreset = "custom";
-    private string? _cronValidationError;
-
     private PaginatedJobExecutionsResponse? _executions;
     private bool _executionsLoading;
     private int _execPage = 1;
@@ -302,24 +296,7 @@ else if (_model is not null)
         if (_presetCrons.TryGetValue(presetId, out var cron) && _model is not null)
         {
             _model.Cron = cron;
-            _cronValidationError = null;
         }
-
-    }
-
-    private string CronInputCssClass =>
-        _cronValidationError is not null ? "form-control is-invalid" : "form-control";
-
-    private void ValidateCron()
-    {
-        if (_model is null || string.IsNullOrWhiteSpace(_model.Cron))
-        {
-            _cronValidationError = L["JobsCronInvalid"];
-            return;
-        }
-
-        var parts = _model.Cron.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        _cronValidationError = parts.Length is 6 or 7 ? null : (string?)L["JobsCronInvalid"];
     }
 
     private async Task OnExecPageChangedAsync(int page)

--- a/src/Feirb.Web/Resources/SharedResources.de-DE.resx
+++ b/src/Feirb.Web/Resources/SharedResources.de-DE.resx
@@ -1353,4 +1353,7 @@
   <data name="JobDetailRunning" xml:space="preserve">
     <value>Laeuft...</value>
   </data>
+  <data name="CronInputInvalid" xml:space="preserve">
+    <value>Ungueltiger Quartz-Cron-Ausdruck.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
+++ b/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
@@ -1353,4 +1353,7 @@
   <data name="JobDetailRunning" xml:space="preserve">
     <value>En cours...</value>
   </data>
+  <data name="CronInputInvalid" xml:space="preserve">
+    <value>Expression cron Quartz invalide.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.it-IT.resx
+++ b/src/Feirb.Web/Resources/SharedResources.it-IT.resx
@@ -1353,4 +1353,7 @@
   <data name="JobDetailRunning" xml:space="preserve">
     <value>In esecuzione...</value>
   </data>
+  <data name="CronInputInvalid" xml:space="preserve">
+    <value>Espressione cron Quartz non valida.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.resx
+++ b/src/Feirb.Web/Resources/SharedResources.resx
@@ -1353,4 +1353,7 @@
   <data name="JobDetailRunning" xml:space="preserve">
     <value>Running...</value>
   </data>
+  <data name="CronInputInvalid" xml:space="preserve">
+    <value>Invalid Quartz cron expression.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Services/CronValidator.cs
+++ b/src/Feirb.Web/Services/CronValidator.cs
@@ -1,0 +1,30 @@
+using CronExpressionDescriptor;
+using Quartz;
+
+namespace Feirb.Web.Services;
+
+internal static class CronValidator
+{
+    internal static (bool IsValid, string? Description) Validate(string? expression)
+    {
+        if (string.IsNullOrWhiteSpace(expression))
+            return (false, null);
+
+        if (!CronExpression.IsValidExpression(expression))
+            return (false, null);
+
+        try
+        {
+            var description = ExpressionDescriptor.GetDescription(expression, new Options
+            {
+                Use24HourTimeFormat = true,
+                ThrowExceptionOnParseError = true,
+            });
+            return (true, description);
+        }
+        catch
+        {
+            return (true, null);
+        }
+    }
+}

--- a/tests/Feirb.Web.Tests/Services/CronValidatorTests.cs
+++ b/tests/Feirb.Web.Tests/Services/CronValidatorTests.cs
@@ -1,0 +1,56 @@
+using Feirb.Web.Services;
+using FluentAssertions;
+
+namespace Feirb.Web.Tests.Services;
+
+public class CronValidatorTests
+{
+    [Theory]
+    [InlineData("0 * * * * ?")]       // Every minute
+    [InlineData("0 */5 * * * ?")]     // Every 5 minutes
+    [InlineData("0 */15 * * * ?")]    // Every 15 minutes
+    [InlineData("0 0 * * * ?")]       // Every hour
+    [InlineData("0 0 12 * * ?")]      // Every day at noon
+    [InlineData("0 0 0 ? * MON-FRI")] // Weekdays at midnight
+    public void Validate_ValidExpression_ReturnsValid(string expression)
+    {
+        var (isValid, description) = CronValidator.Validate(expression);
+
+        isValid.Should().BeTrue();
+        description.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-cron")]
+    [InlineData("* *")]
+    [InlineData("0 0 0 0 0")]
+    public void Validate_InvalidExpression_ReturnsInvalid(string? expression)
+    {
+        var (isValid, description) = CronValidator.Validate(expression);
+
+        isValid.Should().BeFalse();
+        description.Should().BeNull();
+    }
+
+    [Fact]
+    public void Validate_EveryMinute_ReturnsHumanReadableDescription()
+    {
+        var (_, description) = CronValidator.Validate("0 * * * * ?");
+
+        description.Should().NotBeNull();
+        description!.ToLowerInvariant().Should().Contain("minute");
+    }
+
+    [Fact]
+    public void Validate_SevenFieldExpression_ReturnsValid()
+    {
+        // 7-field Quartz format includes year
+        var (isValid, description) = CronValidator.Validate("0 0 12 ? * MON-FRI 2026");
+
+        isValid.Should().BeTrue();
+        description.Should().NotBeNullOrWhiteSpace();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `CronInput` reusable component that validates Quartz cron expressions client-side using the Quartz `CronExpression` parser and displays a human-readable schedule description via CronExpressionDescriptor
- Replace plain text input and basic field-count validation in the Jobs edit modal with the new component
- Add localized `CronInputInvalid` error message for all supported locales (en, de, fr, it)

## Test plan

- [ ] Navigate to a Job detail page, select "Custom" preset
- [ ] Enter a valid cron expression (e.g. `0 */10 * * * ?`) -- green description appears
- [ ] Enter an invalid expression (e.g. `hello`) -- red error message appears
- [ ] Clear the input -- error appears
- [ ] Save a valid custom cron expression -- persists correctly
- [ ] Switch locale -- error message and description update to match language

Closes #155

Generated with [Claude Code](https://claude.com/claude-code)