### PR TITLE
test(api): add unit tests for JobSettingsScheduler

### DIFF
--- a/tests/Feirb.Api.Tests/Services/JobSettingsSchedulerTests.cs
+++ b/tests/Feirb.Api.Tests/Services/JobSettingsSchedulerTests.cs
@@ -1,7 +1,6 @@
 using Feirb.Api.Data;
 using Feirb.Api.Data.Entities;
 using Feirb.Api.Services;
-using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -54,10 +53,15 @@ public class JobSettingsSchedulerTests : IDisposable
         SeedJobSettings("job-b", "classification", enabled: true);
         SeedJobSettings("job-c", "classification", enabled: false);
 
-        var sut = CreateScheduler(withClassificationJob: true);
+        var callCount = 0;
+        var completed = new TaskCompletionSource();
+        _quartzScheduler.ScheduleJob(Arg.Any<IJobDetail>(), Arg.Any<ITrigger>(), Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(DateTimeOffset.UtcNow)
+            .AndDoes(_ => { if (Interlocked.Increment(ref callCount) >= 2) completed.TrySetResult(); });
 
+        var sut = CreateScheduler(withClassificationJob: true);
         await sut.StartAsync(CancellationToken.None);
-        await Task.Delay(200);
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
         await sut.StopAsync(CancellationToken.None);
 
         await _quartzScheduler.Received(2).ScheduleJob(
@@ -69,10 +73,17 @@ public class JobSettingsSchedulerTests : IDisposable
     {
         SeedJobSettings("job-unknown", "unknown-type", enabled: true);
 
-        var sut = CreateScheduler(withClassificationJob: true);
+        // Signal when GetScheduler is called — ExecuteAsync queries the DB after this
+        var schedulerRequested = new TaskCompletionSource();
+        _schedulerFactory.GetScheduler(Arg.Any<CancellationToken>())
+            .Returns(_quartzScheduler)
+            .AndDoes(_ => schedulerRequested.TrySetResult());
 
+        var sut = CreateScheduler(withClassificationJob: true);
         await sut.StartAsync(CancellationToken.None);
-        await Task.Delay(200);
+        await schedulerRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        // Give ExecuteAsync time to process the DB query after GetScheduler returns
+        await Task.Yield();
         await sut.StopAsync(CancellationToken.None);
 
         await _quartzScheduler.DidNotReceive().ScheduleJob(


### PR DESCRIPTION
## Summary
- Adds 9 unit tests for `JobSettingsScheduler`, the `ManagedJob`-based replacement for `ImapSyncScheduler`
- Covers `ExecuteAsync` (startup scheduling), `ScheduleJobAsync`, `UnscheduleJobAsync`, and `RescheduleJobAsync`
- Includes positive paths, edge cases (unregistered job types, non-existent jobs), and operation ordering

Closes #79

## Test plan
- [x] All 9 new tests pass locally
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)