### PR TITLE
fix(api,web): avatar endpoint returns 204 when no avatar exists (#224)

### DIFF
--- a/src/Feirb.Api/Endpoints/AvatarEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/AvatarEndpoints.cs
@@ -27,7 +27,7 @@ public static class AvatarEndpoints
     {
         var avatar = await db.Avatars.FirstOrDefaultAsync(a => a.EmailHash == md5hash);
         if (avatar is null)
-            return Results.NotFound();
+            return Results.NoContent();
 
         return Results.Bytes(
             avatar.ImageData,

--- a/src/Feirb.Web/Components/UI/PersonChip.razor
+++ b/src/Feirb.Web/Components/UI/PersonChip.razor
@@ -8,7 +8,7 @@
         @if (_avatarUrl is not null)
         {
             <img src="@_avatarUrl" alt="" class="feirb-person-chip-avatar-img"
-                 onload="this.parentElement.style.borderStyle='solid'"
+                 onload="if (this.naturalWidth === 0) { this.style.display='none'; } else { this.parentElement.style.borderStyle='solid'; }"
                  onerror="this.style.display='none'" />
         }
     </div>

--- a/tests/Feirb.Api.Tests/Endpoints/AvatarEndpointsTests.cs
+++ b/tests/Feirb.Api.Tests/Endpoints/AvatarEndpointsTests.cs
@@ -31,7 +31,7 @@ public class AvatarEndpointsTests : IDisposable
     // --- GET Tests ---
 
     [Fact]
-    public async Task GetAvatar_NotFound_Returns404Async()
+    public async Task GetAvatar_NotFound_Returns204Async()
     {
         var tokens = await SetupAndLoginAsAdminAsync();
         _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
@@ -39,7 +39,7 @@ public class AvatarEndpointsTests : IDisposable
         var hash = AvatarHashHelper.ComputeEmailHash("nobody@example.com");
         var response = await _client.GetAsync($"/api/avatars/{hash}");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
     [Fact]
@@ -61,12 +61,12 @@ public class AvatarEndpointsTests : IDisposable
     }
 
     [Fact]
-    public async Task GetAvatar_Unauthenticated_ReturnsNotFoundAsync()
+    public async Task GetAvatar_Unauthenticated_ReturnsNoContentAsync()
     {
         var hash = AvatarHashHelper.ComputeEmailHash("admin@example.com");
         var response = await _client.GetAsync($"/api/avatars/{hash}");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
     // --- PUT Tests ---
@@ -192,7 +192,7 @@ public class AvatarEndpointsTests : IDisposable
 
         // Verify it's gone
         var getResponse = await _client.GetAsync($"/api/avatars/{hash}");
-        getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
     [Fact]

--- a/tests/bruno/12-avatars/get-avatar-not-found.bru
+++ b/tests/bruno/12-avatars/get-avatar-not-found.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Get Avatar Not Found
+  name: Get Avatar No Content
   type: http
   seq: 2
 }
@@ -15,7 +15,7 @@ auth:bearer {
 }
 
 tests {
-  test("should return 404", function() {
-    expect(res.status).to.equal(404);
+  test("should return 204", function() {
+    expect(res.status).to.equal(204);
   });
 }


### PR DESCRIPTION
## Summary

Fixes the noisy console errors from `GET /api/avatars/{emailHash}` returning 404 when no uploaded avatar exists. Every page with `PersonChip` instances was generating one console error per unique email address.

## Changes

- **API** (\`AvatarEndpoints.GetAvatarAsync\`): return \`NoContent\` (204) instead of \`NotFound\`
- **Web** (\`PersonChip.razor\`): the \`<img onerror>\` handler no longer fires for 2xx responses, so added a \`naturalWidth === 0\` check in \`onload\` to detect the empty 204 response and hide the img element
- **Tests**: updated 3 xUnit tests (\`GetAvatar_NotFound_Returns404Async\` → \`Returns204Async\`, \`GetAvatar_Unauthenticated_ReturnsNotFoundAsync\` → \`ReturnsNoContentAsync\`, and the delete-verify step in \`DeleteAvatar_AsAdmin\`) and the Bruno \`get-avatar-not-found.bru\` test

## Verified

- All 12 \`AvatarEndpointsTests\` pass
- Browser test on \`/mail/inbox\` with multiple PersonChips (Admin, ToolBot, etc. — none have uploaded avatars):
  - Console errors: **0** (was 5+)
  - Network: \`GET /api/avatars/{hash}\` returns 204
  - DOM: \`img.naturalWidth === 0\`, \`img.style.display === 'none'\`, fallback person icon stays visible

## Related

Split out from PR #221's console noise investigation.

Closes #224