### PR TITLE
feat(api,web,shared): address book with unified AddressStatus enum (#200)

### DIFF
--- a/.claude/skills/dev-harness/start.sh
+++ b/.claude/skills/dev-harness/start.sh
@@ -48,6 +48,10 @@ for i in $(seq 1 40); do
     if curl -sk https://localhost:7272/health 2>/dev/null; then
         echo "Healthy"
         echo "API ready (attempt $i)"
+        DASHBOARD_URL=$(grep -oE 'https://localhost:[0-9]+/login\?t=[a-f0-9]+' /tmp/feirb-aspire.log | head -1)
+        if [ -n "$DASHBOARD_URL" ]; then
+            echo "Aspire dashboard: $DASHBOARD_URL"
+        fi
         exit 0
     fi
     sleep 3

--- a/.claude/skills/implement-ui/SKILL.md
+++ b/.claude/skills/implement-ui/SKILL.md
@@ -11,40 +11,39 @@ Implement UI work using registered primitives from the component library. Enforc
 
 ## Steps
 
-1. **Read the component registry:**
-   ```
-   docs/component-library.md
-   ```
+1. **Read the component registry:** `docs/component-library.md`. This is authoritative for documented primitives.
 
-2. **Check for existing components** — search `src/Feirb.Web/Components/` for similar patterns before creating new ones. Reuse or extend existing components when possible.
+2. **Grep `src/Feirb.Web/Components/` if the registry is silent** — the registry may lag behind new additions. Never conclude "it doesn't exist" from the registry alone. If you find an undocumented component you end up using, add a registry entry for it as part of your change.
 
-3. **Read the page/component context** — understand what exists, what needs to change.
+3. **Check the showcase pages** (`src/Feirb.Web/Pages/Showcase/Showcase*.razor`) to see components rendered interactively with parameter controls. Reuse or extend existing components when possible; only reach for Bootstrap classes when nothing in the library fits.
 
-4. **Draft a short plan** for the UI work:
+4. **Read the page/component context** — understand what exists, what needs to change.
+
+5. **Draft a short plan** for the UI work:
    - Which primitives will be used
    - Which elements need to change
    - Any new primitives needed
    - Ask the user to confirm before proceeding
 
-5. **Implement using registered primitives:**
+6. **Implement using registered primitives:**
    - Replace raw Bootstrap button classes with `<Button>` or `<CircularButton>`
-   - Replace raw `<i class="bi bi-*">` with `<Icon>`
+   - Replace raw `<i class="bi bi-*">` with `<Icon>` **when the icon is registered in the `Icon` component**. If the icon isn't registered, raw `<i class="bi bi-...">` is acceptable — OR add the icon to the `Icon` component's registered set. Don't silently drop icons the project needs.
    - Replace raw card markup with `<Card>`
-   - Follow existing page patterns for layout and structure
+   - Follow existing page patterns for layout and structure — see "Anatomy of a list page" and "Anatomy of a detail page" below
 
-6. **WCAG AA check:**
+7. **WCAG AA check:**
    - All interactive elements are keyboard-focusable
    - `aria-label` on icon-only buttons (CircularButton enforces this)
    - Contrast meets 4.5:1 for text, 3:1 for large text and UI components
    - Semantic HTML elements where appropriate
    - No color-only indicators
 
-7. **Responsive check:**
+8. **Responsive check:**
    - Desktop primary, mobile supported
    - Use Bootstrap breakpoints (`col-sm-`, `col-md-`, `col-lg-`) for layout
    - Test that content doesn't overflow on small screens
 
-8. **If a small primitive is missing** (e.g., a Badge, Divider, or similar):
+9. **If a small primitive is missing** (e.g., a Badge, Divider, or similar):
    - Pause implementation
    - Propose the primitive with 2-3 design questions:
      - What variants does it need?
@@ -52,15 +51,16 @@ Implement UI work using registered primitives from the component library. Enforc
      - Any accessibility requirements?
    - After user confirms, create it in `src/Feirb.Web/Components/UI/`
    - Add styles to `app.css` with `feirb-` prefix
-   - Update `docs/component-library.md`
+   - **Add a showcase page** at `src/Feirb.Web/Pages/Showcase/Showcase{Name}.razor` (see "Showcase requirement" below)
+   - **Update `docs/component-library.md`** with a full registry entry
    - Continue implementation
 
-9. **If a large primitive is missing** (e.g., Modal, DataTable, Toolbar redesign):
+10. **If a large primitive is missing** (e.g., Modal, DataTable, Toolbar redesign):
     - Propose a GitHub issue for the primitive
     - User decides: create issue and defer, or build it now
-    - If building now, follow the same pattern as step 8 but with full design exploration
+    - If building now, follow the same pattern as step 9 but with full design exploration
 
-10. **If UX exploration is needed** (interaction patterns, layout decisions, responsive behavior):
+11. **If UX exploration is needed** (interaction patterns, layout decisions, responsive behavior):
     - Suggest using `/designer-grill-me` for design exploration
     - Wait for design decisions before implementing
 
@@ -70,41 +70,371 @@ Implement UI work using registered primitives from the component library. Enforc
 - Non-covered elements (modals, forms, tables, menus): use Bootstrap classes but encourage componentization
 - If a non-covered pattern appears 2+ times, create a refactoring issue
 - All icon-only buttons MUST use `<CircularButton>` with `AriaLabel`
-- All icons MUST use `<Icon>` component
+- All icons SHOULD use `<Icon>` component — raw `<i class="bi bi-...">` is acceptable ONLY when the icon isn't in the Icon component's registered set. Prefer adding the icon to the `Icon` component if it's used more than once.
 - All standalone buttons MUST use `<Button>` component
 - Cards for content containers MUST use `<Card>` component
+- **Every new shared component MUST have a showcase page AND a registry entry** (see "Showcase requirement" below)
+- **Repeated caller ritual = bake it in.** If the same class/prop/wrapper appears at 3+ call sites of a component (e.g. `Class="mb-4"` on every `<ContentSection>`), move it into the component itself. Callers shouldn't have to remember defaults.
+
+## Showcase requirement
+
+Every shared component in `src/Feirb.Web/Components/` (top-level or `UI/`) must have a matching showcase page at `src/Feirb.Web/Pages/Showcase/Showcase{Name}.razor`. The showcase should:
+
+1. **Summary card** — one-sentence description + parameter table (name / type / default / description)
+2. **Preview card** — interactive controls (inputs/selects) that map to parameters, with the component rendered below
+3. **Variant/state cards** — one per distinct visual state (e.g. all sizes, all status badges, empty vs loaded)
+4. **Code card** — live-updating code snippet reflecting the current preview settings
+
+When adding a new component, create the showcase page in the same commit and link it from `docs/component-library.md`. The showcase is the canonical place for humans to explore the component; the registry is the canonical place for LLMs to look up its API.
+
+Services without visual components (e.g. `NotificationService`, `BreadcrumbOverrideService`) don't need a showcase — but they still need a registry entry.
+
+## Anatomy of a list page
+
+Recurring shape for any "list of entities with detail subpages" page (Labels, Mailboxes, Admin Users, Address Book). Use this as the starting skeleton.
+
+```razor
+@page "/entities"
+@attribute [Authorize]
+@using Feirb.Shared.Entities
+@using Feirb.Web.Components.UI
+@inject HttpClient Http
+@inject IStringLocalizer<SharedResources> L
+@inject NavigationManager Navigation
+@inject ToolbarStateService ToolbarState
+@implements IDisposable
+
+<PageTitle>@L["EntitiesPageTitle"]</PageTitle>
+
+<InfoHeader Title="@L["EntitiesPageTitle"]" Icon="collection" Subtitle="@L["EntitiesPageSubtitle"]" />
+
+<ContentSection Icon="list-ul" Title="@L["EntitiesHeading"]" Subtitle="@L["EntitiesSubtitle"]">
+    @if (_loading)
+    {
+        <div class="text-center py-4"><div class="spinner-border spinner-border-sm" role="status"></div></div>
+    }
+    else if (_page is null || _page.Items.Count == 0)
+    {
+        <StatusMessage Icon="inbox" Title="@L["NoEntitiesTitle"]" Message="@L["NoEntitiesMessage"]" />
+    }
+    else
+    {
+        <Table Hover>
+            <TableHeader>
+                <TableColumn>@L["ColumnName"]</TableColumn>
+                <TableColumn Width="10rem">@L["ColumnUpdated"]</TableColumn>
+            </TableHeader>
+            <TableBody>
+                @foreach (var item in _page.Items)
+                {
+                    <TableRow OnClick="() => Navigation.NavigateTo($"/entities/{item.Id}")" data-testid="entity-row">
+                        <TableCell>@item.Name</TableCell>
+                        <TableCell>@item.UpdatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</TableCell>
+                    </TableRow>
+                }
+            </TableBody>
+        </Table>
+        <Pagination CurrentPage="_currentPage" TotalPages="_page.TotalPages"
+                    CurrentPageChanged="OnPageChangedAsync"
+                    PreviousLabel="@L["PaginationPrevious"]" NextLabel="@L["PaginationNext"]" />
+    }
+</ContentSection>
+
+@code {
+    private const int _pageSize = 25;
+    private PagedResult<EntityListItem>? _page;
+    private bool _loading = true;
+    private int _currentPage = 1;
+    private ToolbarAction[] _toolbarActions = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        _toolbarActions =
+        [
+            new ToolbarAction(L["ButtonCreate"], ButtonVariant.Primary,
+                () => { Navigation.NavigateTo("/entities/new"); return Task.CompletedTask; }, "plus-lg"),
+        ];
+        ToolbarState.AddActions(_toolbarActions);
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        try { _page = await Http.GetFromJsonAsync<PagedResult<EntityListItem>>($"/api/entities?page={_currentPage}&pageSize={_pageSize}"); }
+        catch { _page = null; }
+        finally { _loading = false; }
+    }
+
+    private async Task OnPageChangedAsync(int page) { _currentPage = page; await LoadAsync(); }
+
+    public void Dispose() => ToolbarState.RemoveActions(_toolbarActions);
+}
+```
+
+## Anatomy of a detail page
+
+Recurring shape for any "edit a single entity" page. Use this as the starting skeleton.
+
+```razor
+@page "/entities/{Id:guid}"
+@attribute [Authorize]
+@using Feirb.Shared.Entities
+@using Feirb.Web.Components.UI
+@inject HttpClient Http
+@inject IStringLocalizer<SharedResources> L
+@inject NavigationManager Navigation
+@inject NotificationService Notifications
+@inject BreadcrumbOverrideService BreadcrumbOverride
+@inject ToolbarStateService ToolbarState
+@inject UnsavedChangesService UnsavedChanges
+@implements IDisposable
+
+<PageTitle>@(_entity?.DisplayName ?? L["EntityDetailPageTitle"])</PageTitle>
+
+<InfoHeader Title="@(_entity?.DisplayName ?? L["EntityDetailPageTitle"])" Icon="person-fill" Subtitle="@L["EntityDetailSubtitle"]" />
+
+@if (_loading)
+{
+    <div class="text-center py-5"><div class="spinner-border" role="status"></div></div>
+}
+else if (_entity is null)
+{
+    <StatusMessage Icon="question-circle" Title="@L["EntityNotFoundTitle"]" Message="@L["EntityNotFoundMessage"]" />
+}
+else
+{
+    <ContentSection Icon="pencil" Title="@L["EntityDetailPageTitle"]" Subtitle="@_entity.DisplayName">
+        <TrackedEditForm Model="_model" OnSave="HandleSaveAsync">
+            <DataAnnotationsValidator />
+            <div class="mb-3">
+                <label for="entityName" class="form-label">@L["EntityDisplayName"]</label>
+                <InputText id="entityName" class="form-control" @bind-Value="_model.DisplayName" data-testid="entity-display-name" />
+                <ValidationMessage For="() => _model.DisplayName" />
+            </div>
+        </TrackedEditForm>
+    </ContentSection>
+}
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    private EntityResponse? _entity;
+    private bool _loading = true;
+    private FormModel _model = new();
+    private ToolbarAction[] _toolbarActions = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        _toolbarActions =
+        [
+            new ToolbarAction(L["ButtonCancel"], ButtonVariant.Warning,
+                () => { Navigation.NavigateTo("/entities"); return Task.CompletedTask; }, "x-lg"),
+            new ToolbarAction(L["ButtonSave"], ButtonVariant.Primary,
+                async () => { await UnsavedChanges.SaveAllAsync(); }, "check-lg"),
+            new ToolbarAction(L["ButtonDelete"], ButtonVariant.Danger, HandleDeleteAsync, "trash"),
+        ];
+        ToolbarState.AddActions(_toolbarActions);
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        try
+        {
+            _entity = await Http.GetFromJsonAsync<EntityResponse>($"/api/entities/{Id}");
+            if (_entity is not null)
+            {
+                _model = new FormModel { DisplayName = _entity.DisplayName };
+                BreadcrumbOverride.SetLastSegmentLabel(_entity.DisplayName);
+            }
+        }
+        catch { _entity = null; }
+        finally { _loading = false; }
+    }
+
+    private async Task<bool> HandleSaveAsync()
+    {
+        var response = await Http.PutAsJsonAsync($"/api/entities/{Id}", new UpdateEntityRequest(_model.DisplayName!));
+        if (response.IsSuccessStatusCode)
+        {
+            Notifications.Add(L["ButtonSave"], NotificationSeverity.Success);
+            await LoadAsync();
+            return true;
+        }
+        Notifications.Add("Save failed", NotificationSeverity.Error);
+        return false;
+    }
+
+    private async Task HandleDeleteAsync()
+    {
+        var response = await Http.DeleteAsync($"/api/entities/{Id}");
+        if (response.IsSuccessStatusCode)
+        {
+            Notifications.Add(L["ButtonDelete"], NotificationSeverity.Success);
+            Navigation.NavigateTo("/entities");
+        }
+        else
+        {
+            Notifications.Add("Delete failed", NotificationSeverity.Error);
+        }
+    }
+
+    public void Dispose()
+    {
+        ToolbarState.RemoveActions(_toolbarActions);
+        BreadcrumbOverride.Clear();
+    }
+
+    private sealed class FormModel
+    {
+        [System.ComponentModel.DataAnnotations.Required]
+        [System.ComponentModel.DataAnnotations.StringLength(256)]
+        public string? DisplayName { get; set; }
+    }
+}
+```
+
+## Breadcrumb integration
+
+The `Breadcrumb` component is rendered by the layout — pages do **not** include it manually. It walks the current URL and maps each segment to a label + href.
+
+**When adding a new route, update two maps in `src/Feirb.Web/Components/Breadcrumb.razor`:**
+
+1. **`ResolveLabel`** — add a case for every URL segment (and intermediate segment) your page introduces. Without this, the breadcrumb shows the raw URL segment.
+
+   ```csharp
+   "entities" => L["EntitiesNavLabel"],
+   "entities/new" => L["EntitiesNew"],
+   ```
+
+2. **`ResolveHref`** — if an intermediate URL segment has no landing page, redirect the crumb elsewhere. Without this, clicking the crumb 404s.
+
+   ```csharp
+   "entities/subgroup" => "/entities",   // no page at /entities/subgroup
+   ```
+
+**For detail pages with GUID segments**, inject `BreadcrumbOverrideService` and call `SetLastSegmentLabel(...)` after loading the entity. Always clear it in `Dispose` (see the detail-page template above).
+
+## Page-level actions — Toolbar pattern
+
+**Page-level actions belong in the Toolbar, not inline in the page.** Inline buttons only for section-scoped actions (e.g. "Unlink" inside a "Linked Contact" section).
+
+For **edit/detail pages** (any page that edits a single entity via a form), register these toolbar actions in `OnInitializedAsync`:
+
+| Action | Variant | Icon | Behavior |
+|--------|---------|------|----------|
+| **Cancel** | `Warning` | `x-lg` | Navigate back to the listing. `UnsavedChangesService` warns if dirty. |
+| **Save** | `Primary` | `check-lg` | Call `UnsavedChanges.SaveAllAsync()` — validates and submits the `TrackedEditForm`. |
+| **Delete** | `Danger` | `trash` | Direct delete, no form involvement. |
+
+**Never use a plain "Back" button** on form pages — the breadcrumb already provides navigation, and Cancel carries the additional "discard unsaved edits" semantic.
+
+Standard keys: `ButtonCancel`, `ButtonSave`, `ButtonDelete`. Don't invent locale keys for page-specific wording unless the action is meaningfully different.
+
+### Template
+
+```csharp
+@inject ToolbarStateService ToolbarState
+@inject UnsavedChangesService UnsavedChanges
+@implements IDisposable
+
+@* ... *@
+<ContentSection Icon="..." Title="...">
+    <TrackedEditForm Model="_model" OnSave="HandleSaveAsync">
+        <DataAnnotationsValidator />
+        @* form fields *@
+    </TrackedEditForm>
+</ContentSection>
+
+@code {
+    private ToolbarAction[] _toolbarActions = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        _toolbarActions =
+        [
+            new ToolbarAction(L["ButtonCancel"], ButtonVariant.Warning,
+                () => { Navigation.NavigateTo("/listing"); return Task.CompletedTask; }, "x-lg"),
+            new ToolbarAction(L["ButtonSave"], ButtonVariant.Primary,
+                async () => { await UnsavedChanges.SaveAllAsync(); }, "check-lg"),
+            new ToolbarAction(L["ButtonDelete"], ButtonVariant.Danger, HandleDeleteAsync, "trash"),
+        ];
+        ToolbarState.AddActions(_toolbarActions);
+        await LoadAsync();
+    }
+
+    private async Task<bool> HandleSaveAsync()
+    {
+        // PUT/POST the form model. Return true on success (marks form clean).
+    }
+
+    public void Dispose() => ToolbarState.RemoveActions(_toolbarActions);
+}
+```
+
+**Conditional toolbar actions:** If an action depends on entity state (e.g. "Add to contacts" only when the entity is orphaned), rebuild `_toolbarActions` at the end of `LoadAsync()` via a `RebuildToolbar()` helper that removes the old array and adds a freshly-constructed one.
+
+**Form dirty tracking:** Always use `<TrackedEditForm>`, not raw `<EditForm>`, on detail pages. It registers with `UnsavedChangesService` automatically — the Cancel button then warns on dirty, and Save is driven by `SaveAllAsync()`.
 
 ## New Component Scaffolding
 
 When creating new components, use the following structure:
 
-### `.razor` file (`src/Feirb.Web/Components/{ComponentName}.razor`)
+### `.razor` file (`src/Feirb.Web/Components/UI/{ComponentName}.razor`)
 
 ```razor
-@namespace Feirb.Web.Components
-@inject IStringLocalizer<SharedResources> L
+@namespace Feirb.Web.Components.UI
 
-@* Use semantic HTML elements — not just <div> soup *@
-<section class="container" aria-label="@L["{ComponentName}Section"]">
-    @* Component markup using Bootstrap 5 classes *@
-</section>
+@* One-line purpose comment describing the component. *@
+<div class="feirb-@(_cssName.ToLowerInvariant()) @Class" @attributes="AdditionalAttributes">
+    @* Component markup — use existing primitives where possible *@
+    @ChildContent
+</div>
+
+@code {
+    /// <summary>Child content.</summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>Additional CSS classes.</summary>
+    [Parameter]
+    public string? Class { get; set; }
+
+    /// <summary>Any extra HTML attributes.</summary>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private const string _cssName = "{componentname}";
+}
 ```
 
-### Code-behind (`.razor.cs`)
+### Scoped CSS (`.razor.css`, co-located)
+
+```css
+/* ComponentName — one-line purpose */
+.feirb-{componentname} {
+    /* use design tokens from app.css, not literal colors */
+    color: var(--bs-body-color);
+    background: var(--feirb-surface);
+}
+```
+
+### Code-behind (only when needed)
+
+For non-trivial logic, create `{ComponentName}.razor.cs` as a partial class. Simple components with only `[Parameter]` properties can keep code inside `@code { }` — don't split unnecessarily.
 
 ```csharp
-using Microsoft.Extensions.Localization;
-
-namespace Feirb.Web.Components;
+namespace Feirb.Web.Components.UI;
 
 public partial class {ComponentName} : ComponentBase
 {
-    [Inject]
-    private IStringLocalizer<SharedResources> L { get; set; } = default!;
-
-    // Component parameters and logic
+    // Non-trivial logic here
 }
 ```
+
+**Razor vs code-behind rule of thumb:** if the `@code { }` block is under ~40 lines and has no complex state machines, keep it inline. Split only when the logic becomes hard to read next to the markup.
 
 ### Component design patterns
 

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ tests/playwright/dist/
 # Local Ollama model data
 .ollama-data/
 .playwright-mcp/
+
+# Claude Code runtime state
+.claude/scheduled_tasks.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,17 @@ Shell scripts in `.claude/skills/dev-harness/` for autonomous app interaction:
 - **Adding a new locale:** Create `.{locale}.resx` files in both `Resources/` directories, add culture code to `supportedCultures` in `Feirb.Api/Program.cs`, add option to `LanguageSwitcher.razor`
 - **Adding a new string:** Add key to all `.resx` files (default + all locales), use `L["Key"]` in components or `localizer["Key"]` in API endpoints
 
+## UI/UX Work (`/implement-ui`)
+
+**You MUST invoke the `/implement-ui` skill before touching any Razor file for UI/UX work** — new pages, new components, layout changes, or non-trivial styling. The skill enforces the shared component library, documents hard rules (Button/Icon/Card/CircularButton usage), and captures project-wide patterns like the toolbar actions convention on edit/detail pages.
+
+Exceptions (inline edits OK, no skill needed):
+- Fixing a typo, broken `@onclick`, or a localization key
+- Wiring an existing page to a new API endpoint with no visual changes
+- Bug fixes that don't change the DOM structure
+
+When in doubt, invoke the skill.
+
 ## Browser Testing (Playwright MCP)
 
 Use `/test-ui <path> <what to test>` to verify UI features via browser. The skill:

--- a/docs/component-library.md
+++ b/docs/component-library.md
@@ -1,7 +1,11 @@
 # Feirb Component Library
 
-Shared UI primitives in `src/Feirb.Web/Components/UI/`.
+Shared UI primitives in `src/Feirb.Web/Components/UI/` and higher-level layout components in `src/Feirb.Web/Components/`.
 Global styles in `src/Feirb.Web/wwwroot/css/app.css` (prefixed `feirb-`).
+
+**Every component listed here has a matching showcase page** at `/components-showcase/<name>` — use it to see the component rendered with interactive parameter controls.
+
+**If you need a component and it's not in this file**, grep `src/Feirb.Web/Components/` before concluding it doesn't exist. The registry is authoritative for documented primitives but may lag behind new additions. If you find an undocumented component, add it here as part of your change.
 
 ## Icon
 
@@ -327,6 +331,386 @@ Card component for displaying mail items across different layout contexts. Whole
 | `Color` | `string?` | Hex color for background (falls back to black) |
 
 **Primitives used:** `Card` (implicit via styling), `Icon` (avatar, read indicator), `LabelPill` (labels)
+
+## Table
+
+Grid-based table with ARIA semantics. Children: `TableHeader` + `TableBody`. Columns defined via `TableColumn`; row cells via `TableCell`. Column widths cascade to the grid via `TableColumn.Width`.
+
+```razor
+<Table Hover>
+    <TableHeader>
+        <TableColumn>Name</TableColumn>
+        <TableColumn>Email</TableColumn>
+        <TableColumn Width="8rem">Created</TableColumn>
+        <TableColumn Width="6rem">Actions</TableColumn>
+    </TableHeader>
+    <TableBody>
+        @foreach (var user in _users)
+        {
+            <TableRow OnClick="() => NavigateToDetail(user.Id)" data-testid="user-row">
+                <TableCell>@user.Name</TableCell>
+                <TableCell>@user.Email</TableCell>
+                <TableCell>@user.CreatedAt.ToString("yyyy-MM-dd")</TableCell>
+                <TableCell>
+                    <Button Variant="ButtonVariant.Danger" Size="ButtonSize.Small" Icon="trash" OnClick="() => Delete(user)" />
+                </TableCell>
+            </TableRow>
+        }
+    </TableBody>
+</Table>
+```
+
+### Table Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ChildContent` | `RenderFragment` (required) | — | `TableHeader` + `TableBody` |
+| `Size` | `TableSize` | `Default` | `Default` or `Small` |
+| `Hover` | `bool` | `false` | Highlight row on hover |
+| `Striped` | `bool` | `false` | Alternating row background |
+| `Class` | `string?` | `null` | Extra CSS classes |
+
+### TableColumn Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ChildContent` | `RenderFragment` | — | Column header text |
+| `Width` | `string` | `"1fr"` | CSS grid column width (e.g. `"8rem"`, `"2fr"`) |
+
+### TableRow Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ChildContent` | `RenderFragment` (required) | — | `TableCell` elements |
+| `OnClick` | `EventCallback<MouseEventArgs>` | — | When set, row gets `clickable` class and cursor; use for row-level navigation |
+| `Class` | `string?` | `null` | Extra CSS classes |
+
+**Clickable rows:** If `OnClick` is set, the row automatically becomes keyboard-focusable and the `clickable` class is applied. Don't add explicit `Clickable` parameter — it doesn't exist.
+
+## Pagination
+
+Theme-aware previous/next pager with page indicator and optional page size selector.
+
+```razor
+<Pagination CurrentPage="_page"
+            TotalPages="_totalPages"
+            CurrentPageChanged="OnPageChangedAsync"
+            PreviousLabel="@L["PaginationPrevious"]"
+            NextLabel="@L["PaginationNext"]" />
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `CurrentPage` | `int` (required) | — | 1-based current page |
+| `TotalPages` | `int` (required) | — | Total number of pages |
+| `CurrentPageChanged` | `EventCallback<int>` (required) | — | Fires when page changes |
+| `PageSize` | `int` | `5` | Current page size |
+| `PageSizeChanged` | `EventCallback<int>` | — | When set, page size selector is shown |
+| `PageSizeOptions` | `int[]` | `[5, 10, 25, 50, 100]` | Sizes offered in the selector |
+| `PreviousLabel` | `string` | `"Previous"` | Always pass the localized `L["PaginationPrevious"]` |
+| `NextLabel` | `string` | `"Next"` | Always pass the localized `L["PaginationNext"]` |
+| `PerPageLabel` | `string` | `"per page"` | Label shown next to size selector |
+| `Sticky` | `bool` | `false` | Stick to bottom of viewport |
+| `Class` | `string?` | `null` | Extra CSS classes |
+
+The component renders nothing if `TotalPages <= 1` and no size selector is requested.
+
+## PersonChip
+
+Compact person display with avatar, name, optional email, and optional status badge. Located in `src/Feirb.Web/Components/UI/`.
+
+```razor
+<PersonChip Name="Alice Johnson" Email="alice@example.com" />
+<PersonChip Name="Bob Smith" Email="bob@example.com" Size="PersonChipSize.Small" Status="RecipientStatus.Important" />
+<PersonChip Name="Unknown Sender" Email="someone@external.com" Size="PersonChipSize.Mini" Status="RecipientStatus.Unknown" />
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `Name` | `string` (required) | — | Display name |
+| `Email` | `string?` | `null` | Email address (hidden in Mini size) |
+| `Size` | `PersonChipSize` | `Default` | `Default`, `Small`, `Mini` |
+| `Status` | `RecipientStatus` | `None` | `None` (no badge), `Known`, `Unknown`, `Important`, `Blocked` |
+| `StatusTitle` | `string?` | `null` | Tooltip for the status badge |
+| `Class` | `string?` | `null` | Extra CSS classes |
+
+**Avatar lookup:** If `Email` is set, the component fetches `/api/avatars/{hash}` automatically. The endpoint returns `204` when no avatar exists — the component falls back to a dashed placeholder icon.
+
+**Status badge colors:** `Known` → primary, `Unknown` → secondary, `Important` → warning, `Blocked` → danger. `None` renders no badge (use for chips outside address-book context like Compose recipient tokens).
+
+## Toggle
+
+Switch-style boolean input with optional separate label for the off state.
+
+```razor
+<Toggle Text="@L["CcBccVisible"]" DisabledText="@L["CcBccHidden"]" @bind-Value="_showCcBcc" />
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `Value` | `bool` | `false` | Current state |
+| `ValueChanged` | `EventCallback<bool>` | — | Use `@bind-Value` |
+| `Text` | `string` (required) | — | Label when on (also used when off unless `DisabledText` is set) |
+| `DisabledText` | `string?` | `null` | Label when off; if null, `Text` is shown strikethrough |
+| `For` | `Expression<Func<bool>>?` | `null` | For EditContext integration in forms |
+| `Class` | `string?` | `null` | Extra CSS classes |
+
+## StatusMessage
+
+Centered empty/error state display with icon, title, message, and optional action link.
+
+```razor
+<StatusMessage Icon="inbox"
+               Title="@L["NoMessages"]"
+               Message="@L["NoMessagesDescription"]"
+               ButtonText="@L["ComposeNew"]"
+               ButtonHref="/compose" />
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `Icon` | `string` (required) | — | Bootstrap Icon name without `bi-` prefix |
+| `Title` | `string` (required) | — | Heading text |
+| `Message` | `string` (required) | — | Descriptive message below the heading |
+| `ButtonText` | `string?` | `null` | Optional action button label |
+| `ButtonHref` | `string?` | `null` | Action button target (required if `ButtonText` is set) |
+| `IsFullPage` | `bool` | `false` | Render title as `h1` (for full-page errors like 404) |
+
+Use for empty lists, 404 pages, and loading failures. For inline errors inside forms, use Bootstrap alert classes or `ValidationMessage`.
+
+## RecipientInput
+
+Tokenizing input for email recipients with PersonChip tokens, paste-splitting, and autocomplete. Used in Compose.
+
+```razor
+<RecipientInput @bind-Recipients="_to"
+                Id="compose-to"
+                Placeholder="@L["ComposePlaceholderTo"]"
+                DataTestId="compose-to"
+                ContactsProvider="SearchRecipientsAsync" />
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `Recipients` | `List<RecipientEntry>` (required) | `[]` | Current tokenized recipients; use `@bind-Recipients` |
+| `RecipientsChanged` | `EventCallback<List<RecipientEntry>>` | — | Use `@bind-Recipients` |
+| `Contacts` | `IReadOnlyList<RecipientEntry>` | `[]` | Static suggestion list (fallback if no provider) |
+| `ContactsProvider` | `Func<string, Task<IReadOnlyList<RecipientEntry>>>?` | `null` | Async query→results provider; takes precedence over `Contacts` |
+| `Placeholder` | `string?` | `null` | Placeholder when no recipients |
+| `Id` | `string?` | `null` | HTML id (enables `<label for=...>`) |
+| `DataTestId` | `string?` | `null` | Test ID on the inner input |
+| `Class` | `string?` | `null` | Extra CSS classes (use `is-invalid` for error state) |
+
+**Confirmation triggers:** Enter, Tab, comma, semicolon, space, or blur. Paste splits on comma/semicolon/newline. Duplicates flash the existing chip.
+
+## Breadcrumb
+
+Auto-segmented navigation trail based on the current URL. Rendered by the layout, **do not include it manually on pages**. Located in `src/Feirb.Web/Components/`.
+
+### Label map
+
+Path segments are resolved to labels via a `switch` in `Breadcrumb.razor` (`ResolveLabel` method). **When you add a new page**, add a case for every intermediate URL segment:
+
+```csharp
+private string ResolveLabel(string fullPath, string segment) =>
+    fullPath switch
+    {
+        "address-book" => L["AddressBookNavLabel"],
+        "address-book/contacts" => L["AddressBookContactsHeading"],
+        "address-book/addresses" => L["AddressBookAddressesHeading"],
+        // ...
+        _ => segment
+    };
+```
+
+### Href map
+
+Intermediate segments without their own landing page must point somewhere valid. Override in `ResolveHref`:
+
+```csharp
+private static string ResolveHref(string fullPath) =>
+    fullPath switch
+    {
+        "address-book/contacts" => "/address-book",   // no listing page at /address-book/contacts
+        "address-book/addresses" => "/address-book",
+        _ => $"/{fullPath}"
+    };
+```
+
+Otherwise the breadcrumb link will 404 when clicked.
+
+### BreadcrumbOverrideService
+
+For detail pages, the last URL segment is typically a GUID. Inject `BreadcrumbOverrideService` and set a human-readable label in `OnInitializedAsync` / after data loads:
+
+```csharp
+@inject BreadcrumbOverrideService BreadcrumbOverride
+@implements IDisposable
+
+protected override async Task OnInitializedAsync()
+{
+    var entity = await Http.GetFromJsonAsync<Entity>($"/api/entities/{Id}");
+    BreadcrumbOverride.SetLastSegmentLabel(entity.DisplayName);
+}
+
+public void Dispose() => BreadcrumbOverride.Clear();
+```
+
+Always clear the override in `Dispose` so it doesn't leak to the next page.
+
+## Toolbar
+
+Page-level action bar rendered by the layout (`src/Feirb.Web/Components/Toolbar.razor`). Pages don't render the Toolbar themselves — they register actions via `ToolbarStateService`, and the layout renders them.
+
+### ToolbarStateService
+
+Scoped service. Inject in any page that needs toolbar actions:
+
+```csharp
+@inject ToolbarStateService ToolbarState
+@implements IDisposable
+
+@code {
+    private ToolbarAction[] _toolbarActions = [];
+
+    protected override void OnInitialized()
+    {
+        _toolbarActions =
+        [
+            new ToolbarAction(L["ButtonCancel"], ButtonVariant.Warning,
+                () => { Navigation.NavigateTo("/listing"); return Task.CompletedTask; }, "x-lg"),
+            new ToolbarAction(L["ButtonSave"], ButtonVariant.Primary,
+                async () => { await UnsavedChanges.SaveAllAsync(); }, "check-lg"),
+            new ToolbarAction(L["ButtonDelete"], ButtonVariant.Danger, HandleDeleteAsync, "trash"),
+        ];
+        ToolbarState.AddActions(_toolbarActions);
+    }
+
+    public void Dispose() => ToolbarState.RemoveActions(_toolbarActions);
+}
+```
+
+### ToolbarAction
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Label` | `string` | Button label (always localized) |
+| `Variant` | `ButtonVariant` | Visual variant — see conventions below |
+| `OnClickAsync` | `Func<Task>` | Async click handler |
+| `Icon` | `string?` | Bootstrap Icon name without `bi-` prefix |
+
+### Variant conventions on detail pages
+
+| Action | Variant | Icon |
+|--------|---------|------|
+| **Cancel** | `Warning` | `x-lg` |
+| **Save** | `Primary` | `check-lg` |
+| **Delete** | `Danger` | `trash` |
+| **Create/Add** | `Primary` | `plus-lg` |
+| **Secondary actions** (e.g. "Add to contacts") | `Secondary` | context-specific |
+
+**Never use a plain "Back" button in the toolbar on form pages** — the breadcrumb already provides navigation, and Cancel carries the additional "discard unsaved edits" semantic.
+
+### Conditional actions
+
+If an action depends on entity state, rebuild the array at the end of your data-load method:
+
+```csharp
+private void RebuildToolbar()
+{
+    ToolbarState.RemoveActions(_toolbarActions);
+    var actions = new List<ToolbarAction> { /* always-present actions */ };
+    if (_entity.NeedsExtraAction)
+        actions.Add(new ToolbarAction(...));
+    _toolbarActions = [.. actions];
+    ToolbarState.AddActions(_toolbarActions);
+}
+```
+
+## TrackedEditForm
+
+Form wrapper that integrates with `UnsavedChangesService` for dirty tracking and toolbar-driven save. Use this **instead of raw `<EditForm>`** on any detail/edit page. Located in `src/Feirb.Web/Components/`.
+
+```razor
+@inject UnsavedChangesService UnsavedChanges
+
+<ContentSection Icon="person-gear" Title="@L["ContactDetailPageTitle"]">
+    <TrackedEditForm Model="_model" OnSave="HandleSaveAsync">
+        <DataAnnotationsValidator />
+        <div class="mb-3">
+            <label for="displayName" class="form-label">@L["DisplayName"]</label>
+            <InputText id="displayName" class="form-control" @bind-Value="_model.DisplayName" />
+            <ValidationMessage For="() => _model.DisplayName" />
+        </div>
+    </TrackedEditForm>
+</ContentSection>
+
+@code {
+    private async Task<bool> HandleSaveAsync()
+    {
+        var response = await Http.PutAsJsonAsync($"/api/entities/{Id}", _model);
+        if (response.IsSuccessStatusCode)
+        {
+            Notifications.Add(L["ButtonSave"], NotificationSeverity.Success);
+            return true;   // marks form clean
+        }
+        Notifications.Add("Save failed", NotificationSeverity.Error);
+        return false;
+    }
+}
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `Model` | `object` (required) | — | The form model to bind to |
+| `ChildContent` | `RenderFragment?` | — | Form fields + validator |
+| `OnSave` | `Func<Task<bool>>` (required) | — | Save handler; return `true` to mark clean |
+
+**How it works:**
+- Registers with `UnsavedChangesService` on init
+- Tracks `EditContext.OnFieldChanged` to flip the dirty bit
+- `SubmitAsync()` (called internally by `UnsavedChanges.SaveAllAsync()`) validates then invokes `OnSave`
+- Clean state is restored automatically when `OnSave` returns `true`
+
+### UnsavedChangesService
+
+The service is scoped and auto-registers on the layout. You only interact with it from toolbar actions:
+
+```csharp
+new ToolbarAction(L["ButtonSave"], ButtonVariant.Primary,
+    async () => { await UnsavedChanges.SaveAllAsync(); }, "check-lg"),
+```
+
+`SaveAllAsync()` calls `SubmitAsync()` on every registered `TrackedEditForm` — almost always exactly one per page.
+
+## NotificationService
+
+Scoped service for user-facing toast notifications. Four severities with auto-dismiss timings.
+
+```csharp
+@inject NotificationService Notifications
+
+Notifications.Add(L["SuccessSaved"], NotificationSeverity.Success);
+Notifications.Add("Failed to save", NotificationSeverity.Error);
+```
+
+| Severity | Auto-dismiss | Usage |
+|----------|-------------|-------|
+| `Success` | 10s | Successful mutation (save, create, delete) |
+| `Info` | 10s | Neutral info ("Sync started") |
+| `Warning` | 30s | Recoverable problem ("Retry suggested") |
+| `Error` | never | Failed mutation or unexpected error — user must dismiss |
+
+The layout renders active notifications via `ToastContainer`. Don't render toasts yourself.
+
+**When to use:**
+- CRUD mutation outcome (success + failure both get a toast)
+- Long-running background task completion
+- Network failures on page load
+
+**When NOT to use:**
+- Form validation errors → use `<ValidationMessage>` inline
+- Page state changes triggered directly by user click (click usually provides its own feedback)
 
 ## Enums
 

--- a/docs/component-library.md
+++ b/docs/component-library.md
@@ -421,8 +421,8 @@ Compact person display with avatar, name, optional email, and optional status ba
 
 ```razor
 <PersonChip Name="Alice Johnson" Email="alice@example.com" />
-<PersonChip Name="Bob Smith" Email="bob@example.com" Size="PersonChipSize.Small" Status="RecipientStatus.Important" />
-<PersonChip Name="Unknown Sender" Email="someone@external.com" Size="PersonChipSize.Mini" Status="RecipientStatus.Unknown" />
+<PersonChip Name="Bob Smith" Email="bob@example.com" Size="PersonChipSize.Small" Status="AddressStatus.Important" />
+<PersonChip Name="Unknown Sender" Email="someone@external.com" Size="PersonChipSize.Mini" Status="AddressStatus.Unknown" />
 ```
 
 | Parameter | Type | Default | Description |
@@ -430,13 +430,26 @@ Compact person display with avatar, name, optional email, and optional status ba
 | `Name` | `string` (required) | — | Display name |
 | `Email` | `string?` | `null` | Email address (hidden in Mini size) |
 | `Size` | `PersonChipSize` | `Default` | `Default`, `Small`, `Mini` |
-| `Status` | `RecipientStatus` | `None` | `None` (no badge), `Known`, `Unknown`, `Important`, `Blocked` |
+| `Status` | `AddressStatus?` | `null` | `null` (no badge), `Unknown`, `Known`, `Important`, `Blocked` |
 | `StatusTitle` | `string?` | `null` | Tooltip for the status badge |
 | `Class` | `string?` | `null` | Extra CSS classes |
 
 **Avatar lookup:** If `Email` is set, the component fetches `/api/avatars/{hash}` automatically. The endpoint returns `204` when no avatar exists — the component falls back to a dashed placeholder icon.
 
-**Status badge colors:** `Known` → primary, `Unknown` → secondary, `Important` → warning, `Blocked` → danger. `None` renders no badge (use for chips outside address-book context like Compose recipient tokens).
+**Status badge colors:** `Known` → success (green), `Unknown` → info (blue), `Important` → warning (yellow), `Blocked` → danger (red). `null` renders no badge (use for chips outside address-book context like Compose recipient tokens).
+
+## HelpHint
+
+Inline help text with a question-circle icon. Used below form controls to explain the current selection or provide contextual guidance.
+
+```razor
+<HelpHint>This address was automatically captured and has not been reviewed yet.</HelpHint>
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ChildContent` | `RenderFragment` (required) | — | Help text |
+| `Class` | `string?` | `null` | Extra CSS classes |
 
 ## Toggle
 

--- a/src/Feirb.Api/Data/Entities/Address.cs
+++ b/src/Feirb.Api/Data/Entities/Address.cs
@@ -1,3 +1,5 @@
+using Feirb.Shared.AddressBook;
+
 namespace Feirb.Api.Data.Entities;
 
 public class Address
@@ -9,8 +11,7 @@ public class Address
     public Contact? Contact { get; set; }
     public required string NormalizedEmail { get; set; }
     public required string DisplayName { get; set; }
-    public bool IsUnknown { get; set; } = true;
-    public bool IsBlocked { get; set; }
+    public AddressStatus Status { get; set; } = AddressStatus.Unknown;
     public DateTime FirstSeenAt { get; set; }
     public DateTime LastSeenAt { get; set; }
     public int SeenCount { get; set; }

--- a/src/Feirb.Api/Data/Entities/Address.cs
+++ b/src/Feirb.Api/Data/Entities/Address.cs
@@ -1,0 +1,17 @@
+namespace Feirb.Api.Data.Entities;
+
+public class Address
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public User User { get; set; } = null!;
+    public Guid? ContactId { get; set; }
+    public Contact? Contact { get; set; }
+    public required string NormalizedEmail { get; set; }
+    public required string DisplayName { get; set; }
+    public bool IsUnknown { get; set; } = true;
+    public bool IsBlocked { get; set; }
+    public DateTime FirstSeenAt { get; set; }
+    public DateTime LastSeenAt { get; set; }
+    public int SeenCount { get; set; }
+}

--- a/src/Feirb.Api/Data/Entities/Contact.cs
+++ b/src/Feirb.Api/Data/Entities/Contact.cs
@@ -7,7 +7,6 @@ public class Contact
     public User User { get; set; } = null!;
     public required string DisplayName { get; set; }
     public string? Notes { get; set; }
-    public bool IsImportant { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
 

--- a/src/Feirb.Api/Data/Entities/Contact.cs
+++ b/src/Feirb.Api/Data/Entities/Contact.cs
@@ -1,0 +1,15 @@
+namespace Feirb.Api.Data.Entities;
+
+public class Contact
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public User User { get; set; } = null!;
+    public required string DisplayName { get; set; }
+    public string? Notes { get; set; }
+    public bool IsImportant { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public ICollection<Address> Addresses { get; set; } = [];
+}

--- a/src/Feirb.Api/Data/FeirbDbContext.cs
+++ b/src/Feirb.Api/Data/FeirbDbContext.cs
@@ -21,6 +21,8 @@ public class FeirbDbContext(DbContextOptions<FeirbDbContext> options) : DbContex
     public DbSet<ClassificationResult> ClassificationResults => Set<ClassificationResult>();
     public DbSet<ClassificationRule> ClassificationRules => Set<ClassificationRule>();
     public DbSet<Avatar> Avatars => Set<Avatar>();
+    public DbSet<Contact> Contacts => Set<Contact>();
+    public DbSet<Address> Addresses => Set<Address>();
     public DbSet<DataProtectionKey> DataProtectionKeys => Set<DataProtectionKey>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -239,6 +241,35 @@ public class FeirbDbContext(DbContextOptions<FeirbDbContext> options) : DbContex
             entity.HasIndex(e => e.EmailHash).IsUnique();
             entity.Property(e => e.EmailHash).HasMaxLength(512);
             entity.Property(e => e.Email).HasMaxLength(256);
+        });
+
+        modelBuilder.Entity<Contact>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasIndex(e => e.UserId);
+            entity.Property(e => e.DisplayName).HasMaxLength(256);
+            entity.Property(e => e.Notes).HasMaxLength(2048);
+            entity.HasOne(e => e.User)
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<Address>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasIndex(e => new { e.UserId, e.NormalizedEmail }).IsUnique();
+            entity.HasIndex(e => e.ContactId);
+            entity.Property(e => e.NormalizedEmail).HasMaxLength(256);
+            entity.Property(e => e.DisplayName).HasMaxLength(256);
+            entity.HasOne(e => e.User)
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne(e => e.Contact)
+                .WithMany(c => c.Addresses)
+                .HasForeignKey(e => e.ContactId)
+                .OnDelete(DeleteBehavior.SetNull);
         });
     }
 }

--- a/src/Feirb.Api/Data/Migrations/20260411103255_AddAddressBook.Designer.cs
+++ b/src/Feirb.Api/Data/Migrations/20260411103255_AddAddressBook.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Feirb.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Feirb.Api.Data.Migrations
 {
     [DbContext(typeof(FeirbDbContext))]
-    partial class FeirbDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411103255_AddAddressBook")]
+    partial class AddAddressBook
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Feirb.Api/Data/Migrations/20260411103255_AddAddressBook.cs
+++ b/src/Feirb.Api/Data/Migrations/20260411103255_AddAddressBook.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Feirb.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAddressBook : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Contacts",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Notes = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
+                    IsImportant = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Contacts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Contacts_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Addresses",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ContactId = table.Column<Guid>(type: "uuid", nullable: true),
+                    NormalizedEmail = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    IsUnknown = table.Column<bool>(type: "boolean", nullable: false),
+                    IsBlocked = table.Column<bool>(type: "boolean", nullable: false),
+                    FirstSeenAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastSeenAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    SeenCount = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Addresses", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Addresses_Contacts_ContactId",
+                        column: x => x.ContactId,
+                        principalTable: "Contacts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_Addresses_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Addresses_ContactId",
+                table: "Addresses",
+                column: "ContactId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Addresses_UserId_NormalizedEmail",
+                table: "Addresses",
+                columns: new[] { "UserId", "NormalizedEmail" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Contacts_UserId",
+                table: "Contacts",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Addresses");
+
+            migrationBuilder.DropTable(
+                name: "Contacts");
+        }
+    }
+}

--- a/src/Feirb.Api/Data/Migrations/20260411184336_RefactorAddressStatus.Designer.cs
+++ b/src/Feirb.Api/Data/Migrations/20260411184336_RefactorAddressStatus.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Feirb.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Feirb.Api.Data.Migrations
 {
     [DbContext(typeof(FeirbDbContext))]
-    partial class FeirbDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411184336_RefactorAddressStatus")]
+    partial class RefactorAddressStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Feirb.Api/Data/Migrations/20260411184336_RefactorAddressStatus.cs
+++ b/src/Feirb.Api/Data/Migrations/20260411184336_RefactorAddressStatus.cs
@@ -1,0 +1,90 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Feirb.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RefactorAddressStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Status",
+                table: "Addresses",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            // Backfill: Blocked > Important > Unknown > Known.
+            // AddressStatus: Unknown=0, Known=1, Important=2, Blocked=3
+            migrationBuilder.Sql(@"
+                UPDATE ""Addresses"" SET ""Status"" = CASE
+                    WHEN ""IsBlocked"" THEN 3
+                    WHEN EXISTS (
+                        SELECT 1 FROM ""Contacts"" c
+                        WHERE c.""Id"" = ""Addresses"".""ContactId""
+                          AND c.""IsImportant"" = TRUE
+                    ) THEN 2
+                    WHEN ""IsUnknown"" THEN 0
+                    ELSE 1
+                END;
+            ");
+
+            migrationBuilder.DropColumn(
+                name: "IsImportant",
+                table: "Contacts");
+
+            migrationBuilder.DropColumn(
+                name: "IsBlocked",
+                table: "Addresses");
+
+            migrationBuilder.DropColumn(
+                name: "IsUnknown",
+                table: "Addresses");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsImportant",
+                table: "Contacts",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsBlocked",
+                table: "Addresses",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsUnknown",
+                table: "Addresses",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            // Reverse backfill: derive the three booleans from Status.
+            // Important is per-contact, so set IsImportant on the Contact whenever
+            // any of its addresses carried Important.
+            migrationBuilder.Sql(@"
+                UPDATE ""Addresses"" SET ""IsBlocked"" = TRUE WHERE ""Status"" = 3;
+                UPDATE ""Addresses"" SET ""IsUnknown"" = TRUE WHERE ""Status"" = 0;
+                UPDATE ""Contacts"" SET ""IsImportant"" = TRUE
+                    WHERE ""Id"" IN (
+                        SELECT DISTINCT ""ContactId"" FROM ""Addresses""
+                        WHERE ""Status"" = 2 AND ""ContactId"" IS NOT NULL
+                    );
+            ");
+
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Addresses");
+        }
+    }
+}

--- a/src/Feirb.Api/Endpoints/AddressBookEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/AddressBookEndpoints.cs
@@ -49,6 +49,8 @@ public static class AddressBookEndpoints
         var query = db.Contacts.AsNoTracking().Where(c => c.UserId == userId);
         if (!string.IsNullOrWhiteSpace(q))
         {
+            // ToLower+Contains is portable across providers (InMemory tests + PostgreSQL).
+            // Could be upgraded to EF.Functions.ILike for better index usage on large datasets.
             var term = q.Trim().ToLower();
             query = query.Where(c => c.DisplayName.ToLower().Contains(term));
         }
@@ -168,6 +170,9 @@ public static class AddressBookEndpoints
 
         if (contact is null)
             return Results.NotFound(new { message = localizer["ContactNotFound"].Value });
+
+        if (string.IsNullOrWhiteSpace(request.DisplayName))
+            return Results.BadRequest(new { message = localizer["ContactDisplayNameRequired"].Value });
 
         contact.DisplayName = request.DisplayName.Trim();
         contact.Notes = request.Notes?.Trim();

--- a/src/Feirb.Api/Endpoints/AddressBookEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/AddressBookEndpoints.cs
@@ -1,0 +1,502 @@
+using System.Security.Claims;
+using Feirb.Api.Data;
+using Feirb.Api.Data.Entities;
+using Feirb.Api.Resources;
+using Feirb.Shared.AddressBook;
+using Feirb.Shared.Mail;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Localization;
+
+namespace Feirb.Api.Endpoints;
+
+public static class AddressBookEndpoints
+{
+    private const int _defaultPageSize = 25;
+    private const int _maxPageSize = 100;
+    private const int _autocompleteLimit = 10;
+
+    public static RouteGroupBuilder MapAddressBookEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/contacts", ListContactsAsync);
+        group.MapGet("/contacts/{id:guid}", GetContactAsync);
+        group.MapPost("/contacts", CreateContactAsync);
+        group.MapPut("/contacts/{id:guid}", UpdateContactAsync);
+        group.MapDelete("/contacts/{id:guid}", DeleteContactAsync);
+
+        group.MapGet("/addresses", ListAddressesAsync);
+        group.MapGet("/addresses/{id:guid}", GetAddressAsync);
+        group.MapPut("/addresses/{id:guid}", UpdateAddressAsync);
+        group.MapDelete("/addresses/{id:guid}", DeleteAddressAsync);
+        group.MapPost("/addresses/{id:guid}/promote", PromoteAddressAsync);
+        group.MapPost("/addresses/{id:guid}/link", LinkAddressAsync);
+        group.MapPost("/addresses/{id:guid}/unlink", UnlinkAddressAsync);
+
+        return group;
+    }
+
+    // --- Contacts ---
+
+    private static async Task<IResult> ListContactsAsync(
+        HttpContext httpContext,
+        FeirbDbContext db,
+        int? page,
+        int? pageSize,
+        string? q)
+    {
+        var userId = GetCurrentUserId(httpContext);
+        var (pageNum, size) = NormalizePaging(page, pageSize);
+
+        var query = db.Contacts.AsNoTracking().Where(c => c.UserId == userId);
+        if (!string.IsNullOrWhiteSpace(q))
+        {
+            var term = q.Trim().ToLower();
+            query = query.Where(c => c.DisplayName.ToLower().Contains(term));
+        }
+
+        var total = await query.CountAsync();
+        var items = await query
+            .OrderBy(c => c.DisplayName)
+            .Skip((pageNum - 1) * size)
+            .Take(size)
+            .Select(c => new ContactListItem(
+                c.Id,
+                c.DisplayName,
+                c.IsImportant,
+                c.Addresses.Count,
+                c.Addresses.OrderBy(a => a.NormalizedEmail).Select(a => a.NormalizedEmail).FirstOrDefault(),
+                c.UpdatedAt))
+            .ToListAsync();
+
+        return Results.Ok(new PagedResult<ContactListItem>(items, total, pageNum, size));
+    }
+
+    private static async Task<IResult> GetContactAsync(
+        Guid id,
+        HttpContext httpContext,
+        FeirbDbContext db,
+        IStringLocalizer<ApiMessages> localizer)
+    {
+        var userId = GetCurrentUserId(httpContext);
+        var contact = await db.Contacts
+            .AsNoTracking()
+            .Include(c => c.Addresses)
+            .FirstOrDefaultAsync(c => c.Id == id && c.UserId == userId);
+
+        if (contact is null)
+            return Results.NotFound(new { message = localizer["ContactNotFound"].Value });
+
+        return Results.Ok(ToContactResponse(contact));
+    }
+
+    private static async Task<IResult> CreateContactAsync(
+        CreateContactRequest request,
+        HttpContext httpContext,
+        FeirbDbContext db,
+        IStringLocalizer<ApiMessages> localizer)
+    {
+        var userId = GetCurrentUserId(httpContext);
+
+        if (string.IsNullOrWhiteSpace(request.DisplayName))
+            return Results.BadRequest(new { message = localizer["ContactDisplayNameRequired"].Value });
+
+        var now = DateTime.UtcNow;
+        var contact = new Contact
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            DisplayName = request.DisplayName.Trim(),
+            Notes = request.Notes?.Trim(),
+            IsImportant = request.IsImportant,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        db.Contacts.Add(contact);
+
+        if (request.Emails is { Count: > 0 })
+        {
+            foreach (var rawEmail in request.Emails)
+            {
+                var normalized = EmailNormalizer.Normalize(rawEmail);
+                if (normalized.Length == 0)
+                    continue;
+
+                var existing = await db.Addresses
+                    .FirstOrDefaultAsync(a => a.UserId == userId && a.NormalizedEmail == normalized);
+
+                if (existing is null)
+                {
+                    db.Addresses.Add(new Address
+                    {
+                        Id = Guid.NewGuid(),
+                        UserId = userId,
+                        ContactId = contact.Id,
+                        NormalizedEmail = normalized,
+                        DisplayName = request.DisplayName.Trim(),
+                        IsUnknown = false,
+                        FirstSeenAt = now,
+                        LastSeenAt = now,
+                        SeenCount = 0,
+                    });
+                }
+                else
+                {
+                    existing.ContactId = contact.Id;
+                    existing.IsUnknown = false;
+                }
+            }
+        }
+
+        await db.SaveChangesAsync();
+
+        var created = await db.Contacts.AsNoTracking()
+            .Include(c => c.Addresses)
+            .FirstAsync(c => c.Id == contact.Id);
+
+        return Results.Created($"/api/address-book/contacts/{contact.Id}", ToContactResponse(created));
+    }
+
+    private static async Task<IResult> UpdateContactAsync(
+        Guid id,
+        UpdateContactRequest request,
+        HttpContext httpContext,
+        FeirbDbContext db,
+        IStringLocalizer<ApiMessages> localizer)
+    {
+        var userId = GetCurrentUserId(httpContext);
+        var contact = await db.Contacts
+            .Include(c => c.Addresses)
+            .FirstOrDefaultAsync(c => c.Id == id && c.UserId == userId);
+
+        if (contact is null)
+            return Results.NotFound(new { message = localizer["ContactNotFound"].Value });
+
+        contact.DisplayName = request.DisplayName.Trim();
+        contact.Notes = request.Notes?.Trim();
+        contact.IsImportant = request.IsImportant;
+        contact.UpdatedAt = DateTime.UtcNow;
+
+        foreach (var addr in contact.Addresses)
+        {
+            if (addr.IsUnknown)
+                addr.IsUnknown = false;
+        }
+
+        await db.SaveChangesAsync();
+        return Results.Ok(ToContactResponse(contact));
+    }
+
+    private static async Task<IResult> DeleteContactAsync(
+        Guid id,
+        HttpContext httpContext,
+        FeirbDbContext db,
+        IStringLocalizer<ApiMessages> localizer)
+    {
+        var userId = GetCurrentUserId(httpContext);
+        var contact = await db.Contacts
+            .Include(c => c.Addresses)
+            .FirstOrDefaultAsync(c => c.Id == id && c.UserId == userId);
+
+        if (contact is null)
+            return Results.NotFound(new { message = localizer["ContactNotFound"].Value });
+
+        // Explicitly orphan linked addresses (do not rely on DB cascade semantics)
+        foreach (var addr in contact.Addresses)
+            addr.ContactId = null;
+
+        db.Contacts.Remove(contact);
+        await db.SaveChangesAsync();
+        return Results.Ok(new { message = localizer["ContactDeleted"].Value });
+    }
+
+    // --- Addresses ---
+
+    private static async Task<IResult> ListAddressesAsync(
+        HttpContext httpContext,
+        FeirbDbContext db,
+        int? page,
+        int? pageSize,
+        string? q)
+    {
+        var userId = GetCurrentUserId(httpContext);
+        var (pageNum, size) = NormalizePaging(page, pageSize);
+
+        var query = db.Addresses.AsNoTracking().Where(a => a.UserId == userId);
+        if (!string.IsNullOrWhiteSpace(q))
+        {
+            var term = q.Trim().ToLower();
+            query = query.Where(a => a.NormalizedEmail.Contains(term) || a.DisplayName.ToLower().Contains(term));
+        }
+
+        var total = await query.CountAsync();
+        var items = await query
+            .OrderByDescending(a => a.LastSeenAt)
+            .Skip((pageNum - 1) * size)
+            .Take(size)
+            .Select(a => new AddressResponse(
+                a.Id,
+                a.ContactId,
+                a.Contact != null ? a.Contact.DisplayName : null,
+                a.NormalizedEmail,
+                a.DisplayName,
+                a.IsUnknown,
+                a.IsBlocked,
+                a.Contact != null && a.Contact.IsImportant,
+                a.FirstSeenAt,
+                a.LastSeenAt,
+                a.SeenCount))
+            .ToListAsync();
+
+        return Results.Ok(new PagedResult<AddressResponse>(items, total, pageNum, size));
+    }
+
+    private static async Task<IResult> GetAddressAsync(
+        Guid id,
+        HttpContext httpContext,
+        FeirbDbContext db,
+        IStringLocalizer<ApiMessages> localizer)
+    {
+        var userId = GetCurrentUserId(httpContext);
+        var address = await db.Addresses
+            .AsNoTracking()
+            .Include(a => a.Contact)
+            .FirstOrDefaultAsync(a => a.Id == id && a.UserId == userId);
+
+        if (address is null)
+            return Results.NotFound(new { message = localizer["AddressNotFound"].Value });
+
+        return Results.Ok(ToAddressResponse(address));
+    }
+
+    private static async Task<IResult> UpdateAddressAsync(
+        Guid id,
+        UpdateAddressRequest request,
+        HttpContext httpContext,
+        FeirbDbContext db,
+        IStringLocalizer<ApiMessages> localizer)
+    {
+        var userId = GetCurrentUserId(httpContext);
+        var address = await db.Addresses
+            .Include(a => a.Contact)
+            .FirstOrDefaultAsync(a => a.Id == id && a.UserId == userId);
+
+        if (address is null)
+            return Results.NotFound(new { message = localizer["AddressNotFound"].Value });
+
+        address.DisplayName = request.DisplayName.Trim();
+        address.IsBlocked = request.IsBlocked;
+        if (address.IsUnknown)
+            address.IsUnknown = false;
+
+        await db.SaveChangesAsync();
+        return Results.Ok(ToAddressResponse(address));
+    }
+
+    private static async Task<IResult> DeleteAddressAsync(
+        Guid id,
+        HttpContext httpContext,
+        FeirbDbContext db,
+        IStringLocalizer<ApiMessages> localizer)
+    {
+        var userId = GetCurrentUserId(httpContext);
+        var address = await db.Addresses
+            .FirstOrDefaultAsync(a => a.Id == id && a.UserId == userId);
+
+        if (address is null)
+            return Results.NotFound(new { message = localizer["AddressNotFound"].Value });
+
+        if (address.ContactId is not null)
+            return Results.Conflict(new { message = localizer["AddressLinkedCannotDelete"].Value });
+
+        db.Addresses.Remove(address);
+        await db.SaveChangesAsync();
+        return Results.Ok(new { message = localizer["AddressDeleted"].Value });
+    }
+
+    private static async Task<IResult> PromoteAddressAsync(
+        Guid id,
+        PromoteAddressRequest request,
+        HttpContext httpContext,
+        FeirbDbContext db,
+        IStringLocalizer<ApiMessages> localizer)
+    {
+        var userId = GetCurrentUserId(httpContext);
+        var address = await db.Addresses
+            .FirstOrDefaultAsync(a => a.Id == id && a.UserId == userId);
+
+        if (address is null)
+            return Results.NotFound(new { message = localizer["AddressNotFound"].Value });
+
+        if (address.ContactId is not null)
+            return Results.Conflict(new { message = localizer["AddressAlreadyLinked"].Value });
+
+        var now = DateTime.UtcNow;
+        var contact = new Contact
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            DisplayName = request.DisplayName.Trim(),
+            Notes = request.Notes?.Trim(),
+            IsImportant = request.IsImportant,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        db.Contacts.Add(contact);
+        address.ContactId = contact.Id;
+        address.IsUnknown = false;
+
+        await db.SaveChangesAsync();
+
+        var created = await db.Contacts.AsNoTracking()
+            .Include(c => c.Addresses)
+            .FirstAsync(c => c.Id == contact.Id);
+
+        return Results.Created($"/api/address-book/contacts/{contact.Id}", ToContactResponse(created));
+    }
+
+    private static async Task<IResult> LinkAddressAsync(
+        Guid id,
+        LinkAddressRequest request,
+        HttpContext httpContext,
+        FeirbDbContext db,
+        IStringLocalizer<ApiMessages> localizer)
+    {
+        var userId = GetCurrentUserId(httpContext);
+        var address = await db.Addresses
+            .FirstOrDefaultAsync(a => a.Id == id && a.UserId == userId);
+
+        if (address is null)
+            return Results.NotFound(new { message = localizer["AddressNotFound"].Value });
+
+        var contact = await db.Contacts
+            .FirstOrDefaultAsync(c => c.Id == request.ContactId && c.UserId == userId);
+
+        if (contact is null)
+            return Results.NotFound(new { message = localizer["ContactNotFound"].Value });
+
+        address.ContactId = contact.Id;
+        address.IsUnknown = false;
+        await db.SaveChangesAsync();
+
+        var reloaded = await db.Addresses.AsNoTracking()
+            .Include(a => a.Contact)
+            .FirstAsync(a => a.Id == id);
+
+        return Results.Ok(ToAddressResponse(reloaded));
+    }
+
+    private static async Task<IResult> UnlinkAddressAsync(
+        Guid id,
+        HttpContext httpContext,
+        FeirbDbContext db,
+        IStringLocalizer<ApiMessages> localizer)
+    {
+        var userId = GetCurrentUserId(httpContext);
+        var address = await db.Addresses
+            .FirstOrDefaultAsync(a => a.Id == id && a.UserId == userId);
+
+        if (address is null)
+            return Results.NotFound(new { message = localizer["AddressNotFound"].Value });
+
+        address.ContactId = null;
+        await db.SaveChangesAsync();
+
+        var reloaded = await db.Addresses.AsNoTracking()
+            .Include(a => a.Contact)
+            .FirstAsync(a => a.Id == id);
+
+        return Results.Ok(ToAddressResponse(reloaded));
+    }
+
+    // --- Autocomplete (mounted on /api/mail group) ---
+
+    public static RouteGroupBuilder MapRecipientSearch(this RouteGroupBuilder group)
+    {
+        group.MapGet("/recipients/search", SearchRecipientsAsync);
+        return group;
+    }
+
+    private static async Task<IResult> SearchRecipientsAsync(
+        HttpContext httpContext,
+        FeirbDbContext db,
+        string? q)
+    {
+        var userId = GetCurrentUserId(httpContext);
+        var term = q?.Trim().ToLower() ?? string.Empty;
+
+        var query = db.Addresses
+            .AsNoTracking()
+            .Include(a => a.Contact)
+            .Where(a => a.UserId == userId);
+
+        if (term.Length > 0)
+        {
+            query = query.Where(a =>
+                a.NormalizedEmail.Contains(term) ||
+                a.DisplayName.ToLower().Contains(term) ||
+                (a.Contact != null && a.Contact.DisplayName.ToLower().Contains(term)));
+        }
+
+        // Rank: Important (5) → Known linked (4) → Known orphan (3) → Unknown (2) → Blocked (1), then Recency
+        var items = await query
+            .Select(a => new
+            {
+                Address = a,
+                Rank =
+                    a.IsBlocked ? 1 :
+                    (a.Contact != null && a.Contact.IsImportant) ? 5 :
+                    (a.Contact != null) ? 4 :
+                    a.IsUnknown ? 2 : 3,
+            })
+            .OrderByDescending(x => x.Rank)
+            .ThenByDescending(x => x.Address.LastSeenAt)
+            .Take(_autocompleteLimit)
+            .ToListAsync();
+
+        var results = items
+            .Select(x => new RecipientSuggestion(
+                x.Address.Contact != null ? x.Address.Contact.DisplayName : x.Address.DisplayName,
+                x.Address.NormalizedEmail,
+                StatusFor(x.Address)))
+            .ToList();
+
+        return Results.Ok(results);
+    }
+
+    // --- Helpers ---
+
+    private static (int page, int size) NormalizePaging(int? page, int? pageSize)
+    {
+        var p = page.GetValueOrDefault(1);
+        if (p < 1) p = 1;
+        var s = pageSize.GetValueOrDefault(_defaultPageSize);
+        if (s < 1) s = _defaultPageSize;
+        if (s > _maxPageSize) s = _maxPageSize;
+        return (p, s);
+    }
+
+    private static ContactResponse ToContactResponse(Contact c) =>
+        new(c.Id, c.DisplayName, c.Notes, c.IsImportant, c.CreatedAt, c.UpdatedAt,
+            c.Addresses
+                .OrderBy(a => a.NormalizedEmail)
+                .Select(a => new AddressResponse(
+                    a.Id, a.ContactId, c.DisplayName, a.NormalizedEmail, a.DisplayName,
+                    a.IsUnknown, a.IsBlocked, c.IsImportant,
+                    a.FirstSeenAt, a.LastSeenAt, a.SeenCount))
+                .ToList());
+
+    private static AddressResponse ToAddressResponse(Address a) =>
+        new(a.Id, a.ContactId, a.Contact?.DisplayName, a.NormalizedEmail, a.DisplayName,
+            a.IsUnknown, a.IsBlocked, a.Contact?.IsImportant ?? false,
+            a.FirstSeenAt, a.LastSeenAt, a.SeenCount);
+
+    private static RecipientStatus StatusFor(Address a)
+    {
+        if (a.IsBlocked) return RecipientStatus.Blocked;
+        if (a.Contact?.IsImportant == true) return RecipientStatus.Important;
+        if (a.IsUnknown) return RecipientStatus.Unknown;
+        return RecipientStatus.Known;
+    }
+
+    private static Guid GetCurrentUserId(HttpContext httpContext) =>
+        Guid.Parse(httpContext.User.FindFirst(ClaimTypes.NameIdentifier)!.Value);
+}

--- a/src/Feirb.Api/Endpoints/AddressBookEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/AddressBookEndpoints.cs
@@ -61,7 +61,6 @@ public static class AddressBookEndpoints
             .Select(c => new ContactListItem(
                 c.Id,
                 c.DisplayName,
-                c.IsImportant,
                 c.Addresses.Count,
                 c.Addresses.OrderBy(a => a.NormalizedEmail).Select(a => a.NormalizedEmail).FirstOrDefault(),
                 c.UpdatedAt))
@@ -106,7 +105,6 @@ public static class AddressBookEndpoints
             UserId = userId,
             DisplayName = request.DisplayName.Trim(),
             Notes = request.Notes?.Trim(),
-            IsImportant = request.IsImportant,
             CreatedAt = now,
             UpdatedAt = now,
         };
@@ -132,7 +130,7 @@ public static class AddressBookEndpoints
                         ContactId = contact.Id,
                         NormalizedEmail = normalized,
                         DisplayName = request.DisplayName.Trim(),
-                        IsUnknown = false,
+                        Status = AddressStatus.Known,
                         FirstSeenAt = now,
                         LastSeenAt = now,
                         SeenCount = 0,
@@ -141,7 +139,8 @@ public static class AddressBookEndpoints
                 else
                 {
                     existing.ContactId = contact.Id;
-                    existing.IsUnknown = false;
+                    if (existing.Status == AddressStatus.Unknown)
+                        existing.Status = AddressStatus.Known;
                 }
             }
         }
@@ -172,14 +171,7 @@ public static class AddressBookEndpoints
 
         contact.DisplayName = request.DisplayName.Trim();
         contact.Notes = request.Notes?.Trim();
-        contact.IsImportant = request.IsImportant;
         contact.UpdatedAt = DateTime.UtcNow;
-
-        foreach (var addr in contact.Addresses)
-        {
-            if (addr.IsUnknown)
-                addr.IsUnknown = false;
-        }
 
         await db.SaveChangesAsync();
         return Results.Ok(ToContactResponse(contact));
@@ -238,9 +230,7 @@ public static class AddressBookEndpoints
                 a.Contact != null ? a.Contact.DisplayName : null,
                 a.NormalizedEmail,
                 a.DisplayName,
-                a.IsUnknown,
-                a.IsBlocked,
-                a.Contact != null && a.Contact.IsImportant,
+                a.Status,
                 a.FirstSeenAt,
                 a.LastSeenAt,
                 a.SeenCount))
@@ -282,10 +272,11 @@ public static class AddressBookEndpoints
         if (address is null)
             return Results.NotFound(new { message = localizer["AddressNotFound"].Value });
 
+        if (!Enum.IsDefined(request.Status))
+            return Results.BadRequest(new { message = localizer["AddressStatusInvalid"].Value });
+
         address.DisplayName = request.DisplayName.Trim();
-        address.IsBlocked = request.IsBlocked;
-        if (address.IsUnknown)
-            address.IsUnknown = false;
+        address.Status = request.Status;
 
         await db.SaveChangesAsync();
         return Results.Ok(ToAddressResponse(address));
@@ -329,6 +320,9 @@ public static class AddressBookEndpoints
         if (address.ContactId is not null)
             return Results.Conflict(new { message = localizer["AddressAlreadyLinked"].Value });
 
+        if (request.Status is not (AddressStatus.Known or AddressStatus.Important))
+            return Results.BadRequest(new { message = localizer["AddressStatusInvalid"].Value });
+
         var now = DateTime.UtcNow;
         var contact = new Contact
         {
@@ -336,13 +330,12 @@ public static class AddressBookEndpoints
             UserId = userId,
             DisplayName = request.DisplayName.Trim(),
             Notes = request.Notes?.Trim(),
-            IsImportant = request.IsImportant,
             CreatedAt = now,
             UpdatedAt = now,
         };
         db.Contacts.Add(contact);
         address.ContactId = contact.Id;
-        address.IsUnknown = false;
+        address.Status = request.Status;
 
         await db.SaveChangesAsync();
 
@@ -374,7 +367,6 @@ public static class AddressBookEndpoints
             return Results.NotFound(new { message = localizer["ContactNotFound"].Value });
 
         address.ContactId = contact.Id;
-        address.IsUnknown = false;
         await db.SaveChangesAsync();
 
         var reloaded = await db.Addresses.AsNoTracking()
@@ -436,16 +428,16 @@ public static class AddressBookEndpoints
                 (a.Contact != null && a.Contact.DisplayName.ToLower().Contains(term)));
         }
 
-        // Rank: Important (5) → Known linked (4) → Known orphan (3) → Unknown (2) → Blocked (1), then Recency
+        // Rank: Important (5) > Known (3) > Unknown (2) > Blocked (1), then Recency
         var items = await query
             .Select(a => new
             {
                 Address = a,
                 Rank =
-                    a.IsBlocked ? 1 :
-                    (a.Contact != null && a.Contact.IsImportant) ? 5 :
-                    (a.Contact != null) ? 4 :
-                    a.IsUnknown ? 2 : 3,
+                    a.Status == AddressStatus.Important ? 5 :
+                    a.Status == AddressStatus.Known ? 3 :
+                    a.Status == AddressStatus.Unknown ? 2 :
+                    1,
             })
             .OrderByDescending(x => x.Rank)
             .ThenByDescending(x => x.Address.LastSeenAt)
@@ -456,7 +448,7 @@ public static class AddressBookEndpoints
             .Select(x => new RecipientSuggestion(
                 x.Address.Contact != null ? x.Address.Contact.DisplayName : x.Address.DisplayName,
                 x.Address.NormalizedEmail,
-                StatusFor(x.Address)))
+                x.Address.Status))
             .ToList();
 
         return Results.Ok(results);
@@ -475,27 +467,19 @@ public static class AddressBookEndpoints
     }
 
     private static ContactResponse ToContactResponse(Contact c) =>
-        new(c.Id, c.DisplayName, c.Notes, c.IsImportant, c.CreatedAt, c.UpdatedAt,
+        new(c.Id, c.DisplayName, c.Notes, c.CreatedAt, c.UpdatedAt,
             c.Addresses
                 .OrderBy(a => a.NormalizedEmail)
                 .Select(a => new AddressResponse(
                     a.Id, a.ContactId, c.DisplayName, a.NormalizedEmail, a.DisplayName,
-                    a.IsUnknown, a.IsBlocked, c.IsImportant,
+                    a.Status,
                     a.FirstSeenAt, a.LastSeenAt, a.SeenCount))
                 .ToList());
 
     private static AddressResponse ToAddressResponse(Address a) =>
         new(a.Id, a.ContactId, a.Contact?.DisplayName, a.NormalizedEmail, a.DisplayName,
-            a.IsUnknown, a.IsBlocked, a.Contact?.IsImportant ?? false,
+            a.Status,
             a.FirstSeenAt, a.LastSeenAt, a.SeenCount);
-
-    private static RecipientStatus StatusFor(Address a)
-    {
-        if (a.IsBlocked) return RecipientStatus.Blocked;
-        if (a.Contact?.IsImportant == true) return RecipientStatus.Important;
-        if (a.IsUnknown) return RecipientStatus.Unknown;
-        return RecipientStatus.Known;
-    }
 
     private static Guid GetCurrentUserId(HttpContext httpContext) =>
         Guid.Parse(httpContext.User.FindFirst(ClaimTypes.NameIdentifier)!.Value);

--- a/src/Feirb.Api/Endpoints/MessageEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/MessageEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Feirb.Api.Data;
 using Feirb.Api.Resources;
+using Feirb.Shared.AddressBook;
 using Feirb.Shared.Mail;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
@@ -41,11 +42,34 @@ public static class MessageEndpoints
             .ToListAsync();
 
         var summaryPlaceholder = localizer["SummaryPlaceholder"].Value;
-        var mapped = items.Select(m =>
+
+        var parsedSenders = items
+            .Select(m => new { Item = m, Parsed = ParseFromAddress(m.From) })
+            .ToList();
+
+        var senderEmails = parsedSenders
+            .Select(p => EmailNormalizer.Normalize(p.Parsed.Email))
+            .Where(e => e.Length > 0)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var statusByEmail = senderEmails.Count == 0
+            ? new Dictionary<string, AddressStatus>(StringComparer.Ordinal)
+            : await db.Addresses
+                .AsNoTracking()
+                .Where(a => a.UserId == userId && senderEmails.Contains(a.NormalizedEmail))
+                .Select(a => new { a.NormalizedEmail, a.Status })
+                .ToDictionaryAsync(x => x.NormalizedEmail, x => x.Status, StringComparer.Ordinal);
+
+        var mapped = parsedSenders.Select(p =>
         {
-            var (name, email) = ParseFromAddress(m.From);
+            var m = p.Item;
+            var (name, email) = p.Parsed;
+            var normalized = EmailNormalizer.Normalize(email);
+            AddressStatus? senderStatus = normalized.Length > 0 && statusByEmail.TryGetValue(normalized, out var s)
+                ? s
+                : null;
             var labels = m.Labels.Select(l => new MessageLabelResponse(l.Name, l.Color)).ToList();
-            return new MessageListItemResponse(m.Id, m.MailboxName, m.BadgeColor, name, email, m.Subject, summaryPlaceholder, m.Date, IsRead: false, m.HasAttachments, labels);
+            return new MessageListItemResponse(m.Id, m.MailboxName, m.BadgeColor, name, email, senderStatus, m.Subject, summaryPlaceholder, m.Date, IsRead: false, m.HasAttachments, labels);
         }).ToList();
 
         return Results.Ok(new PaginatedResponse<MessageListItemResponse>(mapped, page, pageSize, totalCount));

--- a/src/Feirb.Api/Program.cs
+++ b/src/Feirb.Api/Program.cs
@@ -95,6 +95,7 @@ builder.Services.AddScoped<IEmailService, EmailService>();
 builder.Services.AddScoped<IImapSyncService, ImapSyncService>();
 builder.Services.AddScoped<IClassificationService, ClassificationService>();
 builder.Services.AddScoped<IMailSendingService, MailSendingService>();
+builder.Services.AddScoped<IAddressExtractor, AddressExtractor>();
 
 var app = builder.Build();
 
@@ -176,6 +177,11 @@ mailGroup.MapMailTestEndpoints();
 mailGroup.MapMessageEndpoints();
 mailGroup.MapMailStatsEndpoints();
 mailGroup.MapComposeEndpoints();
+mailGroup.MapRecipientSearch();
+
+// Address book endpoints (per-user, JWT required)
+var addressBookGroup = apiGroup.MapGroup("/address-book");
+addressBookGroup.MapAddressBookEndpoints();
 
 // Avatar endpoints (GET is public, PUT/DELETE require JWT)
 apiGroup.MapAvatarEndpoints();

--- a/src/Feirb.Api/Resources/ApiMessages.de-DE.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.de-DE.resx
@@ -189,4 +189,25 @@
   <data name="BodyTooLarge" xml:space="preserve">
     <value>Nachrichtentext überschreitet die maximal zulässige Größe.</value>
   </data>
+  <data name="ContactNotFound" xml:space="preserve">
+    <value>Kontakt nicht gefunden.</value>
+  </data>
+  <data name="ContactDeleted" xml:space="preserve">
+    <value>Kontakt erfolgreich gelöscht.</value>
+  </data>
+  <data name="ContactDisplayNameRequired" xml:space="preserve">
+    <value>Anzeigename des Kontakts ist erforderlich.</value>
+  </data>
+  <data name="AddressNotFound" xml:space="preserve">
+    <value>Adresse nicht gefunden.</value>
+  </data>
+  <data name="AddressDeleted" xml:space="preserve">
+    <value>Adresse erfolgreich gelöscht.</value>
+  </data>
+  <data name="AddressLinkedCannotDelete" xml:space="preserve">
+    <value>Adresse ist mit einem Kontakt verknüpft. Vor dem Löschen zuerst trennen.</value>
+  </data>
+  <data name="AddressAlreadyLinked" xml:space="preserve">
+    <value>Adresse ist bereits mit einem Kontakt verknüpft.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.de-DE.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.de-DE.resx
@@ -210,4 +210,7 @@
   <data name="AddressAlreadyLinked" xml:space="preserve">
     <value>Adresse ist bereits mit einem Kontakt verknüpft.</value>
   </data>
+  <data name="AddressStatusInvalid" xml:space="preserve">
+    <value>Ungültiger Adress-Status-Wert.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.fr-FR.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.fr-FR.resx
@@ -210,4 +210,7 @@
   <data name="AddressAlreadyLinked" xml:space="preserve">
     <value>L'adresse est déjà liée à un contact.</value>
   </data>
+  <data name="AddressStatusInvalid" xml:space="preserve">
+    <value>Valeur de statut d'adresse invalide.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.fr-FR.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.fr-FR.resx
@@ -189,4 +189,25 @@
   <data name="BodyTooLarge" xml:space="preserve">
     <value>Le corps du message dépasse la taille maximale autorisée.</value>
   </data>
+  <data name="ContactNotFound" xml:space="preserve">
+    <value>Contact introuvable.</value>
+  </data>
+  <data name="ContactDeleted" xml:space="preserve">
+    <value>Contact supprimé avec succès.</value>
+  </data>
+  <data name="ContactDisplayNameRequired" xml:space="preserve">
+    <value>Le nom d'affichage du contact est requis.</value>
+  </data>
+  <data name="AddressNotFound" xml:space="preserve">
+    <value>Adresse introuvable.</value>
+  </data>
+  <data name="AddressDeleted" xml:space="preserve">
+    <value>Adresse supprimée avec succès.</value>
+  </data>
+  <data name="AddressLinkedCannotDelete" xml:space="preserve">
+    <value>L'adresse est liée à un contact. Dissociez-la avant de la supprimer.</value>
+  </data>
+  <data name="AddressAlreadyLinked" xml:space="preserve">
+    <value>L'adresse est déjà liée à un contact.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.it-IT.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.it-IT.resx
@@ -189,4 +189,25 @@
   <data name="BodyTooLarge" xml:space="preserve">
     <value>Il corpo del messaggio supera la dimensione massima consentita.</value>
   </data>
+  <data name="ContactNotFound" xml:space="preserve">
+    <value>Contatto non trovato.</value>
+  </data>
+  <data name="ContactDeleted" xml:space="preserve">
+    <value>Contatto eliminato con successo.</value>
+  </data>
+  <data name="ContactDisplayNameRequired" xml:space="preserve">
+    <value>Il nome visualizzato del contatto è obbligatorio.</value>
+  </data>
+  <data name="AddressNotFound" xml:space="preserve">
+    <value>Indirizzo non trovato.</value>
+  </data>
+  <data name="AddressDeleted" xml:space="preserve">
+    <value>Indirizzo eliminato con successo.</value>
+  </data>
+  <data name="AddressLinkedCannotDelete" xml:space="preserve">
+    <value>L'indirizzo è collegato a un contatto. Scollegalo prima di eliminarlo.</value>
+  </data>
+  <data name="AddressAlreadyLinked" xml:space="preserve">
+    <value>L'indirizzo è già collegato a un contatto.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.it-IT.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.it-IT.resx
@@ -210,4 +210,7 @@
   <data name="AddressAlreadyLinked" xml:space="preserve">
     <value>L'indirizzo è già collegato a un contatto.</value>
   </data>
+  <data name="AddressStatusInvalid" xml:space="preserve">
+    <value>Valore di stato indirizzo non valido.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.resx
@@ -210,4 +210,7 @@
   <data name="AddressAlreadyLinked" xml:space="preserve">
     <value>Address is already linked to a contact.</value>
   </data>
+  <data name="AddressStatusInvalid" xml:space="preserve">
+    <value>Invalid address status value.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.resx
@@ -189,4 +189,25 @@
   <data name="BodyTooLarge" xml:space="preserve">
     <value>Message body exceeds the maximum allowed size.</value>
   </data>
+  <data name="ContactNotFound" xml:space="preserve">
+    <value>Contact not found.</value>
+  </data>
+  <data name="ContactDeleted" xml:space="preserve">
+    <value>Contact deleted successfully.</value>
+  </data>
+  <data name="ContactDisplayNameRequired" xml:space="preserve">
+    <value>Contact display name is required.</value>
+  </data>
+  <data name="AddressNotFound" xml:space="preserve">
+    <value>Address not found.</value>
+  </data>
+  <data name="AddressDeleted" xml:space="preserve">
+    <value>Address deleted successfully.</value>
+  </data>
+  <data name="AddressLinkedCannotDelete" xml:space="preserve">
+    <value>Address is linked to a contact. Unlink first before deleting.</value>
+  </data>
+  <data name="AddressAlreadyLinked" xml:space="preserve">
+    <value>Address is already linked to a contact.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Services/AddressExtractor.cs
+++ b/src/Feirb.Api/Services/AddressExtractor.cs
@@ -1,5 +1,6 @@
 using Feirb.Api.Data;
 using Feirb.Api.Data.Entities;
+using Feirb.Shared.AddressBook;
 using Feirb.Shared.Mail;
 using Microsoft.EntityFrameworkCore;
 using MimeKit;
@@ -68,8 +69,9 @@ public class AddressExtractor : IAddressExtractor
             {
                 row.LastSeenAt = now;
                 row.SeenCount++;
-                if (markAsKnown && row.IsUnknown)
-                    row.IsUnknown = false;
+                // Only promote Unknown -> Known. Never override Important or Blocked.
+                if (markAsKnown && row.Status == AddressStatus.Unknown)
+                    row.Status = AddressStatus.Known;
             }
             else
             {
@@ -79,8 +81,7 @@ public class AddressExtractor : IAddressExtractor
                     UserId = userId,
                     NormalizedEmail = normalized,
                     DisplayName = displayName,
-                    IsUnknown = !markAsKnown,
-                    IsBlocked = false,
+                    Status = markAsKnown ? AddressStatus.Known : AddressStatus.Unknown,
                     FirstSeenAt = now,
                     LastSeenAt = now,
                     SeenCount = 1,

--- a/src/Feirb.Api/Services/AddressExtractor.cs
+++ b/src/Feirb.Api/Services/AddressExtractor.cs
@@ -1,0 +1,91 @@
+using Feirb.Api.Data;
+using Feirb.Api.Data.Entities;
+using Feirb.Shared.Mail;
+using Microsoft.EntityFrameworkCore;
+using MimeKit;
+
+namespace Feirb.Api.Services;
+
+public interface IAddressExtractor
+{
+    Task CaptureAsync(
+        FeirbDbContext db,
+        Guid userId,
+        IEnumerable<InternetAddressList> addressLists,
+        bool markAsKnown,
+        CancellationToken cancellationToken = default);
+}
+
+public class AddressExtractor : IAddressExtractor
+{
+    public async Task CaptureAsync(
+        FeirbDbContext db,
+        Guid userId,
+        IEnumerable<InternetAddressList> addressLists,
+        bool markAsKnown,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(addressLists);
+
+        var parsed = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var list in addressLists)
+        {
+            if (list is null)
+                continue;
+            foreach (var addr in list.Mailboxes)
+            {
+                if (string.IsNullOrWhiteSpace(addr.Address))
+                    continue;
+                var normalized = EmailNormalizer.Normalize(addr.Address);
+                if (normalized.Length == 0)
+                    continue;
+                parsed.TryAdd(normalized, string.IsNullOrWhiteSpace(addr.Name) ? addr.Address : addr.Name);
+            }
+        }
+
+        if (parsed.Count == 0)
+            return;
+
+        var keys = parsed.Keys.ToList();
+        var existing = await db.Addresses
+            .Where(a => a.UserId == userId && keys.Contains(a.NormalizedEmail))
+            .ToDictionaryAsync(a => a.NormalizedEmail, cancellationToken);
+
+        // Include pending adds from the change tracker so we don't insert duplicates
+        // when CaptureAsync is called multiple times in the same SaveChanges batch.
+        foreach (var local in db.Addresses.Local)
+        {
+            if (local.UserId == userId && !existing.ContainsKey(local.NormalizedEmail))
+                existing[local.NormalizedEmail] = local;
+        }
+
+        var now = DateTime.UtcNow;
+
+        foreach (var (normalized, displayName) in parsed)
+        {
+            if (existing.TryGetValue(normalized, out var row))
+            {
+                row.LastSeenAt = now;
+                row.SeenCount++;
+                if (markAsKnown && row.IsUnknown)
+                    row.IsUnknown = false;
+            }
+            else
+            {
+                db.Addresses.Add(new Address
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = userId,
+                    NormalizedEmail = normalized,
+                    DisplayName = displayName,
+                    IsUnknown = !markAsKnown,
+                    IsBlocked = false,
+                    FirstSeenAt = now,
+                    LastSeenAt = now,
+                    SeenCount = 1,
+                });
+            }
+        }
+    }
+}

--- a/src/Feirb.Api/Services/ImapSyncService.cs
+++ b/src/Feirb.Api/Services/ImapSyncService.cs
@@ -13,7 +13,8 @@ namespace Feirb.Api.Services;
 public class ImapSyncService(
     IServiceScopeFactory scopeFactory,
     ILogger<ImapSyncService> logger,
-    IOptions<ImapSyncSettings> syncSettings) : IImapSyncService
+    IOptions<ImapSyncSettings> syncSettings,
+    IAddressExtractor addressExtractor) : IImapSyncService
 {
     private const string _imapPasswordPurpose = "MailboxImapPassword";
     private readonly int _saveBatchSize = syncSettings.Value.SaveBatchSize;
@@ -94,6 +95,13 @@ public class ImapSyncService(
 
                 var cached = MapToCachedMessage(message, mailboxId, uid);
                 db.CachedMessages.Add(cached);
+
+                await addressExtractor.CaptureAsync(
+                    db,
+                    mailbox.UserId,
+                    [message.From, message.ReplyTo, message.To, message.Cc],
+                    markAsKnown: false,
+                    cancellationToken);
 
                 if (hasClassificationRules)
                 {

--- a/src/Feirb.Api/Services/MailSendingService.cs
+++ b/src/Feirb.Api/Services/MailSendingService.cs
@@ -13,6 +13,7 @@ namespace Feirb.Api.Services;
 public class MailSendingService(
     FeirbDbContext db,
     IDataProtectionProvider dataProtection,
+    IAddressExtractor addressExtractor,
     ILogger<MailSendingService> logger) : IMailSendingService
 {
     private const string _smtpPasswordPurpose = "MailboxSmtpPassword";
@@ -27,6 +28,14 @@ public class MailSendingService(
             ?? throw new InvalidOperationException("Mailbox not found or not owned by user.");
 
         var message = BuildMimeMessage(mailbox, request);
+
+        await addressExtractor.CaptureAsync(
+            db,
+            userId,
+            [message.To, message.Cc, message.Bcc],
+            markAsKnown: true,
+            cancellationToken);
+        await db.SaveChangesAsync(cancellationToken);
 
         await SendViaSmtpAsync(mailbox, message, cancellationToken);
         await AppendToSentFolderAsync(mailbox, message, cancellationToken);

--- a/src/Feirb.Shared/AddressBook/AddressResponse.cs
+++ b/src/Feirb.Shared/AddressBook/AddressResponse.cs
@@ -1,0 +1,14 @@
+namespace Feirb.Shared.AddressBook;
+
+public record AddressResponse(
+    Guid Id,
+    Guid? ContactId,
+    string? ContactDisplayName,
+    string NormalizedEmail,
+    string DisplayName,
+    bool IsUnknown,
+    bool IsBlocked,
+    bool IsImportant,
+    DateTime FirstSeenAt,
+    DateTime LastSeenAt,
+    int SeenCount);

--- a/src/Feirb.Shared/AddressBook/AddressResponse.cs
+++ b/src/Feirb.Shared/AddressBook/AddressResponse.cs
@@ -6,9 +6,7 @@ public record AddressResponse(
     string? ContactDisplayName,
     string NormalizedEmail,
     string DisplayName,
-    bool IsUnknown,
-    bool IsBlocked,
-    bool IsImportant,
+    AddressStatus Status,
     DateTime FirstSeenAt,
     DateTime LastSeenAt,
     int SeenCount);

--- a/src/Feirb.Shared/AddressBook/AddressStatus.cs
+++ b/src/Feirb.Shared/AddressBook/AddressStatus.cs
@@ -1,0 +1,9 @@
+namespace Feirb.Shared.AddressBook;
+
+public enum AddressStatus
+{
+    Unknown = 0,
+    Known = 1,
+    Important = 2,
+    Blocked = 3,
+}

--- a/src/Feirb.Shared/AddressBook/ContactListItem.cs
+++ b/src/Feirb.Shared/AddressBook/ContactListItem.cs
@@ -3,7 +3,6 @@ namespace Feirb.Shared.AddressBook;
 public record ContactListItem(
     Guid Id,
     string DisplayName,
-    bool IsImportant,
     int AddressCount,
     string? PrimaryEmail,
     DateTime UpdatedAt);

--- a/src/Feirb.Shared/AddressBook/ContactListItem.cs
+++ b/src/Feirb.Shared/AddressBook/ContactListItem.cs
@@ -1,0 +1,9 @@
+namespace Feirb.Shared.AddressBook;
+
+public record ContactListItem(
+    Guid Id,
+    string DisplayName,
+    bool IsImportant,
+    int AddressCount,
+    string? PrimaryEmail,
+    DateTime UpdatedAt);

--- a/src/Feirb.Shared/AddressBook/ContactResponse.cs
+++ b/src/Feirb.Shared/AddressBook/ContactResponse.cs
@@ -4,7 +4,6 @@ public record ContactResponse(
     Guid Id,
     string DisplayName,
     string? Notes,
-    bool IsImportant,
     DateTime CreatedAt,
     DateTime UpdatedAt,
     IReadOnlyList<AddressResponse> Addresses);

--- a/src/Feirb.Shared/AddressBook/ContactResponse.cs
+++ b/src/Feirb.Shared/AddressBook/ContactResponse.cs
@@ -1,0 +1,10 @@
+namespace Feirb.Shared.AddressBook;
+
+public record ContactResponse(
+    Guid Id,
+    string DisplayName,
+    string? Notes,
+    bool IsImportant,
+    DateTime CreatedAt,
+    DateTime UpdatedAt,
+    IReadOnlyList<AddressResponse> Addresses);

--- a/src/Feirb.Shared/AddressBook/CreateContactRequest.cs
+++ b/src/Feirb.Shared/AddressBook/CreateContactRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Feirb.Shared.AddressBook;
+
+public record CreateContactRequest(
+    [Required, StringLength(256)] string DisplayName,
+    [StringLength(2048)] string? Notes,
+    bool IsImportant,
+    IReadOnlyList<string>? Emails);

--- a/src/Feirb.Shared/AddressBook/CreateContactRequest.cs
+++ b/src/Feirb.Shared/AddressBook/CreateContactRequest.cs
@@ -5,5 +5,4 @@ namespace Feirb.Shared.AddressBook;
 public record CreateContactRequest(
     [Required, StringLength(256)] string DisplayName,
     [StringLength(2048)] string? Notes,
-    bool IsImportant,
     IReadOnlyList<string>? Emails);

--- a/src/Feirb.Shared/AddressBook/LinkAddressRequest.cs
+++ b/src/Feirb.Shared/AddressBook/LinkAddressRequest.cs
@@ -1,0 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Feirb.Shared.AddressBook;
+
+public record LinkAddressRequest([Required] Guid ContactId);

--- a/src/Feirb.Shared/AddressBook/PagedResult.cs
+++ b/src/Feirb.Shared/AddressBook/PagedResult.cs
@@ -1,0 +1,10 @@
+namespace Feirb.Shared.AddressBook;
+
+public record PagedResult<T>(
+    IReadOnlyList<T> Items,
+    int Total,
+    int Page,
+    int PageSize)
+{
+    public int TotalPages => PageSize <= 0 ? 0 : (int)Math.Ceiling((double)Total / PageSize);
+}

--- a/src/Feirb.Shared/AddressBook/PromoteAddressRequest.cs
+++ b/src/Feirb.Shared/AddressBook/PromoteAddressRequest.cs
@@ -1,0 +1,8 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Feirb.Shared.AddressBook;
+
+public record PromoteAddressRequest(
+    [Required, StringLength(256)] string DisplayName,
+    [StringLength(2048)] string? Notes,
+    bool IsImportant);

--- a/src/Feirb.Shared/AddressBook/PromoteAddressRequest.cs
+++ b/src/Feirb.Shared/AddressBook/PromoteAddressRequest.cs
@@ -5,4 +5,4 @@ namespace Feirb.Shared.AddressBook;
 public record PromoteAddressRequest(
     [Required, StringLength(256)] string DisplayName,
     [StringLength(2048)] string? Notes,
-    bool IsImportant);
+    AddressStatus Status);

--- a/src/Feirb.Shared/AddressBook/RecipientSuggestion.cs
+++ b/src/Feirb.Shared/AddressBook/RecipientSuggestion.cs
@@ -1,15 +1,6 @@
 namespace Feirb.Shared.AddressBook;
 
-public enum RecipientStatus
-{
-    None = 0,
-    Known = 1,
-    Unknown = 2,
-    Important = 3,
-    Blocked = 4,
-}
-
 public record RecipientSuggestion(
     string DisplayName,
     string Email,
-    RecipientStatus Status);
+    AddressStatus Status);

--- a/src/Feirb.Shared/AddressBook/RecipientSuggestion.cs
+++ b/src/Feirb.Shared/AddressBook/RecipientSuggestion.cs
@@ -1,0 +1,15 @@
+namespace Feirb.Shared.AddressBook;
+
+public enum RecipientStatus
+{
+    None = 0,
+    Known = 1,
+    Unknown = 2,
+    Important = 3,
+    Blocked = 4,
+}
+
+public record RecipientSuggestion(
+    string DisplayName,
+    string Email,
+    RecipientStatus Status);

--- a/src/Feirb.Shared/AddressBook/UpdateAddressRequest.cs
+++ b/src/Feirb.Shared/AddressBook/UpdateAddressRequest.cs
@@ -4,4 +4,4 @@ namespace Feirb.Shared.AddressBook;
 
 public record UpdateAddressRequest(
     [Required, StringLength(256)] string DisplayName,
-    bool IsBlocked);
+    AddressStatus Status);

--- a/src/Feirb.Shared/AddressBook/UpdateAddressRequest.cs
+++ b/src/Feirb.Shared/AddressBook/UpdateAddressRequest.cs
@@ -1,0 +1,7 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Feirb.Shared.AddressBook;
+
+public record UpdateAddressRequest(
+    [Required, StringLength(256)] string DisplayName,
+    bool IsBlocked);

--- a/src/Feirb.Shared/AddressBook/UpdateContactRequest.cs
+++ b/src/Feirb.Shared/AddressBook/UpdateContactRequest.cs
@@ -4,5 +4,4 @@ namespace Feirb.Shared.AddressBook;
 
 public record UpdateContactRequest(
     [Required, StringLength(256)] string DisplayName,
-    [StringLength(2048)] string? Notes,
-    bool IsImportant);
+    [StringLength(2048)] string? Notes);

--- a/src/Feirb.Shared/AddressBook/UpdateContactRequest.cs
+++ b/src/Feirb.Shared/AddressBook/UpdateContactRequest.cs
@@ -1,0 +1,8 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Feirb.Shared.AddressBook;
+
+public record UpdateContactRequest(
+    [Required, StringLength(256)] string DisplayName,
+    [StringLength(2048)] string? Notes,
+    bool IsImportant);

--- a/src/Feirb.Shared/Mail/EmailNormalizer.cs
+++ b/src/Feirb.Shared/Mail/EmailNormalizer.cs
@@ -1,0 +1,7 @@
+namespace Feirb.Shared.Mail;
+
+public static class EmailNormalizer
+{
+    public static string Normalize(string email) =>
+        string.IsNullOrWhiteSpace(email) ? string.Empty : email.Trim().ToLowerInvariant();
+}

--- a/src/Feirb.Shared/Mail/MessageListItemResponse.cs
+++ b/src/Feirb.Shared/Mail/MessageListItemResponse.cs
@@ -1,3 +1,5 @@
+using Feirb.Shared.AddressBook;
+
 namespace Feirb.Shared.Mail;
 
 public record MessageListItemResponse(
@@ -6,6 +8,7 @@ public record MessageListItemResponse(
     string? MailboxBadgeColor,
     string FromName,
     string FromEmail,
+    AddressStatus? SenderStatus,
     string Subject,
     string? Summary,
     DateTimeOffset Date,

--- a/src/Feirb.Shared/Mail/RecipientEntry.cs
+++ b/src/Feirb.Shared/Mail/RecipientEntry.cs
@@ -1,4 +1,6 @@
+using Feirb.Shared.AddressBook;
+
 namespace Feirb.Shared.Mail;
 
-/// <summary>A recipient entry with an optional display name and an email address.</summary>
-public record RecipientEntry(string? Name, string Email);
+/// <summary>A recipient entry with an optional display name, an email address, and an optional address-book status.</summary>
+public record RecipientEntry(string? Name, string Email, AddressStatus? Status = null);

--- a/src/Feirb.Web/Components/Breadcrumb.razor
+++ b/src/Feirb.Web/Components/Breadcrumb.razor
@@ -91,6 +91,9 @@
             "mail/trash" => L["BreadcrumbTrash"],
             "mail/archive" => L["BreadcrumbArchive"],
             "compose" => L["BreadcrumbCompose"],
+            "address-book" => L["AddressBookNavLabel"],
+            "address-book/contacts" => L["AddressBookContactsHeading"],
+            "address-book/addresses" => L["AddressBookAddressesHeading"],
             _ => segment
         };
 
@@ -98,6 +101,8 @@
         fullPath switch
         {
             "mail" => "/mail/inbox",
+            "address-book/contacts" => "/address-book",
+            "address-book/addresses" => "/address-book",
             _ => $"/{fullPath}"
         };
 

--- a/src/Feirb.Web/Components/ContentSection.razor
+++ b/src/Feirb.Web/Components/ContentSection.razor
@@ -1,6 +1,6 @@
 @using Feirb.Web.Components.UI
 
-<div class="content-section @Class">
+<div class="content-section mb-4 @Class">
     <div class="content-section-header">
         <Icon Name="@Icon" Size="IconSize.Large" Class="content-section-icon" />
         <Heading Level="HeadingLevel.Small" Subtitle="@Subtitle" Class="mb-0">@Title</Heading>

--- a/src/Feirb.Web/Components/ContentSection.razor.css
+++ b/src/Feirb.Web/Components/ContentSection.razor.css
@@ -2,7 +2,6 @@
     background: var(--feirb-surface);
     border: 1px solid var(--bs-border-color);
     border-radius: var(--bs-border-radius);
-    overflow: clip;
 }
 
 .content-section-header {
@@ -11,6 +10,7 @@
     gap: 1rem;
     padding: 1rem 1.25rem;
     border-bottom: 1px solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius) var(--bs-border-radius) 0 0;
 }
 
 ::deep .content-section-icon {
@@ -19,4 +19,5 @@
 
 .content-section-body {
     padding: 1.25rem;
+    border-radius: 0 0 var(--bs-border-radius) var(--bs-border-radius);
 }

--- a/src/Feirb.Web/Components/MailCard.razor
+++ b/src/Feirb.Web/Components/MailCard.razor
@@ -1,3 +1,4 @@
+@using Feirb.Shared.AddressBook
 @using Feirb.Web.Components.UI
 
 @* Card component for displaying mail items across different layout contexts. *@
@@ -5,7 +6,7 @@
    title="@Subject" data-testid="mail-card">
     <div class="mail-card-body">
         <div class="mail-card-header">
-            <PersonChip Name="@SenderName" Email="@SenderEmail" Size="@PersonChipSizeForMode" />
+            <PersonChip Name="@SenderName" Email="@SenderEmail" Status="@SenderStatus" Size="@PersonChipSizeForMode" />
             <DateTimeChip Value="new DateTimeOffset(ReceivedAt)" />
         </div>
 
@@ -37,6 +38,10 @@
     /// <summary>Sender email address.</summary>
     [Parameter, EditorRequired]
     public string SenderEmail { get; set; } = default!;
+
+    /// <summary>Sender address-book status (null = no badge).</summary>
+    [Parameter]
+    public AddressStatus? SenderStatus { get; set; }
 
     /// <summary>Mail subject line (truncated with ellipsis).</summary>
     [Parameter, EditorRequired]

--- a/src/Feirb.Web/Components/UI/HelpHint.razor
+++ b/src/Feirb.Web/Components/UI/HelpHint.razor
@@ -1,0 +1,14 @@
+@namespace Feirb.Web.Components.UI
+
+<div class="feirb-help-hint @Class">
+    <Icon Name="question-circle" Size="IconSize.Small" />
+    <span>@ChildContent</span>
+</div>
+
+@code {
+    [Parameter, EditorRequired]
+    public RenderFragment ChildContent { get; set; } = default!;
+
+    [Parameter]
+    public string? Class { get; set; }
+}

--- a/src/Feirb.Web/Components/UI/HelpHint.razor.css
+++ b/src/Feirb.Web/Components/UI/HelpHint.razor.css
@@ -1,0 +1,14 @@
+.feirb-help-hint {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.375rem;
+    margin-top: 0.5rem;
+    font-size: 0.8125rem;
+    color: var(--feirb-on-surface-variant);
+    line-height: 1.4;
+}
+
+::deep .feirb-icon {
+    flex-shrink: 0;
+    margin-top: 0.1rem;
+}

--- a/src/Feirb.Web/Components/UI/PersonChip.razor
+++ b/src/Feirb.Web/Components/UI/PersonChip.razor
@@ -14,8 +14,8 @@
         }
         @if (_statusIcon is not null)
         {
-            <span class="feirb-person-chip-status feirb-person-chip-status-@_statusClass" title="@_statusTitle">
-                <i class="bi bi-@_statusIcon"></i>
+            <span class="feirb-person-chip-status feirb-person-chip-status-@_statusClass" title="@_statusTitle" role="img" aria-label="@_statusTitle">
+                <i class="bi bi-@_statusIcon" aria-hidden="true"></i>
             </span>
         }
     </div>

--- a/src/Feirb.Web/Components/UI/PersonChip.razor
+++ b/src/Feirb.Web/Components/UI/PersonChip.razor
@@ -1,4 +1,5 @@
 @namespace Feirb.Web.Components.UI
+@using Feirb.Shared.AddressBook
 @using Feirb.Shared.Avatars
 
 @* Compact person display with avatar placeholder, name, and optional email. *@
@@ -10,6 +11,12 @@
             <img src="@_avatarUrl" alt="" class="feirb-person-chip-avatar-img"
                  onload="if (this.naturalWidth === 0) { this.style.display='none'; } else { this.parentElement.style.borderStyle='solid'; }"
                  onerror="this.style.display='none'" />
+        }
+        @if (_statusIcon is not null)
+        {
+            <span class="feirb-person-chip-status feirb-person-chip-status-@_statusClass" title="@_statusTitle">
+                <i class="bi bi-@_statusIcon"></i>
+            </span>
         }
     </div>
     <div class="feirb-person-chip-info">
@@ -38,13 +45,34 @@
     [Parameter]
     public string? Class { get; set; }
 
+    /// <summary>Recipient status — controls the corner badge icon.</summary>
+    [Parameter]
+    public RecipientStatus Status { get; set; } = RecipientStatus.None;
+
+    /// <summary>Accessible title for the status badge.</summary>
+    [Parameter]
+    public string? StatusTitle { get; set; }
+
     private string? _avatarUrl;
+    private string? _statusIcon;
+    private string _statusClass = "none";
+    private string? _statusTitle;
 
     protected override void OnParametersSet()
     {
         _avatarUrl = !string.IsNullOrEmpty(Email)
             ? $"/api/avatars/{AvatarHashHelper.ComputeEmailHash(Email)}"
             : null;
+
+        (_statusIcon, _statusClass) = Status switch
+        {
+            RecipientStatus.Known => ("check-circle-fill", "known"),
+            RecipientStatus.Unknown => ("question-circle-fill", "unknown"),
+            RecipientStatus.Important => ("exclamation-circle-fill", "important"),
+            RecipientStatus.Blocked => ("x-circle-fill", "blocked"),
+            _ => (null, "none"),
+        };
+        _statusTitle = StatusTitle;
     }
 
     private string SizeCss => Size switch

--- a/src/Feirb.Web/Components/UI/PersonChip.razor
+++ b/src/Feirb.Web/Components/UI/PersonChip.razor
@@ -45,9 +45,9 @@
     [Parameter]
     public string? Class { get; set; }
 
-    /// <summary>Recipient status — controls the corner badge icon.</summary>
+    /// <summary>Address status — controls the corner badge icon. Null = no badge.</summary>
     [Parameter]
-    public RecipientStatus Status { get; set; } = RecipientStatus.None;
+    public AddressStatus? Status { get; set; }
 
     /// <summary>Accessible title for the status badge.</summary>
     [Parameter]
@@ -66,10 +66,10 @@
 
         (_statusIcon, _statusClass) = Status switch
         {
-            RecipientStatus.Known => ("check-circle-fill", "known"),
-            RecipientStatus.Unknown => ("question-circle-fill", "unknown"),
-            RecipientStatus.Important => ("exclamation-circle-fill", "important"),
-            RecipientStatus.Blocked => ("x-circle-fill", "blocked"),
+            AddressStatus.Known => ("check-circle-fill", "known"),
+            AddressStatus.Unknown => ("question-circle-fill", "unknown"),
+            AddressStatus.Important => ("exclamation-circle-fill", "important"),
+            AddressStatus.Blocked => ("x-circle-fill", "blocked"),
             _ => (null, "none"),
         };
         _statusTitle = StatusTitle;

--- a/src/Feirb.Web/Components/UI/PersonChip.razor.css
+++ b/src/Feirb.Web/Components/UI/PersonChip.razor.css
@@ -96,39 +96,43 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 0.75rem;
-    color: #fff;
-    background: var(--bs-secondary);
-    box-shadow: 0 0 0 2px var(--feirb-surface, var(--bs-body-bg));
+    font-size: 1rem;
+    color: var(--bs-secondary);
+    background: var(--feirb-surface);
     z-index: 2;
     pointer-events: none;
+    line-height: 1;
+}
+
+.feirb-person-chip-status > i {
+    display: block;
+    line-height: 1;
 }
 
 .feirb-person-chip-status-known {
-    background: var(--bs-primary);
+    color: var(--bs-success);
 }
 
 .feirb-person-chip-status-unknown {
-    background: var(--bs-warning);
-    color: #000;
+    color: var(--bs-info);
 }
 
 .feirb-person-chip-status-important {
-    background: var(--feirb-tertiary);
+    color: var(--bs-warning);
 }
 
 .feirb-person-chip-status-blocked {
-    background: var(--bs-danger);
+    color: var(--bs-danger);
 }
 
 .feirb-person-chip-sm .feirb-person-chip-status {
     width: 0.875rem;
     height: 0.875rem;
-    font-size: 0.625rem;
+    font-size: 0.875rem;
 }
 
 .feirb-person-chip-mini .feirb-person-chip-status {
     width: 0.75rem;
     height: 0.75rem;
-    font-size: 0.5rem;
+    font-size: 0.75rem;
 }

--- a/src/Feirb.Web/Components/UI/PersonChip.razor.css
+++ b/src/Feirb.Web/Components/UI/PersonChip.razor.css
@@ -17,7 +17,6 @@
     height: 2.75rem;
     border: 2px dashed var(--bs-primary);
     border-radius: 50%;
-    overflow: hidden;
 }
 
 .feirb-person-chip-avatar-img {
@@ -84,4 +83,52 @@
 
 .feirb-person-chip-mini .feirb-person-chip-email {
     font-size: 0.6875rem;
+}
+
+/* === Status badge === */
+.feirb-person-chip-status {
+    position: absolute;
+    bottom: -2px;
+    right: -2px;
+    width: 1rem;
+    height: 1rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    color: #fff;
+    background: var(--bs-secondary);
+    box-shadow: 0 0 0 2px var(--feirb-surface, var(--bs-body-bg));
+    z-index: 2;
+    pointer-events: none;
+}
+
+.feirb-person-chip-status-known {
+    background: var(--bs-primary);
+}
+
+.feirb-person-chip-status-unknown {
+    background: var(--bs-warning);
+    color: #000;
+}
+
+.feirb-person-chip-status-important {
+    background: var(--feirb-tertiary);
+}
+
+.feirb-person-chip-status-blocked {
+    background: var(--bs-danger);
+}
+
+.feirb-person-chip-sm .feirb-person-chip-status {
+    width: 0.875rem;
+    height: 0.875rem;
+    font-size: 0.625rem;
+}
+
+.feirb-person-chip-mini .feirb-person-chip-status {
+    width: 0.75rem;
+    height: 0.75rem;
+    font-size: 0.5rem;
 }

--- a/src/Feirb.Web/Components/UI/RecipientInput.razor
+++ b/src/Feirb.Web/Components/UI/RecipientInput.razor
@@ -1,4 +1,5 @@
 @namespace Feirb.Web.Components.UI
+@using Feirb.Shared.AddressBook
 @using Feirb.Shared.Mail
 @inject IJSRuntime Js
 @implements IAsyncDisposable
@@ -10,7 +11,7 @@
     {
         var key = $"{recipient.Email}-{GetFlashKey(recipient.Email)}";
         <div @key="key" class="feirb-recipient-token @(_flashingEmails.Contains(recipient.Email) ? "feirb-recipient-flash" : "")">
-            <PersonChip Name="@(recipient.Name ?? recipient.Email)" Email="@recipient.Email" Size="PersonChipSize.Mini" />
+            <PersonChip Name="@(recipient.Name ?? recipient.Email)" Email="@recipient.Email" Status="@recipient.Status" Size="PersonChipSize.Mini" />
             <button type="button" class="feirb-recipient-remove" @onclick="() => RemoveRecipientAsync(recipient)"
                     @onclick:stopPropagation="true" aria-label="Remove @(recipient.Name ?? recipient.Email)">
                 <Icon Name="x" Size="IconSize.Small" />
@@ -35,7 +36,7 @@
                 <button type="button" class="feirb-recipient-suggestion"
                         @onmousedown="() => SelectSuggestionAsync(suggestion)"
                         @onmousedown:preventDefault="true">
-                    <PersonChip Name="@suggestion.Name" Email="@suggestion.Email" Size="PersonChipSize.Mini" />
+                    <PersonChip Name="@suggestion.Name" Email="@suggestion.Email" Status="@suggestion.Status" Size="PersonChipSize.Mini" />
                 </button>
             }
         </div>
@@ -198,7 +199,7 @@
             c.Email.Equals(value, StringComparison.OrdinalIgnoreCase)
             || (c.Name?.Equals(value, StringComparison.OrdinalIgnoreCase) ?? false));
 
-        var entry = match ?? new RecipientEntry(null, value.Trim());
+        var entry = match ?? new RecipientEntry(null, value.Trim(), null);
 
         // Avoid duplicates — flash existing chip instead
         if (Recipients.Any(r => r.Email.Equals(entry.Email, StringComparison.OrdinalIgnoreCase)))

--- a/src/Feirb.Web/Components/UI/RecipientInput.razor
+++ b/src/Feirb.Web/Components/UI/RecipientInput.razor
@@ -51,9 +51,13 @@
     [Parameter]
     public EventCallback<List<RecipientEntry>> RecipientsChanged { get; set; }
 
-    /// <summary>Available contacts for autocomplete suggestions.</summary>
+    /// <summary>Available contacts for autocomplete suggestions (static list).</summary>
     [Parameter]
     public IReadOnlyList<RecipientEntry> Contacts { get; set; } = [];
+
+    /// <summary>Async contacts provider — when set, takes precedence over the static Contacts list.</summary>
+    [Parameter]
+    public Func<string, Task<IReadOnlyList<RecipientEntry>>>? ContactsProvider { get; set; }
 
     /// <summary>Placeholder text when no recipients are added.</summary>
     [Parameter]
@@ -137,9 +141,9 @@
         _debounceTimer.Elapsed += (_, _) =>
         {
             _debounceTimer?.Stop();
-            InvokeAsync(() =>
+            InvokeAsync(async () =>
             {
-                UpdateSuggestions(_currentQuery);
+                await UpdateSuggestionsAsync(_currentQuery);
                 StateHasChanged();
             });
         };
@@ -147,7 +151,7 @@
         _debounceTimer.Start();
     }
 
-    private void UpdateSuggestions(string query)
+    private async Task UpdateSuggestionsAsync(string query)
     {
         if (string.IsNullOrWhiteSpace(query) || query.Length < 2)
         {
@@ -157,14 +161,32 @@
         }
 
         var existingEmails = Recipients.Select(r => r.Email).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var q = query.ToLowerInvariant();
 
-        _suggestions = Contacts
-            .Where(c => !existingEmails.Contains(c.Email)
-                && (c.Email.Contains(q, StringComparison.OrdinalIgnoreCase)
-                    || (c.Name?.Contains(q, StringComparison.OrdinalIgnoreCase) ?? false)))
-            .Take(8)
-            .ToList();
+        if (ContactsProvider is not null)
+        {
+            try
+            {
+                var fetched = await ContactsProvider(query);
+                _suggestions = fetched
+                    .Where(c => !existingEmails.Contains(c.Email))
+                    .Take(8)
+                    .ToList();
+            }
+            catch
+            {
+                _suggestions.Clear();
+            }
+        }
+        else
+        {
+            var q = query.ToLowerInvariant();
+            _suggestions = Contacts
+                .Where(c => !existingEmails.Contains(c.Email)
+                    && (c.Email.Contains(q, StringComparison.OrdinalIgnoreCase)
+                        || (c.Name?.Contains(q, StringComparison.OrdinalIgnoreCase) ?? false)))
+                .Take(8)
+                .ToList();
+        }
 
         _showDropdown = _suggestions.Count > 0;
     }

--- a/src/Feirb.Web/Layout/NavMenu.razor
+++ b/src/Feirb.Web/Layout/NavMenu.razor
@@ -57,6 +57,7 @@
 
         _bottomItems =
         [
+            new("person-lines-fill", L["AddressBookNavLabel"], Href: "address-book", TestId: "nav-address-book"),
             new("gear", L["NavSettings"], Href: "settings", TestId: "nav-settings"),
             new("shield-lock", L["NavAdmin"], Href: "admin", Visible: () => _isAdmin, TestId: "nav-admin"),
             new("box-arrow-right", L["NavLogout"], OnClick: LogoutAsync, TestId: "nav-logout")

--- a/src/Feirb.Web/Pages/AddressBook/AddressBookPage.razor
+++ b/src/Feirb.Web/Pages/AddressBook/AddressBookPage.razor
@@ -1,0 +1,206 @@
+@page "/address-book"
+@using Feirb.Shared.AddressBook
+@using Feirb.Web.Components.UI
+@inject HttpClient Http
+@inject IStringLocalizer<SharedResources> L
+@inject NavigationManager Navigation
+
+<PageTitle>@L["AddressBookPageTitle"]</PageTitle>
+
+<InfoHeader Title="@L["AddressBookPageTitle"]" Icon="person-lines-fill" Subtitle="@L["AddressBookPageSubtitle"]" />
+
+<ContentSection Icon="people-fill" Title="@L["AddressBookContactsHeading"]" Subtitle="@L["AddressBookContactsSubtitle"]">
+    @if (_contactsLoading)
+    {
+        <div class="text-center py-4">
+            <div class="spinner-border spinner-border-sm" role="status"></div>
+        </div>
+    }
+    else if (_contacts is null || _contacts.Items.Count == 0)
+    {
+        <p class="text-muted mb-0">@L["AddressBookNoContacts"]</p>
+    }
+    else
+    {
+        <Table Hover>
+            <TableHeader>
+                <TableColumn>@L["AddressBookColumnName"]</TableColumn>
+                <TableColumn>@L["AddressBookColumnEmail"]</TableColumn>
+                <TableColumn Width="6rem">@L["AddressBookColumnAddresses"]</TableColumn>
+                <TableColumn Width="8rem">@L["AddressBookColumnStatus"]</TableColumn>
+            </TableHeader>
+            <TableBody>
+                @foreach (var contact in _contacts.Items)
+                {
+                    <TableRow OnClick="() => NavigateToContact(contact.Id)" data-testid="contact-row">
+                        <TableCell>
+                            <PersonChip Name="@contact.DisplayName"
+                                        Email="@contact.PrimaryEmail"
+                                        Size="PersonChipSize.Small"
+                                        Status="@(contact.IsImportant ? RecipientStatus.Important : RecipientStatus.Known)" />
+                        </TableCell>
+                        <TableCell>@(contact.PrimaryEmail ?? string.Empty)</TableCell>
+                        <TableCell>@contact.AddressCount</TableCell>
+                        <TableCell>
+                            @if (contact.IsImportant)
+                            {
+                                <span class="badge bg-warning text-dark">@L["AddressBookStatusImportant"]</span>
+                            }
+                            else
+                            {
+                                <span class="badge bg-secondary">@L["AddressBookStatusKnown"]</span>
+                            }
+                        </TableCell>
+                    </TableRow>
+                }
+            </TableBody>
+        </Table>
+        <Pagination CurrentPage="_contactsPage"
+                    TotalPages="_contacts.TotalPages"
+                    CurrentPageChanged="OnContactsPageChangedAsync"
+                    PreviousLabel="@L["PaginationPrevious"]"
+                    NextLabel="@L["PaginationNext"]" />
+    }
+</ContentSection>
+
+<ContentSection Icon="at" Title="@L["AddressBookAddressesHeading"]" Subtitle="@L["AddressBookAddressesSubtitle"]">
+    @if (_addressesLoading)
+    {
+        <div class="text-center py-4">
+            <div class="spinner-border spinner-border-sm" role="status"></div>
+        </div>
+    }
+    else if (_addresses is null || _addresses.Items.Count == 0)
+    {
+        <p class="text-muted mb-0">@L["AddressBookNoAddresses"]</p>
+    }
+    else
+    {
+        <Table Hover>
+            <TableHeader>
+                <TableColumn>@L["AddressBookColumnEmail"]</TableColumn>
+                <TableColumn>@L["AddressBookColumnContact"]</TableColumn>
+                <TableColumn Width="8rem">@L["AddressBookColumnStatus"]</TableColumn>
+                <TableColumn Width="6rem">@L["AddressBookColumnSeenCount"]</TableColumn>
+                <TableColumn Width="10rem">@L["AddressBookColumnLastSeen"]</TableColumn>
+            </TableHeader>
+            <TableBody>
+                @foreach (var addr in _addresses.Items)
+                {
+                    <TableRow OnClick="() => NavigateToAddress(addr.Id)" data-testid="address-row">
+                        <TableCell>
+                            <PersonChip Name="@addr.DisplayName"
+                                        Email="@addr.NormalizedEmail"
+                                        Size="PersonChipSize.Mini"
+                                        Status="@StatusForAddress(addr)" />
+                        </TableCell>
+                        <TableCell>
+                            @if (addr.ContactDisplayName is not null)
+                            {
+                                <span>@addr.ContactDisplayName</span>
+                            }
+                            else
+                            {
+                                <span class="text-muted small">@L["AddressDetailNoContact"]</span>
+                            }
+                        </TableCell>
+                        <TableCell>@StatusLabel(addr)</TableCell>
+                        <TableCell>@addr.SeenCount</TableCell>
+                        <TableCell>@addr.LastSeenAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</TableCell>
+                    </TableRow>
+                }
+            </TableBody>
+        </Table>
+        <Pagination CurrentPage="_addressesPage"
+                    TotalPages="_addresses.TotalPages"
+                    CurrentPageChanged="OnAddressesPageChangedAsync"
+                    PreviousLabel="@L["PaginationPrevious"]"
+                    NextLabel="@L["PaginationNext"]" />
+    }
+</ContentSection>
+
+@code {
+    private const int _pageSize = 25;
+
+    private PagedResult<ContactListItem>? _contacts;
+    private PagedResult<AddressResponse>? _addresses;
+    private bool _contactsLoading = true;
+    private bool _addressesLoading = true;
+    private int _contactsPage = 1;
+    private int _addressesPage = 1;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Task.WhenAll(LoadContactsAsync(), LoadAddressesAsync());
+    }
+
+    private async Task LoadContactsAsync()
+    {
+        _contactsLoading = true;
+        try
+        {
+            _contacts = await Http.GetFromJsonAsync<PagedResult<ContactListItem>>(
+                $"/api/address-book/contacts?page={_contactsPage}&pageSize={_pageSize}");
+        }
+        catch
+        {
+            _contacts = null;
+        }
+        finally
+        {
+            _contactsLoading = false;
+        }
+    }
+
+    private async Task LoadAddressesAsync()
+    {
+        _addressesLoading = true;
+        try
+        {
+            _addresses = await Http.GetFromJsonAsync<PagedResult<AddressResponse>>(
+                $"/api/address-book/addresses?page={_addressesPage}&pageSize={_pageSize}");
+        }
+        catch
+        {
+            _addresses = null;
+        }
+        finally
+        {
+            _addressesLoading = false;
+        }
+    }
+
+    private async Task OnContactsPageChangedAsync(int page)
+    {
+        _contactsPage = page;
+        await LoadContactsAsync();
+    }
+
+    private async Task OnAddressesPageChangedAsync(int page)
+    {
+        _addressesPage = page;
+        await LoadAddressesAsync();
+    }
+
+    private void NavigateToContact(Guid id) =>
+        Navigation.NavigateTo($"/address-book/contacts/{id}");
+
+    private void NavigateToAddress(Guid id) =>
+        Navigation.NavigateTo($"/address-book/addresses/{id}");
+
+    private RecipientStatus StatusForAddress(AddressResponse a)
+    {
+        if (a.IsBlocked) return RecipientStatus.Blocked;
+        if (a.IsImportant) return RecipientStatus.Important;
+        if (a.IsUnknown) return RecipientStatus.Unknown;
+        return RecipientStatus.Known;
+    }
+
+    private string StatusLabel(AddressResponse a) => StatusForAddress(a) switch
+    {
+        RecipientStatus.Blocked => L["AddressBookStatusBlocked"],
+        RecipientStatus.Important => L["AddressBookStatusImportant"],
+        RecipientStatus.Unknown => L["AddressBookStatusUnknown"],
+        _ => L["AddressBookStatusKnown"]
+    };
+}

--- a/src/Feirb.Web/Pages/AddressBook/AddressBookPage.razor
+++ b/src/Feirb.Web/Pages/AddressBook/AddressBookPage.razor
@@ -27,7 +27,6 @@
                 <TableColumn>@L["AddressBookColumnName"]</TableColumn>
                 <TableColumn>@L["AddressBookColumnEmail"]</TableColumn>
                 <TableColumn Width="6rem">@L["AddressBookColumnAddresses"]</TableColumn>
-                <TableColumn Width="8rem">@L["AddressBookColumnStatus"]</TableColumn>
             </TableHeader>
             <TableBody>
                 @foreach (var contact in _contacts.Items)
@@ -36,21 +35,10 @@
                         <TableCell>
                             <PersonChip Name="@contact.DisplayName"
                                         Email="@contact.PrimaryEmail"
-                                        Size="PersonChipSize.Small"
-                                        Status="@(contact.IsImportant ? RecipientStatus.Important : RecipientStatus.Known)" />
+                                        Size="PersonChipSize.Small" />
                         </TableCell>
                         <TableCell>@(contact.PrimaryEmail ?? string.Empty)</TableCell>
                         <TableCell>@contact.AddressCount</TableCell>
-                        <TableCell>
-                            @if (contact.IsImportant)
-                            {
-                                <span class="badge bg-warning text-dark">@L["AddressBookStatusImportant"]</span>
-                            }
-                            else
-                            {
-                                <span class="badge bg-secondary">@L["AddressBookStatusKnown"]</span>
-                            }
-                        </TableCell>
                     </TableRow>
                 }
             </TableBody>
@@ -92,7 +80,7 @@
                             <PersonChip Name="@addr.DisplayName"
                                         Email="@addr.NormalizedEmail"
                                         Size="PersonChipSize.Mini"
-                                        Status="@StatusForAddress(addr)" />
+                                        Status="@addr.Status" />
                         </TableCell>
                         <TableCell>
                             @if (addr.ContactDisplayName is not null)
@@ -104,7 +92,7 @@
                                 <span class="text-muted small">@L["AddressDetailNoContact"]</span>
                             }
                         </TableCell>
-                        <TableCell>@StatusLabel(addr)</TableCell>
+                        <TableCell>@StatusLabel(addr.Status)</TableCell>
                         <TableCell>@addr.SeenCount</TableCell>
                         <TableCell>@addr.LastSeenAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</TableCell>
                     </TableRow>
@@ -188,19 +176,11 @@
     private void NavigateToAddress(Guid id) =>
         Navigation.NavigateTo($"/address-book/addresses/{id}");
 
-    private RecipientStatus StatusForAddress(AddressResponse a)
+    private string StatusLabel(AddressStatus s) => s switch
     {
-        if (a.IsBlocked) return RecipientStatus.Blocked;
-        if (a.IsImportant) return RecipientStatus.Important;
-        if (a.IsUnknown) return RecipientStatus.Unknown;
-        return RecipientStatus.Known;
-    }
-
-    private string StatusLabel(AddressResponse a) => StatusForAddress(a) switch
-    {
-        RecipientStatus.Blocked => L["AddressBookStatusBlocked"],
-        RecipientStatus.Important => L["AddressBookStatusImportant"],
-        RecipientStatus.Unknown => L["AddressBookStatusUnknown"],
+        AddressStatus.Blocked => L["AddressBookStatusBlocked"],
+        AddressStatus.Important => L["AddressBookStatusImportant"],
+        AddressStatus.Unknown => L["AddressBookStatusUnknown"],
         _ => L["AddressBookStatusKnown"]
     };
 }

--- a/src/Feirb.Web/Pages/AddressBook/AddressDetail.razor
+++ b/src/Feirb.Web/Pages/AddressBook/AddressDetail.razor
@@ -24,7 +24,7 @@
 }
 else if (_address is null)
 {
-    <p class="text-muted">@L["AddressDetailPageTitle"]</p>
+    <p class="text-muted">@L["AddressNotFound"]</p>
 }
 else
 {
@@ -169,12 +169,12 @@ else
                 return true;
             }
 
-            Notifications.Add("Failed to save address.", NotificationSeverity.Error);
+            Notifications.Add(L["AddressSaveFailed"], NotificationSeverity.Error);
             return false;
         }
         catch
         {
-            Notifications.Add("Failed to save address.", NotificationSeverity.Error);
+            Notifications.Add(L["AddressSaveFailed"], NotificationSeverity.Error);
             return false;
         }
     }
@@ -191,12 +191,12 @@ else
             }
             else
             {
-                Notifications.Add("Failed to delete address.", NotificationSeverity.Error);
+                Notifications.Add(L["AddressDeleteFailed"], NotificationSeverity.Error);
             }
         }
         catch
         {
-            Notifications.Add("Failed to delete address.", NotificationSeverity.Error);
+            Notifications.Add(L["AddressDeleteFailed"], NotificationSeverity.Error);
         }
     }
 
@@ -214,12 +214,12 @@ else
             }
             else
             {
-                Notifications.Add("Failed to add to contacts.", NotificationSeverity.Error);
+                Notifications.Add(L["AddressPromoteFailed"], NotificationSeverity.Error);
             }
         }
         catch
         {
-            Notifications.Add("Failed to add to contacts.", NotificationSeverity.Error);
+            Notifications.Add(L["AddressPromoteFailed"], NotificationSeverity.Error);
         }
     }
 
@@ -235,12 +235,12 @@ else
             }
             else
             {
-                Notifications.Add("Failed to unlink address.", NotificationSeverity.Error);
+                Notifications.Add(L["AddressUnlinkFailed"], NotificationSeverity.Error);
             }
         }
         catch
         {
-            Notifications.Add("Failed to unlink address.", NotificationSeverity.Error);
+            Notifications.Add(L["AddressUnlinkFailed"], NotificationSeverity.Error);
         }
     }
 

--- a/src/Feirb.Web/Pages/AddressBook/AddressDetail.razor
+++ b/src/Feirb.Web/Pages/AddressBook/AddressDetail.razor
@@ -36,9 +36,13 @@ else
                 <InputText id="addressDisplayName" class="form-control" @bind-Value="_model.DisplayName" data-testid="address-display-name" />
                 <ValidationMessage For="() => _model.DisplayName" />
             </div>
-            <div class="form-check mb-3">
-                <InputCheckbox id="addressIsBlocked" class="form-check-input" @bind-Value="_model.IsBlocked" data-testid="address-is-blocked" />
-                <label for="addressIsBlocked" class="form-check-label">@L["AddressDetailIsBlocked"]</label>
+            <div class="mb-3">
+                <label class="form-label">@L["AddressDetailStatusLabel"]</label>
+                <ToggleButtonGroup Items="_statusItems"
+                                   SelectedId="@_model.StatusId"
+                                   SelectedIdChanged="OnStatusChanged"
+                                   For="() => _model.StatusId" />
+                <HelpHint>@StatusHint</HelpHint>
             </div>
         </TrackedEditForm>
     </ContentSection>
@@ -71,9 +75,32 @@ else
     private FormModel _model = new();
     private ToolbarAction[] _toolbarActions = [];
 
+    private IReadOnlyList<ToggleButtonItem> _statusItems = [];
+
     protected override async Task OnInitializedAsync()
     {
+        _statusItems =
+        [
+            new(nameof(AddressStatus.Unknown), L["AddressBookStatusUnknown"]),
+            new(nameof(AddressStatus.Known), L["AddressBookStatusKnown"]),
+            new(nameof(AddressStatus.Important), L["AddressBookStatusImportant"]),
+            new(nameof(AddressStatus.Blocked), L["AddressBookStatusBlocked"]),
+        ];
         await LoadAsync();
+    }
+
+    private string StatusHint => _model.Status switch
+    {
+        AddressStatus.Known => L["AddressStatusHintKnown"],
+        AddressStatus.Important => L["AddressStatusHintImportant"],
+        AddressStatus.Blocked => L["AddressStatusHintBlocked"],
+        _ => L["AddressStatusHintUnknown"],
+    };
+
+    private void OnStatusChanged(string id)
+    {
+        _model.StatusId = id;
+        _model.Status = Enum.Parse<AddressStatus>(id);
     }
 
     private async Task LoadAsync()
@@ -87,7 +114,8 @@ else
                 _model = new FormModel
                 {
                     DisplayName = _address.DisplayName,
-                    IsBlocked = _address.IsBlocked,
+                    Status = _address.Status,
+                    StatusId = _address.Status.ToString(),
                 };
                 BreadcrumbOverride.SetLastSegmentLabel(_address.NormalizedEmail);
             }
@@ -132,7 +160,7 @@ else
     {
         try
         {
-            var request = new UpdateAddressRequest(_model.DisplayName!, _model.IsBlocked);
+            var request = new UpdateAddressRequest(_model.DisplayName!, _model.Status);
             var response = await Http.PutAsJsonAsync($"/api/address-book/addresses/{Id}", request);
             if (response.IsSuccessStatusCode)
             {
@@ -177,7 +205,7 @@ else
         if (_address is null) return;
         try
         {
-            var request = new PromoteAddressRequest(_address.DisplayName, null, false);
+            var request = new PromoteAddressRequest(_address.DisplayName, null, AddressStatus.Known);
             var response = await Http.PostAsJsonAsync($"/api/address-book/addresses/{Id}/promote", request);
             if (response.IsSuccessStatusCode)
             {
@@ -228,6 +256,8 @@ else
         [System.ComponentModel.DataAnnotations.StringLength(256)]
         public string? DisplayName { get; set; }
 
-        public bool IsBlocked { get; set; }
+        public AddressStatus Status { get; set; } = AddressStatus.Unknown;
+
+        public string StatusId { get; set; } = nameof(AddressStatus.Unknown);
     }
 }

--- a/src/Feirb.Web/Pages/AddressBook/AddressDetail.razor
+++ b/src/Feirb.Web/Pages/AddressBook/AddressDetail.razor
@@ -1,0 +1,233 @@
+@page "/address-book/addresses/{Id:guid}"
+@using Feirb.Shared.AddressBook
+@using Feirb.Web.Components.UI
+@inject HttpClient Http
+@inject IStringLocalizer<SharedResources> L
+@inject NavigationManager Navigation
+@inject NotificationService Notifications
+@inject BreadcrumbOverrideService BreadcrumbOverride
+@inject ToolbarStateService ToolbarState
+@inject UnsavedChangesService UnsavedChanges
+@implements IDisposable
+
+<PageTitle>@(_address?.NormalizedEmail ?? L["AddressDetailPageTitle"])</PageTitle>
+
+<InfoHeader Title="@(_address?.NormalizedEmail ?? L["AddressDetailPageTitle"])"
+            Icon="at"
+            Subtitle="@L["AddressDetailPageTitle"]" />
+
+@if (_loading)
+{
+    <div class="text-center py-5">
+        <div class="spinner-border" role="status"></div>
+    </div>
+}
+else if (_address is null)
+{
+    <p class="text-muted">@L["AddressDetailPageTitle"]</p>
+}
+else
+{
+    <ContentSection Icon="at" Title="@L["AddressDetailPageTitle"]" Subtitle="@_address.NormalizedEmail">
+        <TrackedEditForm Model="_model" OnSave="HandleSaveAsync">
+            <DataAnnotationsValidator />
+            <div class="mb-3">
+                <label for="addressDisplayName" class="form-label">@L["AddressDetailDisplayName"]</label>
+                <InputText id="addressDisplayName" class="form-control" @bind-Value="_model.DisplayName" data-testid="address-display-name" />
+                <ValidationMessage For="() => _model.DisplayName" />
+            </div>
+            <div class="form-check mb-3">
+                <InputCheckbox id="addressIsBlocked" class="form-check-input" @bind-Value="_model.IsBlocked" data-testid="address-is-blocked" />
+                <label for="addressIsBlocked" class="form-check-label">@L["AddressDetailIsBlocked"]</label>
+            </div>
+        </TrackedEditForm>
+    </ContentSection>
+
+    <ContentSection Icon="person" Title="@L["AddressDetailLinkedContact"]">
+        @if (_address.ContactId is not null)
+        {
+            <div class="d-flex align-items-center gap-3 flex-wrap">
+                <a href="@($"/address-book/contacts/{_address.ContactId}")" class="link-primary">
+                    @_address.ContactDisplayName
+                </a>
+                <Button Variant="ButtonVariant.Secondary" OnClick="HandleUnlinkAsync" Icon="link-45deg" data-testid="address-unlink">
+                    @L["AddressDetailUnlink"]
+                </Button>
+            </div>
+        }
+        else
+        {
+            <p class="text-muted mb-0">@L["AddressDetailNoContact"]</p>
+        }
+    </ContentSection>
+}
+
+@code {
+    [Parameter]
+    public Guid Id { get; set; }
+
+    private AddressResponse? _address;
+    private bool _loading = true;
+    private FormModel _model = new();
+    private ToolbarAction[] _toolbarActions = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        try
+        {
+            _address = await Http.GetFromJsonAsync<AddressResponse>($"/api/address-book/addresses/{Id}");
+            if (_address is not null)
+            {
+                _model = new FormModel
+                {
+                    DisplayName = _address.DisplayName,
+                    IsBlocked = _address.IsBlocked,
+                };
+                BreadcrumbOverride.SetLastSegmentLabel(_address.NormalizedEmail);
+            }
+        }
+        catch
+        {
+            _address = null;
+        }
+        finally
+        {
+            _loading = false;
+            RebuildToolbar();
+        }
+    }
+
+    private void RebuildToolbar()
+    {
+        ToolbarState.RemoveActions(_toolbarActions);
+
+        var actions = new List<ToolbarAction>
+        {
+            new(L["ButtonCancel"], ButtonVariant.Warning,
+                () => { Navigation.NavigateTo("/address-book"); return Task.CompletedTask; }, "x-lg"),
+            new(L["ButtonSave"], ButtonVariant.Primary,
+                async () => { await UnsavedChanges.SaveAllAsync(); }, "check-lg"),
+        };
+
+        if (_address is not null && _address.ContactId is null)
+        {
+            actions.Add(new ToolbarAction(L["AddressDetailPromote"], ButtonVariant.Secondary,
+                HandlePromoteAsync, "person-plus"));
+        }
+
+        actions.Add(new ToolbarAction(L["ButtonDelete"], ButtonVariant.Danger,
+            HandleDeleteAsync, "trash"));
+
+        _toolbarActions = [.. actions];
+        ToolbarState.AddActions(_toolbarActions);
+    }
+
+    private async Task<bool> HandleSaveAsync()
+    {
+        try
+        {
+            var request = new UpdateAddressRequest(_model.DisplayName!, _model.IsBlocked);
+            var response = await Http.PutAsJsonAsync($"/api/address-book/addresses/{Id}", request);
+            if (response.IsSuccessStatusCode)
+            {
+                Notifications.Add(L["ButtonSave"], NotificationSeverity.Success);
+                await LoadAsync();
+                return true;
+            }
+
+            Notifications.Add("Failed to save address.", NotificationSeverity.Error);
+            return false;
+        }
+        catch
+        {
+            Notifications.Add("Failed to save address.", NotificationSeverity.Error);
+            return false;
+        }
+    }
+
+    private async Task HandleDeleteAsync()
+    {
+        try
+        {
+            var response = await Http.DeleteAsync($"/api/address-book/addresses/{Id}");
+            if (response.IsSuccessStatusCode)
+            {
+                Notifications.Add(L["ButtonDelete"], NotificationSeverity.Success);
+                Navigation.NavigateTo("/address-book");
+            }
+            else
+            {
+                Notifications.Add("Failed to delete address.", NotificationSeverity.Error);
+            }
+        }
+        catch
+        {
+            Notifications.Add("Failed to delete address.", NotificationSeverity.Error);
+        }
+    }
+
+    private async Task HandlePromoteAsync()
+    {
+        if (_address is null) return;
+        try
+        {
+            var request = new PromoteAddressRequest(_address.DisplayName, null, false);
+            var response = await Http.PostAsJsonAsync($"/api/address-book/addresses/{Id}/promote", request);
+            if (response.IsSuccessStatusCode)
+            {
+                Notifications.Add(L["AddressDetailPromote"], NotificationSeverity.Success);
+                await LoadAsync();
+            }
+            else
+            {
+                Notifications.Add("Failed to add to contacts.", NotificationSeverity.Error);
+            }
+        }
+        catch
+        {
+            Notifications.Add("Failed to add to contacts.", NotificationSeverity.Error);
+        }
+    }
+
+    private async Task HandleUnlinkAsync()
+    {
+        try
+        {
+            var response = await Http.PostAsync($"/api/address-book/addresses/{Id}/unlink", null);
+            if (response.IsSuccessStatusCode)
+            {
+                Notifications.Add(L["AddressDetailUnlink"], NotificationSeverity.Success);
+                await LoadAsync();
+            }
+            else
+            {
+                Notifications.Add("Failed to unlink address.", NotificationSeverity.Error);
+            }
+        }
+        catch
+        {
+            Notifications.Add("Failed to unlink address.", NotificationSeverity.Error);
+        }
+    }
+
+    public void Dispose()
+    {
+        ToolbarState.RemoveActions(_toolbarActions);
+        BreadcrumbOverride.Clear();
+    }
+
+    private sealed class FormModel
+    {
+        [System.ComponentModel.DataAnnotations.Required]
+        [System.ComponentModel.DataAnnotations.StringLength(256)]
+        public string? DisplayName { get; set; }
+
+        public bool IsBlocked { get; set; }
+    }
+}

--- a/src/Feirb.Web/Pages/AddressBook/ContactDetail.razor
+++ b/src/Feirb.Web/Pages/AddressBook/ContactDetail.razor
@@ -40,10 +40,7 @@ else
                 <label for="contactNotes" class="form-label">@L["ContactDetailNotes"]</label>
                 <InputTextArea id="contactNotes" class="form-control" rows="4" @bind-Value="_model.Notes" data-testid="contact-notes" />
             </div>
-            <div class="form-check mb-3">
-                <InputCheckbox id="contactImportant" class="form-check-input" @bind-Value="_model.IsImportant" data-testid="contact-is-important" />
-                <label for="contactImportant" class="form-check-label">@L["ContactDetailIsImportant"]</label>
-            </div>
+            <p class="text-muted small mb-0">@L["ContactDetailStatusPerAddressHint"]</p>
         </TrackedEditForm>
     </ContentSection>
 
@@ -111,7 +108,6 @@ else
                 {
                     DisplayName = _contact.DisplayName,
                     Notes = _contact.Notes,
-                    IsImportant = _contact.IsImportant,
                 };
                 BreadcrumbOverride.SetLastSegmentLabel(_contact.DisplayName);
             }
@@ -131,7 +127,7 @@ else
         if (_contact is null) return false;
         try
         {
-            var request = new UpdateContactRequest(_model.DisplayName!, _model.Notes, _model.IsImportant);
+            var request = new UpdateContactRequest(_model.DisplayName!, _model.Notes);
             var response = await Http.PutAsJsonAsync($"/api/address-book/contacts/{Id}", request);
             if (response.IsSuccessStatusCode)
             {
@@ -188,7 +184,5 @@ else
 
         [System.ComponentModel.DataAnnotations.StringLength(2048)]
         public string? Notes { get; set; }
-
-        public bool IsImportant { get; set; }
     }
 }

--- a/src/Feirb.Web/Pages/AddressBook/ContactDetail.razor
+++ b/src/Feirb.Web/Pages/AddressBook/ContactDetail.razor
@@ -136,12 +136,12 @@ else
                 return true;
             }
 
-            Notifications.Add("Failed to save contact.", NotificationSeverity.Error);
+            Notifications.Add(L["ContactSaveFailed"], NotificationSeverity.Error);
             return false;
         }
         catch
         {
-            Notifications.Add("Failed to save contact.", NotificationSeverity.Error);
+            Notifications.Add(L["ContactSaveFailed"], NotificationSeverity.Error);
             return false;
         }
     }
@@ -158,12 +158,12 @@ else
             }
             else
             {
-                Notifications.Add("Failed to delete contact.", NotificationSeverity.Error);
+                Notifications.Add(L["ContactDeleteFailed"], NotificationSeverity.Error);
             }
         }
         catch
         {
-            Notifications.Add("Failed to delete contact.", NotificationSeverity.Error);
+            Notifications.Add(L["ContactDeleteFailed"], NotificationSeverity.Error);
         }
     }
 

--- a/src/Feirb.Web/Pages/AddressBook/ContactDetail.razor
+++ b/src/Feirb.Web/Pages/AddressBook/ContactDetail.razor
@@ -1,0 +1,194 @@
+@page "/address-book/contacts/{Id:guid}"
+@using Feirb.Shared.AddressBook
+@using Feirb.Web.Components.UI
+@inject HttpClient Http
+@inject IStringLocalizer<SharedResources> L
+@inject NavigationManager Navigation
+@inject NotificationService Notifications
+@inject BreadcrumbOverrideService BreadcrumbOverride
+@inject ToolbarStateService ToolbarState
+@inject UnsavedChangesService UnsavedChanges
+@implements IDisposable
+
+<PageTitle>@(_contact?.DisplayName ?? L["ContactDetailPageTitle"])</PageTitle>
+
+<InfoHeader Title="@(_contact?.DisplayName ?? L["ContactDetailPageTitle"])"
+            Icon="person-fill"
+            Subtitle="@L["ContactDetailPageTitle"]" />
+
+@if (_loading)
+{
+    <div class="text-center py-5">
+        <div class="spinner-border" role="status"></div>
+    </div>
+}
+else if (_contact is null)
+{
+    <p class="text-muted">@L["ContactNotFound"]</p>
+}
+else
+{
+    <ContentSection Icon="person-gear" Title="@L["ContactDetailPageTitle"]" Subtitle="@_contact.DisplayName">
+        <TrackedEditForm Model="_model" OnSave="HandleSaveAsync">
+            <DataAnnotationsValidator />
+            <div class="mb-3">
+                <label for="contactDisplayName" class="form-label">@L["ContactDetailDisplayName"]</label>
+                <InputText id="contactDisplayName" class="form-control" @bind-Value="_model.DisplayName" data-testid="contact-display-name" />
+                <ValidationMessage For="() => _model.DisplayName" />
+            </div>
+            <div class="mb-3">
+                <label for="contactNotes" class="form-label">@L["ContactDetailNotes"]</label>
+                <InputTextArea id="contactNotes" class="form-control" rows="4" @bind-Value="_model.Notes" data-testid="contact-notes" />
+            </div>
+            <div class="form-check mb-3">
+                <InputCheckbox id="contactImportant" class="form-check-input" @bind-Value="_model.IsImportant" data-testid="contact-is-important" />
+                <label for="contactImportant" class="form-check-label">@L["ContactDetailIsImportant"]</label>
+            </div>
+        </TrackedEditForm>
+    </ContentSection>
+
+    <ContentSection Icon="at" Title="@L["ContactDetailLinkedAddresses"]">
+        @if (_contact.Addresses.Count == 0)
+        {
+            <p class="text-muted mb-0">@L["AddressBookNoAddresses"]</p>
+        }
+        else
+        {
+            <Table Hover>
+                <TableHeader>
+                    <TableColumn>@L["AddressBookColumnEmail"]</TableColumn>
+                    <TableColumn Width="8rem">@L["AddressBookColumnSeenCount"]</TableColumn>
+                    <TableColumn Width="10rem">@L["AddressBookColumnLastSeen"]</TableColumn>
+                </TableHeader>
+                <TableBody>
+                    @foreach (var addr in _contact.Addresses)
+                    {
+                        <TableRow OnClick="() => NavigateToAddress(addr.Id)">
+                            <TableCell>@addr.NormalizedEmail</TableCell>
+                            <TableCell>@addr.SeenCount</TableCell>
+                            <TableCell>@addr.LastSeenAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</TableCell>
+                        </TableRow>
+                    }
+                </TableBody>
+            </Table>
+        }
+    </ContentSection>
+}
+
+@code {
+    [Parameter]
+    public Guid Id { get; set; }
+
+    private ContactResponse? _contact;
+    private bool _loading = true;
+    private FormModel _model = new();
+    private ToolbarAction[] _toolbarActions = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        _toolbarActions =
+        [
+            new ToolbarAction(L["ButtonCancel"], ButtonVariant.Warning,
+                () => { Navigation.NavigateTo("/address-book"); return Task.CompletedTask; }, "x-lg"),
+            new ToolbarAction(L["ButtonSave"], ButtonVariant.Primary,
+                async () => { await UnsavedChanges.SaveAllAsync(); }, "check-lg"),
+            new ToolbarAction(L["ButtonDelete"], ButtonVariant.Danger, HandleDeleteAsync, "trash"),
+        ];
+        ToolbarState.AddActions(_toolbarActions);
+
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        try
+        {
+            _contact = await Http.GetFromJsonAsync<ContactResponse>($"/api/address-book/contacts/{Id}");
+            if (_contact is not null)
+            {
+                _model = new FormModel
+                {
+                    DisplayName = _contact.DisplayName,
+                    Notes = _contact.Notes,
+                    IsImportant = _contact.IsImportant,
+                };
+                BreadcrumbOverride.SetLastSegmentLabel(_contact.DisplayName);
+            }
+        }
+        catch
+        {
+            _contact = null;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task<bool> HandleSaveAsync()
+    {
+        if (_contact is null) return false;
+        try
+        {
+            var request = new UpdateContactRequest(_model.DisplayName!, _model.Notes, _model.IsImportant);
+            var response = await Http.PutAsJsonAsync($"/api/address-book/contacts/{Id}", request);
+            if (response.IsSuccessStatusCode)
+            {
+                Notifications.Add(L["ButtonSave"], NotificationSeverity.Success);
+                await LoadAsync();
+                return true;
+            }
+
+            Notifications.Add("Failed to save contact.", NotificationSeverity.Error);
+            return false;
+        }
+        catch
+        {
+            Notifications.Add("Failed to save contact.", NotificationSeverity.Error);
+            return false;
+        }
+    }
+
+    private async Task HandleDeleteAsync()
+    {
+        try
+        {
+            var response = await Http.DeleteAsync($"/api/address-book/contacts/{Id}");
+            if (response.IsSuccessStatusCode)
+            {
+                Notifications.Add(L["ButtonDelete"], NotificationSeverity.Success);
+                Navigation.NavigateTo("/address-book");
+            }
+            else
+            {
+                Notifications.Add("Failed to delete contact.", NotificationSeverity.Error);
+            }
+        }
+        catch
+        {
+            Notifications.Add("Failed to delete contact.", NotificationSeverity.Error);
+        }
+    }
+
+    private void NavigateToAddress(Guid addressId) =>
+        Navigation.NavigateTo($"/address-book/addresses/{addressId}");
+
+    public void Dispose()
+    {
+        ToolbarState.RemoveActions(_toolbarActions);
+        BreadcrumbOverride.Clear();
+    }
+
+    private sealed class FormModel
+    {
+        [System.ComponentModel.DataAnnotations.Required]
+        [System.ComponentModel.DataAnnotations.StringLength(256)]
+        public string? DisplayName { get; set; }
+
+        [System.ComponentModel.DataAnnotations.StringLength(2048)]
+        public string? Notes { get; set; }
+
+        public bool IsImportant { get; set; }
+    }
+}

--- a/src/Feirb.Web/Pages/Admin/SystemSettings/JobDetail.razor
+++ b/src/Feirb.Web/Pages/Admin/SystemSettings/JobDetail.razor
@@ -36,7 +36,7 @@ else if (_model is not null)
 {
     <TrackedEditForm Model="_model" OnSave="HandleSaveAsync">
         <DataAnnotationsValidator />
-        <ContentSection Icon="calendar-event" Title="@L["JobDetailSectionSchedule"]" Subtitle="@L["JobDetailSectionScheduleSubtitle"]" Class="mb-4">
+        <ContentSection Icon="calendar-event" Title="@L["JobDetailSectionSchedule"]" Subtitle="@L["JobDetailSectionScheduleSubtitle"]">
             <div class="mb-3">
                 <label class="form-label">@L["JobsCronSchedule"]</label>
                 <ToggleButtonGroup Items="_schedulePresets" SelectedId="@_selectedPreset" SelectedIdChanged="OnPresetChanged" For="() => _model.Cron" />

--- a/src/Feirb.Web/Pages/Admin/SystemSettings/OutgoingSmtp.razor
+++ b/src/Feirb.Web/Pages/Admin/SystemSettings/OutgoingSmtp.razor
@@ -46,7 +46,7 @@ else if (_model is not null)
     <TrackedEditForm Model="_model" OnSave="HandleSaveAsync">
         <DataAnnotationsValidator />
 
-        <ContentSection Icon="send" Title="@L["MailboxSectionSmtp"]" Subtitle="@L["SectionSmtpSubtitle"]" Class="mb-4">
+        <ContentSection Icon="send" Title="@L["MailboxSectionSmtp"]" Subtitle="@L["SectionSmtpSubtitle"]">
                 <div class="row mb-3">
                     <div class="col-md-8">
                         <label for="smtpHost" class="form-label">@L["LabelSmtpHostMailbox"]</label>
@@ -100,7 +100,7 @@ else if (_model is not null)
                 }
         </ContentSection>
 
-        <ContentSection Icon="person" Title="@L["SectionSender"]" Subtitle="@L["SectionSenderSubtitle"]" Class="mb-4">
+        <ContentSection Icon="person" Title="@L["SectionSender"]" Subtitle="@L["SectionSenderSubtitle"]">
                 <div class="row mb-3">
                     <div class="col-md-6">
                         <label for="fromAddress" class="form-label">@L["LabelFromAddress"]</label>

--- a/src/Feirb.Web/Pages/ComponentsShowcase.razor
+++ b/src/Feirb.Web/Pages/ComponentsShowcase.razor
@@ -86,6 +86,9 @@
     case "recipient-input":
         <ShowcaseRecipientInput />
         break;
+    case "help-hint":
+        <ShowcaseHelpHint />
+        break;
     default:
         <div class="text-center py-5">
             <Feirb.Web.Components.UI.Icon Name="palette2" Size="Feirb.Web.Components.UI.IconSize.Large" Class="mb-3 d-block mx-auto" />

--- a/src/Feirb.Web/Pages/Compose.razor
+++ b/src/Feirb.Web/Pages/Compose.razor
@@ -231,7 +231,7 @@ else
                 $"/api/mail/recipients/search?q={encoded}");
             return suggestions is null
                 ? []
-                : suggestions.Select(s => new RecipientEntry(s.DisplayName, s.Email)).ToList();
+                : suggestions.Select(s => new RecipientEntry(s.DisplayName, s.Email, s.Status)).ToList();
         }
         catch
         {

--- a/src/Feirb.Web/Pages/Compose.razor
+++ b/src/Feirb.Web/Pages/Compose.razor
@@ -1,5 +1,6 @@
 @page "/compose"
 @attribute [Authorize]
+@using Feirb.Shared.AddressBook
 @using Feirb.Shared.Mail
 @using Feirb.Shared.Settings
 @inject HttpClient Http
@@ -56,6 +57,7 @@ else
                                     Id="compose-to"
                                     Placeholder="@L["ComposePlaceholderTo"]"
                                     DataTestId="compose-to"
+                                    ContactsProvider="SearchRecipientsAsync"
                                     Class="@(HasError("to") ? "is-invalid" : "")" />
                     <Toggle Text="@L["ComposeShowCcBcc"]"
                             DisabledText="@L["ComposeShowCcBccOff"]"
@@ -77,6 +79,7 @@ else
                                     Id="compose-cc"
                                     Placeholder="@L["ComposePlaceholderCc"]"
                                     DataTestId="compose-cc"
+                                    ContactsProvider="SearchRecipientsAsync"
                                     Class="@(HasError("cc") ? "is-invalid" : "")" />
                     @if (HasError("cc"))
                     {
@@ -89,6 +92,7 @@ else
                                     Id="compose-bcc"
                                     Placeholder="@L["ComposePlaceholderBcc"]"
                                     DataTestId="compose-bcc"
+                                    ContactsProvider="SearchRecipientsAsync"
                                     Class="@(HasError("bcc") ? "is-invalid" : "")" />
                     @if (HasError("bcc"))
                     {
@@ -215,6 +219,23 @@ else
                 // Ignored during disposal
             }
             _quillInitialized = false;
+        }
+    }
+
+    private async Task<IReadOnlyList<RecipientEntry>> SearchRecipientsAsync(string query)
+    {
+        try
+        {
+            var encoded = Uri.EscapeDataString(query);
+            var suggestions = await Http.GetFromJsonAsync<List<RecipientSuggestion>>(
+                $"/api/mail/recipients/search?q={encoded}");
+            return suggestions is null
+                ? []
+                : suggestions.Select(s => new RecipientEntry(s.DisplayName, s.Email)).ToList();
+        }
+        catch
+        {
+            return [];
         }
     }
 

--- a/src/Feirb.Web/Pages/Inbox.razor
+++ b/src/Feirb.Web/Pages/Inbox.razor
@@ -41,6 +41,7 @@ else if (UseCardLayout)
             <MailCard Mode="MailCardMode.Small"
                       SenderName="@msg.FromName"
                       SenderEmail="@msg.FromEmail"
+                      SenderStatus="@msg.SenderStatus"
                       Subject="@msg.Subject"
                       Summary="@msg.Summary"
                       Labels="@msg.Labels.Select(l => new MailCardLabel(l.Name, l.Color)).ToList()"
@@ -81,7 +82,7 @@ else
                             <MailboxChip Name="@msg.MailboxName" Color="@msg.MailboxBadgeColor" />
                         </TableCell>
                         <TableCell>
-                            <PersonChip Name="@msg.FromName" Email="@msg.FromEmail" Size="PersonChipSize.Small" />
+                            <PersonChip Name="@msg.FromName" Email="@msg.FromEmail" Status="@msg.SenderStatus" Size="PersonChipSize.Small" />
                         </TableCell>
                         <TableCell Class="inbox-subject-cell">
                             <MailSubjectChip Subject="@msg.Subject"

--- a/src/Feirb.Web/Pages/Settings/Mailboxes/Create.razor
+++ b/src/Feirb.Web/Pages/Settings/Mailboxes/Create.razor
@@ -25,7 +25,7 @@
 <TrackedEditForm Model="_model" OnSave="HandleSaveAsync" data-testid="mailbox-form">
     <DataAnnotationsValidator />
 
-    <ContentSection Icon="info-circle" Title="@L["MailboxSectionGeneral"]" Subtitle="@L["SectionMailboxGeneralSubtitle"]" Class="mb-4">
+    <ContentSection Icon="info-circle" Title="@L["MailboxSectionGeneral"]" Subtitle="@L["SectionMailboxGeneralSubtitle"]">
         <div class="mb-3">
             <label for="name" class="form-label">@L["LabelMailboxName"]</label>
             <InputText id="name" class="form-control" @bind-Value="_model.Name" placeholder="@L["PlaceholderMailboxName"]" data-testid="mailbox-name" />
@@ -46,7 +46,7 @@
         </div>
     </ContentSection>
 
-    <ContentSection Icon="inbox" Title="@L["MailboxSectionImap"]" Subtitle="@L["SectionMailboxImapSubtitle"]" Class="mb-4">
+    <ContentSection Icon="inbox" Title="@L["MailboxSectionImap"]" Subtitle="@L["SectionMailboxImapSubtitle"]">
         <div class="row mb-3">
             <div class="col-md-8">
                 <label for="imapHost" class="form-label">@L["LabelImapHost"]</label>
@@ -91,7 +91,7 @@
         }
     </ContentSection>
 
-    <ContentSection Icon="inbox" Title="@L["MailboxSectionSmtp"]" Subtitle="@L["SectionMailboxSmtpSubtitle"]" Class="mb-4">
+    <ContentSection Icon="inbox" Title="@L["MailboxSectionSmtp"]" Subtitle="@L["SectionMailboxSmtpSubtitle"]">
         <div class="row mb-3">
             <div class="col-md-8">
                 <label for="smtpHost" class="form-label">@L["LabelSmtpHostMailbox"]</label>

--- a/src/Feirb.Web/Pages/Settings/Mailboxes/Edit.razor
+++ b/src/Feirb.Web/Pages/Settings/Mailboxes/Edit.razor
@@ -52,7 +52,7 @@ else if (_model is not null)
     <TrackedEditForm Model="_model" OnSave="HandleSaveAsync">
         <DataAnnotationsValidator />
 
-        <ContentSection Icon="info-circle" Title="@L["MailboxSectionGeneral"]" Subtitle="@L["SectionMailboxGeneralSubtitle"]" Class="mb-4">
+        <ContentSection Icon="info-circle" Title="@L["MailboxSectionGeneral"]" Subtitle="@L["SectionMailboxGeneralSubtitle"]">
             <div class="mb-3">
                 <label for="name" class="form-label">@L["LabelMailboxName"]</label>
                 <InputText id="name" class="form-control" @bind-Value="_model.Name" placeholder="@L["PlaceholderMailboxName"]" />
@@ -73,7 +73,7 @@ else if (_model is not null)
             </div>
         </ContentSection>
 
-        <ContentSection Icon="inbox" Title="@L["MailboxSectionImap"]" Subtitle="@L["SectionMailboxImapSubtitle"]" Class="mb-4">
+        <ContentSection Icon="inbox" Title="@L["MailboxSectionImap"]" Subtitle="@L["SectionMailboxImapSubtitle"]">
             <div class="row mb-3">
                 <div class="col-md-8">
                     <label for="imapHost" class="form-label">@L["LabelImapHost"]</label>
@@ -119,7 +119,7 @@ else if (_model is not null)
             }
         </ContentSection>
 
-        <ContentSection Icon="inbox" Title="@L["MailboxSectionSmtp"]" Subtitle="@L["SectionMailboxSmtpSubtitle"]" Class="mb-4">
+        <ContentSection Icon="inbox" Title="@L["MailboxSectionSmtp"]" Subtitle="@L["SectionMailboxSmtpSubtitle"]">
             <div class="row mb-3">
                 <div class="col-md-8">
                     <label for="smtpHost" class="form-label">@L["LabelSmtpHostMailbox"]</label>
@@ -175,7 +175,7 @@ else if (_model is not null)
         </ContentSection>
     </TrackedEditForm>
 
-    <ContentSection Icon="clock" Title="@L["MailboxSectionSyncSchedule"]" Subtitle="@L["SectionMailboxSyncScheduleSubtitle"]" Class="mb-4">
+    <ContentSection Icon="clock" Title="@L["MailboxSectionSyncSchedule"]" Subtitle="@L["SectionMailboxSyncScheduleSubtitle"]">
         <JobSettingsPanel ResourceType="Mailbox" ResourceId="@Id" />
     </ContentSection>
 }

--- a/src/Feirb.Web/Pages/Settings/Profile/Security.razor
+++ b/src/Feirb.Web/Pages/Settings/Profile/Security.razor
@@ -30,7 +30,7 @@
     </div>
 }
 
-<ContentSection Icon="key" Title="@L["SecurityChangePasswordTitle"]" Subtitle="@L["SectionChangePasswordSubtitle"]" Class="mb-4">
+<ContentSection Icon="key" Title="@L["SecurityChangePasswordTitle"]" Subtitle="@L["SectionChangePasswordSubtitle"]">
     <EditForm Model="_passwordModel" OnValidSubmit="HandleChangePasswordAsync">
         <DataAnnotationsValidator />
 

--- a/src/Feirb.Web/Pages/Showcase/ShowcaseDesignFundamentals.razor
+++ b/src/Feirb.Web/Pages/Showcase/ShowcaseDesignFundamentals.razor
@@ -38,11 +38,27 @@
             </div>
         </div>
         <div class="showcase-color-item">
+            <div class="showcase-color-swatch" style="background-color: var(--bs-success);"></div>
+            <div class="showcase-color-info">
+                <strong class="showcase-color-name">Success</strong>
+                <code class="showcase-color-token">--bs-success</code>
+                <span class="showcase-color-usage text-muted">Known / positive status</span>
+            </div>
+        </div>
+        <div class="showcase-color-item">
+            <div class="showcase-color-swatch" style="background-color: var(--bs-info);"></div>
+            <div class="showcase-color-info">
+                <strong class="showcase-color-name">Info</strong>
+                <code class="showcase-color-token">--bs-info</code>
+                <span class="showcase-color-usage text-muted">Unknown / informational status</span>
+            </div>
+        </div>
+        <div class="showcase-color-item">
             <div class="showcase-color-swatch" style="background-color: var(--bs-warning);"></div>
             <div class="showcase-color-info">
                 <strong class="showcase-color-name">Warning</strong>
                 <code class="showcase-color-token">--bs-warning</code>
-                <span class="showcase-color-usage text-muted">Warnings, tags, highlights</span>
+                <span class="showcase-color-usage text-muted">Important / attention-required status</span>
             </div>
         </div>
         <div class="showcase-color-item">
@@ -50,7 +66,7 @@
             <div class="showcase-color-info">
                 <strong class="showcase-color-name">Error</strong>
                 <code class="showcase-color-token">--bs-danger</code>
-                <span class="showcase-color-usage text-muted">Danger actions, validation errors</span>
+                <span class="showcase-color-usage text-muted">Blocked / danger / validation errors</span>
             </div>
         </div>
         <div class="showcase-color-item">
@@ -94,6 +110,24 @@
             </div>
         </div>
     </div>
+</Card>
+
+<Card Class="mb-3 p-4">
+    <Heading Level="HeadingLevel.Small">Semantic Status Colors</Heading>
+    <p class="mb-2">Status indicators (badges, chips, validation) always use these four Bootstrap semantic tokens — never the themed <code>--bs-primary</code>, since accent color changes per theme and would break the meaning.</p>
+    <Table Size="TableSize.Small">
+        <TableHeader>
+            <TableColumn>Status</TableColumn>
+            <TableColumn>Token</TableColumn>
+            <TableColumn>Meaning</TableColumn>
+        </TableHeader>
+        <TableBody>
+            <TableRow><TableCell>Known / positive</TableCell><TableCell><code>--bs-success</code> (green)</TableCell><TableCell>Recipient known, action succeeded, healthy</TableCell></TableRow>
+            <TableRow><TableCell>Unknown / informational</TableCell><TableCell><code>--bs-info</code> (blue)</TableCell><TableCell>Recipient unknown, neutral info, hint</TableCell></TableRow>
+            <TableRow><TableCell>Important / attention</TableCell><TableCell><code>--bs-warning</code> (yellow)</TableCell><TableCell>Needs attention, flagged, pending</TableCell></TableRow>
+            <TableRow><TableCell>Blocked / error</TableCell><TableCell><code>--bs-danger</code> (red)</TableCell><TableCell>Blocked, failed, validation error</TableCell></TableRow>
+        </TableBody>
+    </Table>
 </Card>
 
 <Card Class="mb-3 p-4">

--- a/src/Feirb.Web/Pages/Showcase/ShowcaseHelpHint.razor
+++ b/src/Feirb.Web/Pages/Showcase/ShowcaseHelpHint.razor
@@ -1,0 +1,59 @@
+@using Feirb.Web.Components.UI
+@inject IJSRuntime JS
+
+<InfoHeader Title="HelpHint" Icon="question-circle" Subtitle="Inline help text with icon for contextual guidance" />
+
+<Card Class="mb-3 p-4">
+    <Heading Level="HeadingLevel.Small">Info</Heading>
+    <p>Inline help text with a question-circle icon. Used below form controls to explain the current selection or provide contextual guidance. Inherits the muted on-surface-variant color for subtle presentation.</p>
+    <Table Size="TableSize.Small">
+        <TableHeader>
+            <TableColumn>Parameter</TableColumn>
+            <TableColumn>Type</TableColumn>
+            <TableColumn>Default</TableColumn>
+            <TableColumn>Description</TableColumn>
+        </TableHeader>
+        <TableBody>
+            <TableRow><TableCell><code>ChildContent</code></TableCell><TableCell><code>RenderFragment</code></TableCell><TableCell>required</TableCell><TableCell>Help text content</TableCell></TableRow>
+            <TableRow><TableCell><code>Class</code></TableCell><TableCell><code>string?</code></TableCell><TableCell><code>null</code></TableCell><TableCell>Extra CSS classes</TableCell></TableRow>
+        </TableBody>
+    </Table>
+</Card>
+
+<Card Class="mb-3 p-4">
+    <Heading Level="HeadingLevel.Small">Examples</Heading>
+    <div class="d-flex flex-column gap-3">
+        <div>
+            <span class="badge bg-secondary mb-2">Short hint</span>
+            <HelpHint>This field is optional.</HelpHint>
+        </div>
+        <div>
+            <span class="badge bg-secondary mb-2">Descriptive hint</span>
+            <HelpHint>This address was automatically captured from incoming or outgoing mail and has not been reviewed yet.</HelpHint>
+        </div>
+        <div>
+            <span class="badge bg-secondary mb-2">With custom class</span>
+            <HelpHint Class="mt-0">Hint with removed top margin via custom class.</HelpHint>
+        </div>
+    </div>
+</Card>
+
+<Card Class="p-4">
+    <Heading Level="HeadingLevel.Small">Code</Heading>
+    <pre><code class="language-xml" @ref="_codeElement"></code></pre>
+</Card>
+
+@code {
+    private ElementReference _codeElement;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        try { await JS.InvokeVoidAsync("highlightCode", _codeElement, _code); }
+        catch (JSException) { }
+    }
+
+    private const string _code = """
+        <HelpHint>This field is optional.</HelpHint>
+        <HelpHint Class="mt-0">Custom class example.</HelpHint>
+        """;
+}

--- a/src/Feirb.Web/Pages/Showcase/ShowcasePersonChip.razor
+++ b/src/Feirb.Web/Pages/Showcase/ShowcasePersonChip.razor
@@ -18,7 +18,7 @@
             <TableRow><TableCell><code>Name</code></TableCell><TableCell><code>string</code></TableCell><TableCell>required</TableCell><TableCell>Display name</TableCell></TableRow>
             <TableRow><TableCell><code>Email</code></TableCell><TableCell><code>string?</code></TableCell><TableCell><code>null</code></TableCell><TableCell>Email address (hidden in Mini size)</TableCell></TableRow>
             <TableRow><TableCell><code>Size</code></TableCell><TableCell><code>PersonChipSize</code></TableCell><TableCell><code>Default</code></TableCell><TableCell>Default, Small, Mini</TableCell></TableRow>
-            <TableRow><TableCell><code>Status</code></TableCell><TableCell><code>RecipientStatus</code></TableCell><TableCell><code>None</code></TableCell><TableCell>None (no badge), Known, Unknown, Important, Blocked</TableCell></TableRow>
+            <TableRow><TableCell><code>Status</code></TableCell><TableCell><code>AddressStatus?</code></TableCell><TableCell><code>null</code></TableCell><TableCell>null (no badge), Unknown, Known, Important, Blocked</TableCell></TableRow>
             <TableRow><TableCell><code>StatusTitle</code></TableCell><TableCell><code>string?</code></TableCell><TableCell><code>null</code></TableCell><TableCell>Tooltip text for the status badge</TableCell></TableRow>
             <TableRow><TableCell><code>Class</code></TableCell><TableCell><code>string?</code></TableCell><TableCell><code>null</code></TableCell><TableCell>Extra CSS classes</TableCell></TableRow>
         </TableBody>
@@ -47,12 +47,12 @@
         </div>
         <div>
             <label class="form-label">Status</label>
-            <select class="form-select form-select-sm" @bind="_status">
-                <option value="@RecipientStatus.None">None (no badge)</option>
-                <option value="@RecipientStatus.Known">Known</option>
-                <option value="@RecipientStatus.Unknown">Unknown</option>
-                <option value="@RecipientStatus.Important">Important</option>
-                <option value="@RecipientStatus.Blocked">Blocked</option>
+            <select class="form-select form-select-sm" value="@(_status?.ToString() ?? "None")" @onchange="OnStatusChanged">
+                <option value="None">None (no badge)</option>
+                <option value="@nameof(AddressStatus.Unknown)">Unknown</option>
+                <option value="@nameof(AddressStatus.Known)">Known</option>
+                <option value="@nameof(AddressStatus.Important)">Important</option>
+                <option value="@nameof(AddressStatus.Blocked)">Blocked</option>
             </select>
         </div>
     </div>
@@ -64,9 +64,13 @@
 
 <Card Class="mb-3 p-4">
     <Heading Level="HeadingLevel.Small">Status Badges</Heading>
-    <p class="text-muted mb-3">The corner badge reflects recipient status with solid colored backgrounds. None renders without a badge (use for chips outside address-book context). Known / Important / Blocked use white icons; Unknown uses a dark icon for contrast against the yellow background. The Important color adapts per theme via <code>--feirb-tertiary</code>.</p>
+    <p class="text-muted mb-3">The corner badge reflects address status. Null renders without a badge (use for chips outside address-book context). Colors come from Bootstrap semantic tokens: Known = success (green), Unknown = info (blue), Important = warning (yellow), Blocked = danger (red).</p>
     <div class="d-flex flex-wrap gap-4">
-        @foreach (var status in new[] { RecipientStatus.None, RecipientStatus.Known, RecipientStatus.Unknown, RecipientStatus.Important, RecipientStatus.Blocked })
+        <div>
+            <span class="badge bg-secondary mb-2">null</span>
+            <PersonChip Name="@_name" Email="@_email" Size="PersonChipSize.Default" />
+        </div>
+        @foreach (var status in Enum.GetValues<AddressStatus>())
         {
             <div>
                 <span class="badge bg-secondary mb-2">@status</span>
@@ -120,7 +124,7 @@
     private string _email = "alice.johnson@example.com";
     private string _avatarTestEmail = "admin@feirb.local";
     private PersonChipSize _size = PersonChipSize.Default;
-    private RecipientStatus _status = RecipientStatus.None;
+    private AddressStatus? _status;
     private ElementReference _codeElement;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -129,13 +133,19 @@
         catch (JSException) { }
     }
 
+    private void OnStatusChanged(ChangeEventArgs e)
+    {
+        var value = e.Value?.ToString();
+        _status = value is null or "None" ? null : Enum.Parse<AddressStatus>(value);
+    }
+
     private string CurrentCode
     {
         get
         {
             var sizeStr = _size != PersonChipSize.Default ? $"\n          Size=\"PersonChipSize.{_size}\"" : "";
             var emailStr = !string.IsNullOrEmpty(_email) ? $"\n          Email=\"{_email}\"" : "";
-            var statusStr = _status != RecipientStatus.None ? $"\n          Status=\"RecipientStatus.{_status}\"" : "";
+            var statusStr = _status is not null ? $"\n          Status=\"AddressStatus.{_status}\"" : "";
             return "<" + $"PersonChip Name=\"{_name}\"{emailStr}{sizeStr}{statusStr} />";
         }
     }

--- a/src/Feirb.Web/Pages/Showcase/ShowcasePersonChip.razor
+++ b/src/Feirb.Web/Pages/Showcase/ShowcasePersonChip.razor
@@ -1,3 +1,4 @@
+@using Feirb.Shared.AddressBook
 @using Feirb.Web.Components.UI
 @inject IJSRuntime JS
 
@@ -17,6 +18,8 @@
             <TableRow><TableCell><code>Name</code></TableCell><TableCell><code>string</code></TableCell><TableCell>required</TableCell><TableCell>Display name</TableCell></TableRow>
             <TableRow><TableCell><code>Email</code></TableCell><TableCell><code>string?</code></TableCell><TableCell><code>null</code></TableCell><TableCell>Email address (hidden in Mini size)</TableCell></TableRow>
             <TableRow><TableCell><code>Size</code></TableCell><TableCell><code>PersonChipSize</code></TableCell><TableCell><code>Default</code></TableCell><TableCell>Default, Small, Mini</TableCell></TableRow>
+            <TableRow><TableCell><code>Status</code></TableCell><TableCell><code>RecipientStatus</code></TableCell><TableCell><code>None</code></TableCell><TableCell>None (no badge), Known, Unknown, Important, Blocked</TableCell></TableRow>
+            <TableRow><TableCell><code>StatusTitle</code></TableCell><TableCell><code>string?</code></TableCell><TableCell><code>null</code></TableCell><TableCell>Tooltip text for the status badge</TableCell></TableRow>
             <TableRow><TableCell><code>Class</code></TableCell><TableCell><code>string?</code></TableCell><TableCell><code>null</code></TableCell><TableCell>Extra CSS classes</TableCell></TableRow>
         </TableBody>
     </Table>
@@ -42,10 +45,34 @@
                 <option value="@PersonChipSize.Mini">Mini</option>
             </select>
         </div>
+        <div>
+            <label class="form-label">Status</label>
+            <select class="form-select form-select-sm" @bind="_status">
+                <option value="@RecipientStatus.None">None (no badge)</option>
+                <option value="@RecipientStatus.Known">Known</option>
+                <option value="@RecipientStatus.Unknown">Unknown</option>
+                <option value="@RecipientStatus.Important">Important</option>
+                <option value="@RecipientStatus.Blocked">Blocked</option>
+            </select>
+        </div>
     </div>
 
     <div class="showcase-preview-area">
-        <PersonChip Name="@_name" Email="@_email" Size="_size" />
+        <PersonChip Name="@_name" Email="@_email" Size="_size" Status="_status" />
+    </div>
+</Card>
+
+<Card Class="mb-3 p-4">
+    <Heading Level="HeadingLevel.Small">Status Badges</Heading>
+    <p class="text-muted mb-3">The corner badge reflects recipient status with solid colored backgrounds. None renders without a badge (use for chips outside address-book context). Known / Important / Blocked use white icons; Unknown uses a dark icon for contrast against the yellow background. The Important color adapts per theme via <code>--feirb-tertiary</code>.</p>
+    <div class="d-flex flex-wrap gap-4">
+        @foreach (var status in new[] { RecipientStatus.None, RecipientStatus.Known, RecipientStatus.Unknown, RecipientStatus.Important, RecipientStatus.Blocked })
+        {
+            <div>
+                <span class="badge bg-secondary mb-2">@status</span>
+                <PersonChip Name="@_name" Email="@_email" Size="PersonChipSize.Default" Status="status" />
+            </div>
+        }
     </div>
 </Card>
 
@@ -77,7 +104,7 @@
         {
             <div>
                 <span class="badge bg-secondary mb-2">@size</span>
-                <PersonChip Name="@_name" Email="@_email" Size="size" />
+                <PersonChip Name="@_name" Email="@_email" Size="size" Status="_status" />
             </div>
         }
     </div>
@@ -93,6 +120,7 @@
     private string _email = "alice.johnson@example.com";
     private string _avatarTestEmail = "admin@feirb.local";
     private PersonChipSize _size = PersonChipSize.Default;
+    private RecipientStatus _status = RecipientStatus.None;
     private ElementReference _codeElement;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -107,7 +135,8 @@
         {
             var sizeStr = _size != PersonChipSize.Default ? $"\n          Size=\"PersonChipSize.{_size}\"" : "";
             var emailStr = !string.IsNullOrEmpty(_email) ? $"\n          Email=\"{_email}\"" : "";
-            return "<" + $"PersonChip Name=\"{_name}\"{emailStr}{sizeStr} />";
+            var statusStr = _status != RecipientStatus.None ? $"\n          Status=\"RecipientStatus.{_status}\"" : "";
+            return "<" + $"PersonChip Name=\"{_name}\"{emailStr}{sizeStr}{statusStr} />";
         }
     }
 }

--- a/src/Feirb.Web/Resources/SharedResources.de-DE.resx
+++ b/src/Feirb.Web/Resources/SharedResources.de-DE.resx
@@ -1617,4 +1617,112 @@
   <data name="ComposeNoMailboxes" xml:space="preserve">
     <value>Keine Postfächer konfiguriert. Bitte fügen Sie zuerst ein Postfach in den Einstellungen hinzu.</value>
   </data>
+  <data name="AddressBookNavLabel" xml:space="preserve">
+    <value>Adressbuch</value>
+  </data>
+  <data name="AddressBookPageTitle" xml:space="preserve">
+    <value>Adressbuch</value>
+  </data>
+  <data name="AddressBookPageSubtitle" xml:space="preserve">
+    <value>Kontakte und erfasste Adressen</value>
+  </data>
+  <data name="AddressBookContactsHeading" xml:space="preserve">
+    <value>Kontakte</value>
+  </data>
+  <data name="AddressBookContactsSubtitle" xml:space="preserve">
+    <value>Gepflegte Personen</value>
+  </data>
+  <data name="AddressBookAddressesHeading" xml:space="preserve">
+    <value>Adressen</value>
+  </data>
+  <data name="AddressBookAddressesSubtitle" xml:space="preserve">
+    <value>Alle E-Mail-Adressen aus ein- und ausgehender Post</value>
+  </data>
+  <data name="AddressBookNewContact" xml:space="preserve">
+    <value>Neuer Kontakt</value>
+  </data>
+  <data name="AddressBookColumnName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="AddressBookColumnEmail" xml:space="preserve">
+    <value>E-Mail</value>
+  </data>
+  <data name="AddressBookColumnAddresses" xml:space="preserve">
+    <value>Adressen</value>
+  </data>
+  <data name="AddressBookColumnStatus" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="AddressBookColumnLastSeen" xml:space="preserve">
+    <value>Zuletzt gesehen</value>
+  </data>
+  <data name="AddressBookColumnContact" xml:space="preserve">
+    <value>Kontakt</value>
+  </data>
+  <data name="AddressBookColumnSeenCount" xml:space="preserve">
+    <value>Gesehen</value>
+  </data>
+  <data name="AddressBookStatusKnown" xml:space="preserve">
+    <value>Bekannt</value>
+  </data>
+  <data name="AddressBookStatusUnknown" xml:space="preserve">
+    <value>Unbekannt</value>
+  </data>
+  <data name="AddressBookStatusImportant" xml:space="preserve">
+    <value>Wichtig</value>
+  </data>
+  <data name="AddressBookStatusBlocked" xml:space="preserve">
+    <value>Blockiert</value>
+  </data>
+  <data name="AddressBookNoContacts" xml:space="preserve">
+    <value>Noch keine Kontakte. Aus ein- und ausgehenden Mails erfasste Adressen erscheinen im Bereich „Adressen".</value>
+  </data>
+  <data name="AddressBookNoAddresses" xml:space="preserve">
+    <value>Noch keine Adressen erfasst. Adressen werden beim Empfangen und Senden von Mails automatisch hinzugefügt.</value>
+  </data>
+  <data name="ContactDetailPageTitle" xml:space="preserve">
+    <value>Kontakt</value>
+  </data>
+  <data name="ContactDetailDisplayName" xml:space="preserve">
+    <value>Anzeigename</value>
+  </data>
+  <data name="ContactDetailNotes" xml:space="preserve">
+    <value>Notizen</value>
+  </data>
+  <data name="ContactDetailIsImportant" xml:space="preserve">
+    <value>Wichtiger Kontakt</value>
+  </data>
+  <data name="ContactDetailLinkedAddresses" xml:space="preserve">
+    <value>Verknüpfte Adressen</value>
+  </data>
+  <data name="AddressDetailPageTitle" xml:space="preserve">
+    <value>Adresse</value>
+  </data>
+  <data name="AddressDetailDisplayName" xml:space="preserve">
+    <value>Anzeigename</value>
+  </data>
+  <data name="AddressDetailIsBlocked" xml:space="preserve">
+    <value>Diese Adresse blockieren</value>
+  </data>
+  <data name="AddressDetailLinkedContact" xml:space="preserve">
+    <value>Verknüpfter Kontakt</value>
+  </data>
+  <data name="AddressDetailPromote" xml:space="preserve">
+    <value>Zu Kontakten hinzufügen</value>
+  </data>
+  <data name="AddressDetailUnlink" xml:space="preserve">
+    <value>Verknüpfung aufheben</value>
+  </data>
+  <data name="AddressDetailNoContact" xml:space="preserve">
+    <value>Mit keinem Kontakt verknüpft</value>
+  </data>
+  <data name="AddressBookActionSave" xml:space="preserve">
+    <value>Speichern</value>
+  </data>
+  <data name="AddressBookActionDelete" xml:space="preserve">
+    <value>Löschen</value>
+  </data>
+  <data name="AddressBookActionBack" xml:space="preserve">
+    <value>Zurück</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.de-DE.resx
+++ b/src/Feirb.Web/Resources/SharedResources.de-DE.resx
@@ -1689,8 +1689,8 @@
   <data name="ContactDetailNotes" xml:space="preserve">
     <value>Notizen</value>
   </data>
-  <data name="ContactDetailIsImportant" xml:space="preserve">
-    <value>Wichtiger Kontakt</value>
+  <data name="ContactDetailStatusPerAddressHint" xml:space="preserve">
+    <value>Status (bekannt, wichtig, blockiert) wird pro Adresse in den verknüpften Adressen unten gesetzt.</value>
   </data>
   <data name="ContactDetailLinkedAddresses" xml:space="preserve">
     <value>Verknüpfte Adressen</value>
@@ -1701,8 +1701,20 @@
   <data name="AddressDetailDisplayName" xml:space="preserve">
     <value>Anzeigename</value>
   </data>
-  <data name="AddressDetailIsBlocked" xml:space="preserve">
-    <value>Diese Adresse blockieren</value>
+  <data name="AddressDetailStatusLabel" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="AddressStatusHintUnknown" xml:space="preserve">
+    <value>Diese Adresse wurde automatisch aus ein- oder ausgehenden Mails erfasst und noch nicht geprüft.</value>
+  </data>
+  <data name="AddressStatusHintKnown" xml:space="preserve">
+    <value>Du hast diese Adresse bestätigt. Mails von diesem Absender erscheinen mit einem grünen Badge.</value>
+  </data>
+  <data name="AddressStatusHintImportant" xml:space="preserve">
+    <value>Diese Adresse ist als wichtig markiert. Mails von diesem Absender werden hervorgehoben und in Vorschlägen höher gereiht.</value>
+  </data>
+  <data name="AddressStatusHintBlocked" xml:space="preserve">
+    <value>Diese Adresse ist blockiert. Mails von diesem Absender werden in Vorschlägen am niedrigsten gereiht.</value>
   </data>
   <data name="AddressDetailLinkedContact" xml:space="preserve">
     <value>Verknüpfter Kontakt</value>

--- a/src/Feirb.Web/Resources/SharedResources.de-DE.resx
+++ b/src/Feirb.Web/Resources/SharedResources.de-DE.resx
@@ -1737,4 +1737,28 @@
   <data name="AddressBookActionBack" xml:space="preserve">
     <value>Zurück</value>
   </data>
+  <data name="ContactNotFound" xml:space="preserve">
+    <value>Kontakt nicht gefunden.</value>
+  </data>
+  <data name="AddressNotFound" xml:space="preserve">
+    <value>Adresse nicht gefunden.</value>
+  </data>
+  <data name="ContactSaveFailed" xml:space="preserve">
+    <value>Kontakt konnte nicht gespeichert werden.</value>
+  </data>
+  <data name="ContactDeleteFailed" xml:space="preserve">
+    <value>Kontakt konnte nicht gelöscht werden.</value>
+  </data>
+  <data name="AddressSaveFailed" xml:space="preserve">
+    <value>Adresse konnte nicht gespeichert werden.</value>
+  </data>
+  <data name="AddressDeleteFailed" xml:space="preserve">
+    <value>Adresse konnte nicht gelöscht werden.</value>
+  </data>
+  <data name="AddressPromoteFailed" xml:space="preserve">
+    <value>Adresse konnte nicht zu Kontakten hinzugefügt werden.</value>
+  </data>
+  <data name="AddressUnlinkFailed" xml:space="preserve">
+    <value>Adresse konnte nicht getrennt werden.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
+++ b/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
@@ -1689,8 +1689,8 @@
   <data name="ContactDetailNotes" xml:space="preserve">
     <value>Notes</value>
   </data>
-  <data name="ContactDetailIsImportant" xml:space="preserve">
-    <value>Contact important</value>
+  <data name="ContactDetailStatusPerAddressHint" xml:space="preserve">
+    <value>Le statut (connu, important, bloqué) se définit par adresse dans la liste ci-dessous.</value>
   </data>
   <data name="ContactDetailLinkedAddresses" xml:space="preserve">
     <value>Adresses liées</value>
@@ -1701,8 +1701,20 @@
   <data name="AddressDetailDisplayName" xml:space="preserve">
     <value>Nom affiché</value>
   </data>
-  <data name="AddressDetailIsBlocked" xml:space="preserve">
-    <value>Bloquer cette adresse</value>
+  <data name="AddressDetailStatusLabel" xml:space="preserve">
+    <value>Statut</value>
+  </data>
+  <data name="AddressStatusHintUnknown" xml:space="preserve">
+    <value>Cette adresse a été capturée automatiquement depuis un e-mail entrant ou sortant et n'a pas encore été examinée.</value>
+  </data>
+  <data name="AddressStatusHintKnown" xml:space="preserve">
+    <value>Vous avez confirmé cette adresse. Les e-mails de cet expéditeur apparaissent avec un badge vert.</value>
+  </data>
+  <data name="AddressStatusHintImportant" xml:space="preserve">
+    <value>Cette adresse est marquée comme importante. Les e-mails de cet expéditeur sont mis en avant et mieux classés dans les suggestions.</value>
+  </data>
+  <data name="AddressStatusHintBlocked" xml:space="preserve">
+    <value>Cette adresse est bloquée. Les e-mails de cet expéditeur sont classés en dernier dans les suggestions.</value>
   </data>
   <data name="AddressDetailLinkedContact" xml:space="preserve">
     <value>Contact lié</value>

--- a/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
+++ b/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
@@ -1737,4 +1737,28 @@
   <data name="AddressBookActionBack" xml:space="preserve">
     <value>Retour</value>
   </data>
+  <data name="ContactNotFound" xml:space="preserve">
+    <value>Contact introuvable.</value>
+  </data>
+  <data name="AddressNotFound" xml:space="preserve">
+    <value>Adresse introuvable.</value>
+  </data>
+  <data name="ContactSaveFailed" xml:space="preserve">
+    <value>Impossible d'enregistrer le contact.</value>
+  </data>
+  <data name="ContactDeleteFailed" xml:space="preserve">
+    <value>Impossible de supprimer le contact.</value>
+  </data>
+  <data name="AddressSaveFailed" xml:space="preserve">
+    <value>Impossible d'enregistrer l'adresse.</value>
+  </data>
+  <data name="AddressDeleteFailed" xml:space="preserve">
+    <value>Impossible de supprimer l'adresse.</value>
+  </data>
+  <data name="AddressPromoteFailed" xml:space="preserve">
+    <value>Impossible d'ajouter aux contacts.</value>
+  </data>
+  <data name="AddressUnlinkFailed" xml:space="preserve">
+    <value>Impossible de dissocier l'adresse.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
+++ b/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
@@ -1617,4 +1617,112 @@
   <data name="ComposeNoMailboxes" xml:space="preserve">
     <value>Aucune boîte mail configurée. Veuillez d'abord ajouter une boîte mail dans les paramètres.</value>
   </data>
+  <data name="AddressBookNavLabel" xml:space="preserve">
+    <value>Carnet d'adresses</value>
+  </data>
+  <data name="AddressBookPageTitle" xml:space="preserve">
+    <value>Carnet d'adresses</value>
+  </data>
+  <data name="AddressBookPageSubtitle" xml:space="preserve">
+    <value>Contacts et adresses capturées</value>
+  </data>
+  <data name="AddressBookContactsHeading" xml:space="preserve">
+    <value>Contacts</value>
+  </data>
+  <data name="AddressBookContactsSubtitle" xml:space="preserve">
+    <value>Personnes que vous avez organisées</value>
+  </data>
+  <data name="AddressBookAddressesHeading" xml:space="preserve">
+    <value>Adresses</value>
+  </data>
+  <data name="AddressBookAddressesSubtitle" xml:space="preserve">
+    <value>Toutes les adresses vues dans le courrier entrant et sortant</value>
+  </data>
+  <data name="AddressBookNewContact" xml:space="preserve">
+    <value>Nouveau contact</value>
+  </data>
+  <data name="AddressBookColumnName" xml:space="preserve">
+    <value>Nom</value>
+  </data>
+  <data name="AddressBookColumnEmail" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="AddressBookColumnAddresses" xml:space="preserve">
+    <value>Adresses</value>
+  </data>
+  <data name="AddressBookColumnStatus" xml:space="preserve">
+    <value>Statut</value>
+  </data>
+  <data name="AddressBookColumnLastSeen" xml:space="preserve">
+    <value>Vu récemment</value>
+  </data>
+  <data name="AddressBookColumnContact" xml:space="preserve">
+    <value>Contact</value>
+  </data>
+  <data name="AddressBookColumnSeenCount" xml:space="preserve">
+    <value>Vu</value>
+  </data>
+  <data name="AddressBookStatusKnown" xml:space="preserve">
+    <value>Connu</value>
+  </data>
+  <data name="AddressBookStatusUnknown" xml:space="preserve">
+    <value>Inconnu</value>
+  </data>
+  <data name="AddressBookStatusImportant" xml:space="preserve">
+    <value>Important</value>
+  </data>
+  <data name="AddressBookStatusBlocked" xml:space="preserve">
+    <value>Bloqué</value>
+  </data>
+  <data name="AddressBookNoContacts" xml:space="preserve">
+    <value>Aucun contact pour l'instant. Les adresses capturées apparaîtront dans la section Adresses.</value>
+  </data>
+  <data name="AddressBookNoAddresses" xml:space="preserve">
+    <value>Aucune adresse capturée pour l'instant. Les adresses sont ajoutées automatiquement à la réception et à l'envoi.</value>
+  </data>
+  <data name="ContactDetailPageTitle" xml:space="preserve">
+    <value>Contact</value>
+  </data>
+  <data name="ContactDetailDisplayName" xml:space="preserve">
+    <value>Nom affiché</value>
+  </data>
+  <data name="ContactDetailNotes" xml:space="preserve">
+    <value>Notes</value>
+  </data>
+  <data name="ContactDetailIsImportant" xml:space="preserve">
+    <value>Contact important</value>
+  </data>
+  <data name="ContactDetailLinkedAddresses" xml:space="preserve">
+    <value>Adresses liées</value>
+  </data>
+  <data name="AddressDetailPageTitle" xml:space="preserve">
+    <value>Adresse</value>
+  </data>
+  <data name="AddressDetailDisplayName" xml:space="preserve">
+    <value>Nom affiché</value>
+  </data>
+  <data name="AddressDetailIsBlocked" xml:space="preserve">
+    <value>Bloquer cette adresse</value>
+  </data>
+  <data name="AddressDetailLinkedContact" xml:space="preserve">
+    <value>Contact lié</value>
+  </data>
+  <data name="AddressDetailPromote" xml:space="preserve">
+    <value>Ajouter aux contacts</value>
+  </data>
+  <data name="AddressDetailUnlink" xml:space="preserve">
+    <value>Dissocier du contact</value>
+  </data>
+  <data name="AddressDetailNoContact" xml:space="preserve">
+    <value>Non lié à un contact</value>
+  </data>
+  <data name="AddressBookActionSave" xml:space="preserve">
+    <value>Enregistrer</value>
+  </data>
+  <data name="AddressBookActionDelete" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+  <data name="AddressBookActionBack" xml:space="preserve">
+    <value>Retour</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.it-IT.resx
+++ b/src/Feirb.Web/Resources/SharedResources.it-IT.resx
@@ -1617,4 +1617,112 @@
   <data name="ComposeNoMailboxes" xml:space="preserve">
     <value>Nessuna casella di posta configurata. Aggiungi prima una casella di posta nelle impostazioni.</value>
   </data>
+  <data name="AddressBookNavLabel" xml:space="preserve">
+    <value>Rubrica</value>
+  </data>
+  <data name="AddressBookPageTitle" xml:space="preserve">
+    <value>Rubrica</value>
+  </data>
+  <data name="AddressBookPageSubtitle" xml:space="preserve">
+    <value>Contatti e indirizzi catturati</value>
+  </data>
+  <data name="AddressBookContactsHeading" xml:space="preserve">
+    <value>Contatti</value>
+  </data>
+  <data name="AddressBookContactsSubtitle" xml:space="preserve">
+    <value>Persone che hai curato</value>
+  </data>
+  <data name="AddressBookAddressesHeading" xml:space="preserve">
+    <value>Indirizzi</value>
+  </data>
+  <data name="AddressBookAddressesSubtitle" xml:space="preserve">
+    <value>Ogni indirizzo email visto nella posta in entrata e in uscita</value>
+  </data>
+  <data name="AddressBookNewContact" xml:space="preserve">
+    <value>Nuovo contatto</value>
+  </data>
+  <data name="AddressBookColumnName" xml:space="preserve">
+    <value>Nome</value>
+  </data>
+  <data name="AddressBookColumnEmail" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="AddressBookColumnAddresses" xml:space="preserve">
+    <value>Indirizzi</value>
+  </data>
+  <data name="AddressBookColumnStatus" xml:space="preserve">
+    <value>Stato</value>
+  </data>
+  <data name="AddressBookColumnLastSeen" xml:space="preserve">
+    <value>Ultimo avvistamento</value>
+  </data>
+  <data name="AddressBookColumnContact" xml:space="preserve">
+    <value>Contatto</value>
+  </data>
+  <data name="AddressBookColumnSeenCount" xml:space="preserve">
+    <value>Visto</value>
+  </data>
+  <data name="AddressBookStatusKnown" xml:space="preserve">
+    <value>Conosciuto</value>
+  </data>
+  <data name="AddressBookStatusUnknown" xml:space="preserve">
+    <value>Sconosciuto</value>
+  </data>
+  <data name="AddressBookStatusImportant" xml:space="preserve">
+    <value>Importante</value>
+  </data>
+  <data name="AddressBookStatusBlocked" xml:space="preserve">
+    <value>Bloccato</value>
+  </data>
+  <data name="AddressBookNoContacts" xml:space="preserve">
+    <value>Nessun contatto ancora. Gli indirizzi catturati appariranno nella sezione Indirizzi.</value>
+  </data>
+  <data name="AddressBookNoAddresses" xml:space="preserve">
+    <value>Nessun indirizzo catturato. Gli indirizzi vengono aggiunti automaticamente quando ricevi o invii posta.</value>
+  </data>
+  <data name="ContactDetailPageTitle" xml:space="preserve">
+    <value>Contatto</value>
+  </data>
+  <data name="ContactDetailDisplayName" xml:space="preserve">
+    <value>Nome visualizzato</value>
+  </data>
+  <data name="ContactDetailNotes" xml:space="preserve">
+    <value>Note</value>
+  </data>
+  <data name="ContactDetailIsImportant" xml:space="preserve">
+    <value>Contatto importante</value>
+  </data>
+  <data name="ContactDetailLinkedAddresses" xml:space="preserve">
+    <value>Indirizzi collegati</value>
+  </data>
+  <data name="AddressDetailPageTitle" xml:space="preserve">
+    <value>Indirizzo</value>
+  </data>
+  <data name="AddressDetailDisplayName" xml:space="preserve">
+    <value>Nome visualizzato</value>
+  </data>
+  <data name="AddressDetailIsBlocked" xml:space="preserve">
+    <value>Blocca questo indirizzo</value>
+  </data>
+  <data name="AddressDetailLinkedContact" xml:space="preserve">
+    <value>Contatto collegato</value>
+  </data>
+  <data name="AddressDetailPromote" xml:space="preserve">
+    <value>Aggiungi ai contatti</value>
+  </data>
+  <data name="AddressDetailUnlink" xml:space="preserve">
+    <value>Scollega dal contatto</value>
+  </data>
+  <data name="AddressDetailNoContact" xml:space="preserve">
+    <value>Non collegato a un contatto</value>
+  </data>
+  <data name="AddressBookActionSave" xml:space="preserve">
+    <value>Salva</value>
+  </data>
+  <data name="AddressBookActionDelete" xml:space="preserve">
+    <value>Elimina</value>
+  </data>
+  <data name="AddressBookActionBack" xml:space="preserve">
+    <value>Indietro</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.it-IT.resx
+++ b/src/Feirb.Web/Resources/SharedResources.it-IT.resx
@@ -1737,4 +1737,28 @@
   <data name="AddressBookActionBack" xml:space="preserve">
     <value>Indietro</value>
   </data>
+  <data name="ContactNotFound" xml:space="preserve">
+    <value>Contatto non trovato.</value>
+  </data>
+  <data name="AddressNotFound" xml:space="preserve">
+    <value>Indirizzo non trovato.</value>
+  </data>
+  <data name="ContactSaveFailed" xml:space="preserve">
+    <value>Impossibile salvare il contatto.</value>
+  </data>
+  <data name="ContactDeleteFailed" xml:space="preserve">
+    <value>Impossibile eliminare il contatto.</value>
+  </data>
+  <data name="AddressSaveFailed" xml:space="preserve">
+    <value>Impossibile salvare l'indirizzo.</value>
+  </data>
+  <data name="AddressDeleteFailed" xml:space="preserve">
+    <value>Impossibile eliminare l'indirizzo.</value>
+  </data>
+  <data name="AddressPromoteFailed" xml:space="preserve">
+    <value>Impossibile aggiungere ai contatti.</value>
+  </data>
+  <data name="AddressUnlinkFailed" xml:space="preserve">
+    <value>Impossibile scollegare l'indirizzo.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.it-IT.resx
+++ b/src/Feirb.Web/Resources/SharedResources.it-IT.resx
@@ -1689,8 +1689,8 @@
   <data name="ContactDetailNotes" xml:space="preserve">
     <value>Note</value>
   </data>
-  <data name="ContactDetailIsImportant" xml:space="preserve">
-    <value>Contatto importante</value>
+  <data name="ContactDetailStatusPerAddressHint" xml:space="preserve">
+    <value>Lo stato (conosciuto, importante, bloccato) si imposta per indirizzo nell'elenco degli indirizzi collegati.</value>
   </data>
   <data name="ContactDetailLinkedAddresses" xml:space="preserve">
     <value>Indirizzi collegati</value>
@@ -1701,8 +1701,20 @@
   <data name="AddressDetailDisplayName" xml:space="preserve">
     <value>Nome visualizzato</value>
   </data>
-  <data name="AddressDetailIsBlocked" xml:space="preserve">
-    <value>Blocca questo indirizzo</value>
+  <data name="AddressDetailStatusLabel" xml:space="preserve">
+    <value>Stato</value>
+  </data>
+  <data name="AddressStatusHintUnknown" xml:space="preserve">
+    <value>Questo indirizzo è stato acquisito automaticamente da un'e-mail in entrata o in uscita e non è ancora stato esaminato.</value>
+  </data>
+  <data name="AddressStatusHintKnown" xml:space="preserve">
+    <value>Hai confermato questo indirizzo. Le e-mail da questo mittente appaiono con un badge verde.</value>
+  </data>
+  <data name="AddressStatusHintImportant" xml:space="preserve">
+    <value>Questo indirizzo è contrassegnato come importante. Le e-mail da questo mittente sono evidenziate e classificate più in alto nei suggerimenti.</value>
+  </data>
+  <data name="AddressStatusHintBlocked" xml:space="preserve">
+    <value>Questo indirizzo è bloccato. Le e-mail da questo mittente sono classificate per ultime nei suggerimenti.</value>
   </data>
   <data name="AddressDetailLinkedContact" xml:space="preserve">
     <value>Contatto collegato</value>

--- a/src/Feirb.Web/Resources/SharedResources.resx
+++ b/src/Feirb.Web/Resources/SharedResources.resx
@@ -1737,4 +1737,28 @@
   <data name="AddressBookActionBack" xml:space="preserve">
     <value>Back</value>
   </data>
+  <data name="ContactNotFound" xml:space="preserve">
+    <value>Contact not found.</value>
+  </data>
+  <data name="AddressNotFound" xml:space="preserve">
+    <value>Address not found.</value>
+  </data>
+  <data name="ContactSaveFailed" xml:space="preserve">
+    <value>Failed to save contact.</value>
+  </data>
+  <data name="ContactDeleteFailed" xml:space="preserve">
+    <value>Failed to delete contact.</value>
+  </data>
+  <data name="AddressSaveFailed" xml:space="preserve">
+    <value>Failed to save address.</value>
+  </data>
+  <data name="AddressDeleteFailed" xml:space="preserve">
+    <value>Failed to delete address.</value>
+  </data>
+  <data name="AddressPromoteFailed" xml:space="preserve">
+    <value>Failed to add to contacts.</value>
+  </data>
+  <data name="AddressUnlinkFailed" xml:space="preserve">
+    <value>Failed to unlink address.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.resx
+++ b/src/Feirb.Web/Resources/SharedResources.resx
@@ -1617,4 +1617,112 @@
   <data name="ComposeNoMailboxes" xml:space="preserve">
     <value>No mailboxes configured. Please add a mailbox in settings first.</value>
   </data>
+  <data name="AddressBookNavLabel" xml:space="preserve">
+    <value>Address Book</value>
+  </data>
+  <data name="AddressBookPageTitle" xml:space="preserve">
+    <value>Address Book</value>
+  </data>
+  <data name="AddressBookPageSubtitle" xml:space="preserve">
+    <value>Contacts and captured addresses</value>
+  </data>
+  <data name="AddressBookContactsHeading" xml:space="preserve">
+    <value>Contacts</value>
+  </data>
+  <data name="AddressBookContactsSubtitle" xml:space="preserve">
+    <value>People you have curated</value>
+  </data>
+  <data name="AddressBookAddressesHeading" xml:space="preserve">
+    <value>Addresses</value>
+  </data>
+  <data name="AddressBookAddressesSubtitle" xml:space="preserve">
+    <value>Every email address seen in incoming and outgoing mail</value>
+  </data>
+  <data name="AddressBookNewContact" xml:space="preserve">
+    <value>New contact</value>
+  </data>
+  <data name="AddressBookColumnName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="AddressBookColumnEmail" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="AddressBookColumnAddresses" xml:space="preserve">
+    <value>Addresses</value>
+  </data>
+  <data name="AddressBookColumnStatus" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="AddressBookColumnLastSeen" xml:space="preserve">
+    <value>Last seen</value>
+  </data>
+  <data name="AddressBookColumnContact" xml:space="preserve">
+    <value>Contact</value>
+  </data>
+  <data name="AddressBookColumnSeenCount" xml:space="preserve">
+    <value>Seen</value>
+  </data>
+  <data name="AddressBookStatusKnown" xml:space="preserve">
+    <value>Known</value>
+  </data>
+  <data name="AddressBookStatusUnknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="AddressBookStatusImportant" xml:space="preserve">
+    <value>Important</value>
+  </data>
+  <data name="AddressBookStatusBlocked" xml:space="preserve">
+    <value>Blocked</value>
+  </data>
+  <data name="AddressBookNoContacts" xml:space="preserve">
+    <value>No contacts yet. Addresses captured from incoming and outgoing mail will appear in the Addresses section.</value>
+  </data>
+  <data name="AddressBookNoAddresses" xml:space="preserve">
+    <value>No addresses captured yet. Addresses are added automatically when you receive or send mail.</value>
+  </data>
+  <data name="ContactDetailPageTitle" xml:space="preserve">
+    <value>Contact</value>
+  </data>
+  <data name="ContactDetailDisplayName" xml:space="preserve">
+    <value>Display name</value>
+  </data>
+  <data name="ContactDetailNotes" xml:space="preserve">
+    <value>Notes</value>
+  </data>
+  <data name="ContactDetailIsImportant" xml:space="preserve">
+    <value>Important contact</value>
+  </data>
+  <data name="ContactDetailLinkedAddresses" xml:space="preserve">
+    <value>Linked addresses</value>
+  </data>
+  <data name="AddressDetailPageTitle" xml:space="preserve">
+    <value>Address</value>
+  </data>
+  <data name="AddressDetailDisplayName" xml:space="preserve">
+    <value>Display name</value>
+  </data>
+  <data name="AddressDetailIsBlocked" xml:space="preserve">
+    <value>Block this address</value>
+  </data>
+  <data name="AddressDetailLinkedContact" xml:space="preserve">
+    <value>Linked contact</value>
+  </data>
+  <data name="AddressDetailPromote" xml:space="preserve">
+    <value>Add to contacts</value>
+  </data>
+  <data name="AddressDetailUnlink" xml:space="preserve">
+    <value>Unlink from contact</value>
+  </data>
+  <data name="AddressDetailNoContact" xml:space="preserve">
+    <value>Not linked to a contact</value>
+  </data>
+  <data name="AddressBookActionSave" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="AddressBookActionDelete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="AddressBookActionBack" xml:space="preserve">
+    <value>Back</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.resx
+++ b/src/Feirb.Web/Resources/SharedResources.resx
@@ -1689,8 +1689,8 @@
   <data name="ContactDetailNotes" xml:space="preserve">
     <value>Notes</value>
   </data>
-  <data name="ContactDetailIsImportant" xml:space="preserve">
-    <value>Important contact</value>
+  <data name="ContactDetailStatusPerAddressHint" xml:space="preserve">
+    <value>Status (known, important, blocked) is set per address in the linked addresses below.</value>
   </data>
   <data name="ContactDetailLinkedAddresses" xml:space="preserve">
     <value>Linked addresses</value>
@@ -1701,8 +1701,20 @@
   <data name="AddressDetailDisplayName" xml:space="preserve">
     <value>Display name</value>
   </data>
-  <data name="AddressDetailIsBlocked" xml:space="preserve">
-    <value>Block this address</value>
+  <data name="AddressDetailStatusLabel" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="AddressStatusHintUnknown" xml:space="preserve">
+    <value>This address was automatically captured from incoming or outgoing mail and has not been reviewed yet.</value>
+  </data>
+  <data name="AddressStatusHintKnown" xml:space="preserve">
+    <value>You have acknowledged this address. Mails from this sender appear with a green badge.</value>
+  </data>
+  <data name="AddressStatusHintImportant" xml:space="preserve">
+    <value>This address is marked as important. Mails from this sender are highlighted and ranked higher in suggestions.</value>
+  </data>
+  <data name="AddressStatusHintBlocked" xml:space="preserve">
+    <value>This address is blocked. Mails from this sender are ranked lowest in suggestions.</value>
   </data>
   <data name="AddressDetailLinkedContact" xml:space="preserve">
     <value>Linked contact</value>

--- a/tests/Feirb.Api.Tests/Endpoints/AddressBookEndpointsTests.cs
+++ b/tests/Feirb.Api.Tests/Endpoints/AddressBookEndpointsTests.cs
@@ -47,7 +47,7 @@ public class AddressBookEndpointsTests : IDisposable
     {
         await LoginAsync();
         var request = new CreateContactRequest(
-            "John Doe", "VIP client", true, ["john@example.com", "john.doe@work.com"]);
+            "John Doe", "VIP client", ["john@example.com", "john.doe@work.com"]);
 
         var response = await _client.PostAsJsonAsync("/api/address-book/contacts", request);
 
@@ -55,8 +55,8 @@ public class AddressBookEndpointsTests : IDisposable
         var contact = await response.Content.ReadFromJsonAsync<ContactResponse>();
         contact.Should().NotBeNull();
         contact!.DisplayName.Should().Be("John Doe");
-        contact.IsImportant.Should().BeTrue();
         contact.Addresses.Should().HaveCount(2);
+        contact.Addresses.Should().OnlyContain(a => a.Status == AddressStatus.Known);
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public class AddressBookEndpointsTests : IDisposable
         await LoginAsync();
         var created = await CreateContactAsync("Original Name");
 
-        var update = new UpdateContactRequest("Updated Name", "Note", false);
+        var update = new UpdateContactRequest("Updated Name", "Note");
         var response = await _client.PutAsJsonAsync($"/api/address-book/contacts/{created.Id}", update);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -136,7 +136,7 @@ public class AddressBookEndpointsTests : IDisposable
         var addressId = temp.Addresses[0].Id;
         await _client.DeleteAsync($"/api/address-book/contacts/{temp.Id}");
 
-        var promote = new PromoteAddressRequest("Promoted Contact", null, false);
+        var promote = new PromoteAddressRequest("Promoted Contact", null, AddressStatus.Known);
         var response = await _client.PostAsJsonAsync($"/api/address-book/addresses/{addressId}/promote", promote);
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -194,16 +194,20 @@ public class AddressBookEndpointsTests : IDisposable
     public async Task SearchRecipients_ImportantRanksAboveOthersAsync()
     {
         await LoginAsync();
-        // Create: one important contact, one normal contact
-        await CreateContactAsync("Alice Normal", emails: ["alice@example.com"], isImportant: false);
-        await CreateContactAsync("Alice Important", emails: ["alice2@example.com"], isImportant: true);
+        var normal = await CreateContactAsync("Alice Normal", emails: ["alice@example.com"]);
+        var important = await CreateContactAsync("Alice Important", emails: ["alice2@example.com"]);
+
+        // Promote the second contact's address to Important via UpdateAddress
+        var importantAddress = important.Addresses[0];
+        var updateImportant = new UpdateAddressRequest(importantAddress.DisplayName, AddressStatus.Important);
+        await _client.PutAsJsonAsync($"/api/address-book/addresses/{importantAddress.Id}", updateImportant);
 
         var response = await _client.GetAsync("/api/mail/recipients/search?q=alice");
         var suggestions = await response.Content.ReadFromJsonAsync<List<RecipientSuggestion>>();
 
         suggestions.Should().NotBeNull();
         suggestions.Should().HaveCountGreaterThanOrEqualTo(2);
-        suggestions![0].Status.Should().Be(RecipientStatus.Important);
+        suggestions![0].Status.Should().Be(AddressStatus.Important);
     }
 
     [Fact]
@@ -214,14 +218,14 @@ public class AddressBookEndpointsTests : IDisposable
         await CreateContactAsync("Zed", emails: ["zed@example.com"]);
 
         // Block bob
-        var blocked = new UpdateAddressRequest("Bob", true);
+        var blocked = new UpdateAddressRequest("Bob", AddressStatus.Blocked);
         await _client.PutAsJsonAsync($"/api/address-book/addresses/{contact.Addresses[0].Id}", blocked);
 
         var response = await _client.GetAsync("/api/mail/recipients/search?q=e");
         var suggestions = await response.Content.ReadFromJsonAsync<List<RecipientSuggestion>>();
 
         suggestions.Should().NotBeNull();
-        suggestions!.Last().Status.Should().Be(RecipientStatus.Blocked);
+        suggestions!.Last().Status.Should().Be(AddressStatus.Blocked);
     }
 
     [Fact]
@@ -254,10 +258,9 @@ public class AddressBookEndpointsTests : IDisposable
 
     private async Task<ContactResponse> CreateContactAsync(
         string displayName,
-        IReadOnlyList<string>? emails = null,
-        bool isImportant = false)
+        IReadOnlyList<string>? emails = null)
     {
-        var request = new CreateContactRequest(displayName, null, isImportant, emails);
+        var request = new CreateContactRequest(displayName, null, emails);
         var response = await _client.PostAsJsonAsync("/api/address-book/contacts", request);
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         return (await response.Content.ReadFromJsonAsync<ContactResponse>())!;

--- a/tests/Feirb.Api.Tests/Endpoints/AddressBookEndpointsTests.cs
+++ b/tests/Feirb.Api.Tests/Endpoints/AddressBookEndpointsTests.cs
@@ -1,0 +1,281 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Feirb.Shared.AddressBook;
+using Feirb.Shared.Auth;
+using Feirb.Shared.Setup;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Feirb.Api.Tests.Endpoints;
+
+public class AddressBookEndpointsTests : IDisposable
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    public AddressBookEndpointsTests()
+    {
+        _factory = TestWebApplicationFactory.Create($"TestDb-{Guid.NewGuid()}");
+        _client = _factory.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    // --- Contacts CRUD ---
+
+    [Fact]
+    public async Task ListContacts_Empty_ReturnsEmptyPageAsync()
+    {
+        await LoginAsync();
+        var response = await _client.GetAsync("/api/address-book/contacts");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var page = await response.Content.ReadFromJsonAsync<PagedResult<ContactListItem>>();
+        page.Should().NotBeNull();
+        page!.Items.Should().BeEmpty();
+        page.Total.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CreateContact_WithEmails_ReturnsCreatedAsync()
+    {
+        await LoginAsync();
+        var request = new CreateContactRequest(
+            "John Doe", "VIP client", true, ["john@example.com", "john.doe@work.com"]);
+
+        var response = await _client.PostAsJsonAsync("/api/address-book/contacts", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var contact = await response.Content.ReadFromJsonAsync<ContactResponse>();
+        contact.Should().NotBeNull();
+        contact!.DisplayName.Should().Be("John Doe");
+        contact.IsImportant.Should().BeTrue();
+        contact.Addresses.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task UpdateContact_ChangesDisplayNameAsync()
+    {
+        await LoginAsync();
+        var created = await CreateContactAsync("Original Name");
+
+        var update = new UpdateContactRequest("Updated Name", "Note", false);
+        var response = await _client.PutAsJsonAsync($"/api/address-book/contacts/{created.Id}", update);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await response.Content.ReadFromJsonAsync<ContactResponse>();
+        updated!.DisplayName.Should().Be("Updated Name");
+        updated.Notes.Should().Be("Note");
+    }
+
+    [Fact]
+    public async Task DeleteContact_OrphansLinkedAddressesAsync()
+    {
+        await LoginAsync();
+        var created = await CreateContactAsync("To Delete", emails: ["orphan@example.com"]);
+
+        var deleteResponse = await _client.DeleteAsync($"/api/address-book/contacts/{created.Id}");
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Address should still exist but unlinked
+        var addressId = created.Addresses[0].Id;
+        var addressResponse = await _client.GetAsync($"/api/address-book/addresses/{addressId}");
+        addressResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var address = await addressResponse.Content.ReadFromJsonAsync<AddressResponse>();
+        address!.ContactId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetContact_NotFound_Returns404Async()
+    {
+        await LoginAsync();
+        var response = await _client.GetAsync($"/api/address-book/contacts/{Guid.NewGuid()}");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // --- Addresses CRUD ---
+
+    [Fact]
+    public async Task DeleteAddress_WhenLinked_Returns409Async()
+    {
+        await LoginAsync();
+        var created = await CreateContactAsync("Linked", emails: ["linked@example.com"]);
+        var addressId = created.Addresses[0].Id;
+
+        var response = await _client.DeleteAsync($"/api/address-book/addresses/{addressId}");
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task DeleteAddress_WhenOrphan_ReturnsOkAsync()
+    {
+        await LoginAsync();
+        var created = await CreateContactAsync("To Orphan", emails: ["orphan2@example.com"]);
+        var addressId = created.Addresses[0].Id;
+
+        // Delete contact first — orphans the address
+        await _client.DeleteAsync($"/api/address-book/contacts/{created.Id}");
+
+        // Now delete the address
+        var response = await _client.DeleteAsync($"/api/address-book/addresses/{addressId}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task PromoteAddress_CreatesContactAndLinksAsync()
+    {
+        await LoginAsync();
+        // Create an orphan address by creating a contact and then deleting it
+        var temp = await CreateContactAsync("Temp", emails: ["to-promote@example.com"]);
+        var addressId = temp.Addresses[0].Id;
+        await _client.DeleteAsync($"/api/address-book/contacts/{temp.Id}");
+
+        var promote = new PromoteAddressRequest("Promoted Contact", null, false);
+        var response = await _client.PostAsJsonAsync($"/api/address-book/addresses/{addressId}/promote", promote);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var newContact = await response.Content.ReadFromJsonAsync<ContactResponse>();
+        newContact!.DisplayName.Should().Be("Promoted Contact");
+        newContact.Addresses.Should().HaveCount(1);
+        newContact.Addresses[0].Id.Should().Be(addressId);
+    }
+
+    [Fact]
+    public async Task LinkAddress_AttachesToContactAsync()
+    {
+        await LoginAsync();
+        var contactA = await CreateContactAsync("Contact A", emails: ["a@example.com"]);
+        var contactB = await CreateContactAsync("Contact B");
+        var addressId = contactA.Addresses[0].Id;
+
+        var request = new LinkAddressRequest(contactB.Id);
+        var response = await _client.PostAsJsonAsync($"/api/address-book/addresses/{addressId}/link", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var linked = await response.Content.ReadFromJsonAsync<AddressResponse>();
+        linked!.ContactId.Should().Be(contactB.Id);
+    }
+
+    [Fact]
+    public async Task UnlinkAddress_RemovesContactLinkAsync()
+    {
+        await LoginAsync();
+        var contact = await CreateContactAsync("To Unlink", emails: ["unlink@example.com"]);
+        var addressId = contact.Addresses[0].Id;
+
+        var response = await _client.PostAsync($"/api/address-book/addresses/{addressId}/unlink", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var unlinked = await response.Content.ReadFromJsonAsync<AddressResponse>();
+        unlinked!.ContactId.Should().BeNull();
+    }
+
+    // --- Autocomplete ---
+
+    [Fact]
+    public async Task SearchRecipients_Empty_ReturnsEmptyListAsync()
+    {
+        await LoginAsync();
+        var response = await _client.GetAsync("/api/mail/recipients/search?q=nothing");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var suggestions = await response.Content.ReadFromJsonAsync<List<RecipientSuggestion>>();
+        suggestions.Should().NotBeNull();
+        suggestions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchRecipients_ImportantRanksAboveOthersAsync()
+    {
+        await LoginAsync();
+        // Create: one important contact, one normal contact
+        await CreateContactAsync("Alice Normal", emails: ["alice@example.com"], isImportant: false);
+        await CreateContactAsync("Alice Important", emails: ["alice2@example.com"], isImportant: true);
+
+        var response = await _client.GetAsync("/api/mail/recipients/search?q=alice");
+        var suggestions = await response.Content.ReadFromJsonAsync<List<RecipientSuggestion>>();
+
+        suggestions.Should().NotBeNull();
+        suggestions.Should().HaveCountGreaterThanOrEqualTo(2);
+        suggestions![0].Status.Should().Be(RecipientStatus.Important);
+    }
+
+    [Fact]
+    public async Task SearchRecipients_BlockedRanksLastAsync()
+    {
+        await LoginAsync();
+        var contact = await CreateContactAsync("Bob", emails: ["bob@example.com"]);
+        await CreateContactAsync("Zed", emails: ["zed@example.com"]);
+
+        // Block bob
+        var blocked = new UpdateAddressRequest("Bob", true);
+        await _client.PutAsJsonAsync($"/api/address-book/addresses/{contact.Addresses[0].Id}", blocked);
+
+        var response = await _client.GetAsync("/api/mail/recipients/search?q=e");
+        var suggestions = await response.Content.ReadFromJsonAsync<List<RecipientSuggestion>>();
+
+        suggestions.Should().NotBeNull();
+        suggestions!.Last().Status.Should().Be(RecipientStatus.Blocked);
+    }
+
+    [Fact]
+    public async Task Contacts_OnlyReturnsCurrentUsersContactsAsync()
+    {
+        var adminTokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminTokens.AccessToken);
+        await CreateContactAsync("Admin contact");
+
+        // Register and login as another user
+        await _client.PostAsJsonAsync("/api/auth/register",
+            new RegisterRequest("otheruser", "other@example.com", "Password123!"));
+        var loginResponse = await _client.PostAsJsonAsync("/api/auth/login",
+            new LoginRequest("otheruser", "Password123!"));
+        var otherTokens = await loginResponse.Content.ReadFromJsonAsync<TokenResponse>();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", otherTokens!.AccessToken);
+
+        var response = await _client.GetAsync("/api/address-book/contacts");
+        var page = await response.Content.ReadFromJsonAsync<PagedResult<ContactListItem>>();
+        page!.Items.Should().BeEmpty();
+    }
+
+    // --- Helpers ---
+
+    private async Task LoginAsync()
+    {
+        var tokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+    }
+
+    private async Task<ContactResponse> CreateContactAsync(
+        string displayName,
+        IReadOnlyList<string>? emails = null,
+        bool isImportant = false)
+    {
+        var request = new CreateContactRequest(displayName, null, isImportant, emails);
+        var response = await _client.PostAsJsonAsync("/api/address-book/contacts", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        return (await response.Content.ReadFromJsonAsync<ContactResponse>())!;
+    }
+
+    private async Task<TokenResponse> SetupAndLoginAsAdminAsync()
+    {
+        var setupRequest = new CompleteSetupRequest(
+            "admin", "admin@example.com", "AdminPassword123!",
+            "smtp.example.com", 587, "smtp@example.com", "smtppass", true, true);
+        await _client.PostAsJsonAsync("/api/setup/complete", setupRequest);
+
+        var loginResponse = await _client.PostAsJsonAsync("/api/auth/login",
+            new LoginRequest("admin", "AdminPassword123!"));
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var tokens = await loginResponse.Content.ReadFromJsonAsync<TokenResponse>();
+        tokens.Should().NotBeNull();
+        return tokens!;
+    }
+}

--- a/tests/Feirb.Api.Tests/Services/ImapSyncServiceTests.cs
+++ b/tests/Feirb.Api.Tests/Services/ImapSyncServiceTests.cs
@@ -131,7 +131,7 @@ public class ImapSyncServiceTests
         var logger = NullLogger<ImapSyncService>.Instance;
         var scopeFactory = services.GetRequiredService<IServiceScopeFactory>();
 
-        var service = new ImapSyncService(scopeFactory, logger, Options.Create(new ImapSyncSettings()));
+        var service = new ImapSyncService(scopeFactory, logger, Options.Create(new ImapSyncSettings()), new AddressExtractor());
 
         // Should not throw — just logs warning
         await service.Invoking(s => s.SyncMailboxAsync(Guid.NewGuid()))
@@ -171,7 +171,7 @@ public class ImapSyncServiceTests
 
         var logger = NullLogger<ImapSyncService>.Instance;
         var scopeFactory = services.GetRequiredService<IServiceScopeFactory>();
-        var service = new ImapSyncService(scopeFactory, logger, Options.Create(new ImapSyncSettings()));
+        var service = new ImapSyncService(scopeFactory, logger, Options.Create(new ImapSyncSettings()), new AddressExtractor());
 
         // Should not throw — just logs warning and skips
         await service.Invoking(s => s.SyncMailboxAsync(mailbox.Id))


### PR DESCRIPTION
Closes #200. Follow-up spawn: #226 (backfill component showcases), #228 (mailbox save unsaved-changes warning).

## Summary

- New `Contact` + `Address` entities with EF migration. Addresses are captured automatically during IMAP sync (received) and compose-send (outgoing) via `AddressExtractor` service
- 12 API endpoints under `/api/address-book/*` (contacts & addresses CRUD, promote/link/unlink) plus `/api/mail/recipients/search` for ranked autocomplete
- Unified `AddressStatus` enum (`Unknown`, `Known`, `Important`, `Blocked`) replaces three distributed boolean flags (`Address.IsUnknown`, `Address.IsBlocked`, `Contact.IsImportant`), enabling per-address status (e.g. same person's work email = Important, private email = Known)
- Sender status badges on Inbox PersonChips via batched address lookup in `ListMessagesAsync`
- `PersonChip.Status` is nullable `AddressStatus?` (null = no badge), with semantic colors: Known = success (green), Unknown = info (blue), Important = warning (yellow), Blocked = danger (red)
- Address detail page uses `ToggleButtonGroup` for status selection with new `HelpHint` component showing context-sensitive descriptions
- `ContentSection` overflow fix: removed `overflow: clip` to allow autocomplete dropdowns to render outside section bounds
- Semantic status colors documented in design fundamentals showcase

### Non-obvious decisions

- `AddressExtractor` only promotes `Unknown -> Known` on markAsKnown; never overrides `Important` or `Blocked` (blocking a sender survives when you reply to them)
- Contact has no status — it's a pure grouping entity (DisplayName + Notes + Addresses). Status is always per-address, so the same person's different email addresses can have different statuses
- Contact list table drops the status column entirely; status is visible on individual addresses
- EF migration includes SQL backfill (`Blocked > Important > Unknown > Known` precedence) with symmetric down-path

## Test plan

- [ ] `dotnet build` and `dotnet test` pass (383 tests green)
- [ ] Start with `--seeding`, verify address book pages load (`/address-book`)
- [ ] Send test emails, verify addresses are auto-captured with `Unknown` status
- [ ] Edit address status via ToggleButtonGroup, verify persistence and HelpHint updates
- [ ] Inbox PersonChips show correct status badges for known senders
- [ ] Compose recipient autocomplete shows status badges, ranks Important above Known, dropdown not clipped
- [ ] Components showcase: `/components-showcase/person-chip` shows all 4 statuses + null
- [ ] Contact detail: no IsImportant checkbox, hint text visible, save/delete via toolbar

Generated with [Claude Code](https://claude.com/claude-code)