### PR TITLE
fix(web): toolbar Save button now triggers form submission on all pages

### DIFF
--- a/src/Feirb.Web/Components/TrackedEditForm.razor
+++ b/src/Feirb.Web/Components/TrackedEditForm.razor
@@ -55,9 +55,12 @@
     {
         if (_editContext.Validate())
         {
-            return await HandleValidSubmitAsync();
+            var result = await HandleValidSubmitAsync();
+            StateHasChanged();
+            return result;
         }
 
+        StateHasChanged();
         return false;
     }
 

--- a/src/Feirb.Web/Services/UnsavedChangesService.cs
+++ b/src/Feirb.Web/Services/UnsavedChangesService.cs
@@ -18,7 +18,7 @@ public sealed class UnsavedChangesService
 
     public async Task<bool> SaveAllAsync()
     {
-        foreach (var form in _forms.Where(f => f.HasUnsavedChanges).ToList())
+        foreach (var form in _forms.ToList())
         {
             if (!await form.SubmitAsync())
                 return false;

--- a/tests/Feirb.Web.Tests/Services/UnsavedChangesServiceTests.cs
+++ b/tests/Feirb.Web.Tests/Services/UnsavedChangesServiceTests.cs
@@ -76,7 +76,7 @@ public class UnsavedChangesServiceTests
     }
 
     [Fact]
-    public async Task SaveAllAsync_CallsSubmitOnDirtyFormsOnlyAsync()
+    public async Task SaveAllAsync_CallsSubmitOnAllRegisteredFormsAsync()
     {
         var clean = new FakeTrackedForm();
         var dirty = new FakeTrackedForm { HasUnsavedChanges = true };
@@ -85,7 +85,7 @@ public class UnsavedChangesServiceTests
 
         await _sut.SaveAllAsync();
 
-        clean.SubmitCallCount.Should().Be(0);
+        clean.SubmitCallCount.Should().Be(1);
         dirty.SubmitCallCount.Should().Be(1);
     }
 


### PR DESCRIPTION
## Summary
- `UnsavedChangesService.SaveAllAsync()` now submits all registered forms, not just dirty ones — fixes create pages where the form was skipped because it had no unsaved changes yet
- `TrackedEditForm.SubmitAsync()` now calls `StateHasChanged()` after programmatic submission so validation messages render correctly

Closes #217

## Test plan
- [ ] Navigate to Settings > Mailboxes > Add Mailbox, fill fields, click toolbar Save — verify form submits
- [ ] Edit an existing mailbox, click toolbar Save — verify save works
- [ ] Submit with missing required fields — verify validation errors appear
- [ ] Test other pages with toolbar Save (SMTP, address book) — verify they still work
- [ ] Run `dotnet test` — all tests pass

Generated with [Claude Code](https://claude.com/claude-code)