### PR TITLE
fix(api,web,shared): align HTML sanitizers on shared base configuration

### DIFF
--- a/src/Feirb.Api/Services/OutgoingHtmlSanitizer.cs
+++ b/src/Feirb.Api/Services/OutgoingHtmlSanitizer.cs
@@ -6,8 +6,9 @@ namespace Feirb.Api.Services;
 /// Sanitizes HTML for outgoing (composed) mail.
 ///
 /// Extends the shared base (<see cref="HtmlSanitizerBase"/>) with:
-///   - data: URI scheme — allowed so users can embed inline images
-///     (e.g., pasted screenshots) in composed messages.
+///   - data: URI scheme — enabled at scheme level but restricted via FilterUrl
+///     to img tags only (for user-pasted screenshots); data: URIs on other
+///     elements (e.g., a href) are stripped to prevent phishing.
 /// </summary>
 public static class OutgoingHtmlSanitizer
 {
@@ -20,8 +21,22 @@ public static class OutgoingHtmlSanitizer
     {
         var sanitizer = HtmlSanitizerBase.CreateBaseSanitizer();
 
-        // Outgoing mail may contain user-pasted inline images as data: URIs.
+        // Allow data: scheme so the FilterUrl callback can selectively permit
+        // data: URIs on img tags while stripping them everywhere else.
         sanitizer.AllowedSchemes.Add("data");
+
+        // Allow data: URIs only on img tags for user-pasted inline images;
+        // strip data: URIs on all other elements to prevent phishing vectors.
+        sanitizer.FilterUrl += (_, e) =>
+        {
+            if (!e.OriginalUrl.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+                return;
+
+            var isImgTag = string.Equals(e.Tag.LocalName, "img", StringComparison.OrdinalIgnoreCase);
+
+            if (!isImgTag)
+                e.SanitizedUrl = null;
+        };
 
         return sanitizer;
     }

--- a/src/Feirb.Api/Services/OutgoingHtmlSanitizer.cs
+++ b/src/Feirb.Api/Services/OutgoingHtmlSanitizer.cs
@@ -1,30 +1,27 @@
-using Ganss.Xss;
+using Feirb.Shared.Mail;
 
 namespace Feirb.Api.Services;
 
+/// <summary>
+/// Sanitizes HTML for outgoing (composed) mail.
+///
+/// Extends the shared base (<see cref="HtmlSanitizerBase"/>) with:
+///   - data: URI scheme — allowed so users can embed inline images
+///     (e.g., pasted screenshots) in composed messages.
+/// </summary>
 public static class OutgoingHtmlSanitizer
 {
-    private static readonly HtmlSanitizer _sanitizer = CreateSanitizer();
+    private static readonly Ganss.Xss.HtmlSanitizer _sanitizer = CreateSanitizer();
 
     public static string Sanitize(string html) =>
         string.IsNullOrWhiteSpace(html) ? string.Empty : _sanitizer.Sanitize(html);
 
-    private static HtmlSanitizer CreateSanitizer()
+    private static Ganss.Xss.HtmlSanitizer CreateSanitizer()
     {
-        var sanitizer = new HtmlSanitizer();
+        var sanitizer = HtmlSanitizerBase.CreateBaseSanitizer();
 
-        sanitizer.AllowedSchemes.Clear();
-        sanitizer.AllowedSchemes.Add("https");
-        sanitizer.AllowedSchemes.Add("http");
-        sanitizer.AllowedSchemes.Add("mailto");
+        // Outgoing mail may contain user-pasted inline images as data: URIs.
         sanitizer.AllowedSchemes.Add("data");
-
-        sanitizer.AllowedTags.Remove("script");
-        sanitizer.AllowedTags.Remove("form");
-        sanitizer.AllowedTags.Remove("input");
-        sanitizer.AllowedTags.Remove("button");
-        sanitizer.AllowedTags.Remove("select");
-        sanitizer.AllowedTags.Remove("textarea");
 
         return sanitizer;
     }

--- a/src/Feirb.Shared/Feirb.Shared.csproj
+++ b/src/Feirb.Shared/Feirb.Shared.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
+  </ItemGroup>
+
 </Project>

--- a/src/Feirb.Shared/Mail/HtmlSanitizerBase.cs
+++ b/src/Feirb.Shared/Mail/HtmlSanitizerBase.cs
@@ -1,0 +1,52 @@
+using Ganss.Xss;
+
+namespace Feirb.Shared.Mail;
+
+/// <summary>
+/// Shared base configuration for HTML sanitizers used across the application.
+/// Both incoming (Web) and outgoing (API) sanitizers inherit this baseline,
+/// then apply context-specific rules on top.
+///
+/// Base policy:
+///   - Allowed URI schemes: https, http, mailto
+///   - Blocked tags: script, form, input, button, select, textarea
+///
+/// Context-specific extensions are documented in each consumer.
+/// </summary>
+public static class HtmlSanitizerBase
+{
+    /// <summary>
+    /// URI schemes considered safe for all contexts.
+    /// Consumers may add additional schemes (e.g., data: for inline images).
+    /// </summary>
+    private static readonly string[] _baseAllowedSchemes = ["https", "http", "mailto"];
+
+    /// <summary>
+    /// Tags blocked in all contexts: scripting and form interaction elements.
+    /// Consumers may block additional tags (e.g., media tags for incoming mail).
+    /// </summary>
+    private static readonly string[] _baseBlockedTags =
+        ["script", "form", "input", "button", "select", "textarea"];
+
+    /// <summary>
+    /// Creates a sanitizer with the shared base configuration applied.
+    /// Callers can further customize the returned instance before use.
+    /// </summary>
+    public static HtmlSanitizer CreateBaseSanitizer()
+    {
+        var sanitizer = new HtmlSanitizer();
+
+        sanitizer.AllowedSchemes.Clear();
+        foreach (var scheme in _baseAllowedSchemes)
+        {
+            sanitizer.AllowedSchemes.Add(scheme);
+        }
+
+        foreach (var tag in _baseBlockedTags)
+        {
+            sanitizer.AllowedTags.Remove(tag);
+        }
+
+        return sanitizer;
+    }
+}

--- a/src/Feirb.Web/Services/HtmlSanitizer.cs
+++ b/src/Feirb.Web/Services/HtmlSanitizer.cs
@@ -1,7 +1,17 @@
-using Ganss.Xss;
+using Feirb.Shared.Mail;
 
 namespace Feirb.Web.Services;
 
+/// <summary>
+/// Sanitizes HTML for incoming (received) mail display.
+///
+/// Extends the shared base (<see cref="HtmlSanitizerBase"/>) with:
+///   - data: URI scheme — allowed for inline images already embedded in mail.
+///   - Blocked media tags (video, audio, source, picture, link) — prevents
+///     auto-loading external media content in the browser.
+///   - External image URL filter — only data: URIs pass on img tags;
+///     remote image URLs are stripped to prevent tracking pixels.
+/// </summary>
 public static class HtmlSanitizer
 {
     private static readonly Ganss.Xss.HtmlSanitizer _sanitizer = CreateSanitizer();
@@ -11,28 +21,20 @@ public static class HtmlSanitizer
 
     private static Ganss.Xss.HtmlSanitizer CreateSanitizer()
     {
-        var sanitizer = new Ganss.Xss.HtmlSanitizer();
+        var sanitizer = HtmlSanitizerBase.CreateBaseSanitizer();
 
-        // Only allow safe URI schemes
-        sanitizer.AllowedSchemes.Clear();
-        sanitizer.AllowedSchemes.Add("https");
-        sanitizer.AllowedSchemes.Add("http");
-        sanitizer.AllowedSchemes.Add("mailto");
+        // Allow data: URIs for inline images already embedded in the mail body.
         sanitizer.AllowedSchemes.Add("data");
 
-        // Remove tags that load external content or allow interaction
+        // Block tags that auto-load external media content in the browser.
         sanitizer.AllowedTags.Remove("video");
         sanitizer.AllowedTags.Remove("audio");
         sanitizer.AllowedTags.Remove("source");
         sanitizer.AllowedTags.Remove("picture");
         sanitizer.AllowedTags.Remove("link");
-        sanitizer.AllowedTags.Remove("form");
-        sanitizer.AllowedTags.Remove("input");
-        sanitizer.AllowedTags.Remove("button");
-        sanitizer.AllowedTags.Remove("select");
-        sanitizer.AllowedTags.Remove("textarea");
 
-        // Block external image sources — only allow data: URIs
+        // Block external image sources — only allow data: URIs on img tags
+        // to prevent tracking pixels and remote content loading.
         sanitizer.FilterUrl += (_, e) =>
         {
             if (e.OriginalUrl.StartsWith("data:", StringComparison.OrdinalIgnoreCase))

--- a/src/Feirb.Web/Services/HtmlSanitizer.cs
+++ b/src/Feirb.Web/Services/HtmlSanitizer.cs
@@ -6,11 +6,13 @@ namespace Feirb.Web.Services;
 /// Sanitizes HTML for incoming (received) mail display.
 ///
 /// Extends the shared base (<see cref="HtmlSanitizerBase"/>) with:
-///   - data: URI scheme — allowed for inline images already embedded in mail.
+///   - data: URI scheme — enabled at scheme level but restricted via FilterUrl
+///     to img tags only; data: URIs on other elements (e.g., a href) are
+///     stripped to prevent phishing.
 ///   - Blocked media tags (video, audio, source, picture, link) — prevents
 ///     auto-loading external media content in the browser.
-///   - External image URL filter — only data: URIs pass on img tags;
-///     remote image URLs are stripped to prevent tracking pixels.
+///   - External image URL filter — remote image URLs are stripped to prevent
+///     tracking pixels.
 /// </summary>
 public static class HtmlSanitizer
 {
@@ -23,7 +25,8 @@ public static class HtmlSanitizer
     {
         var sanitizer = HtmlSanitizerBase.CreateBaseSanitizer();
 
-        // Allow data: URIs for inline images already embedded in the mail body.
+        // Allow data: scheme so the FilterUrl callback can selectively permit
+        // data: URIs on img tags while stripping them everywhere else.
         sanitizer.AllowedSchemes.Add("data");
 
         // Block tags that auto-load external media content in the browser.
@@ -33,14 +36,25 @@ public static class HtmlSanitizer
         sanitizer.AllowedTags.Remove("picture");
         sanitizer.AllowedTags.Remove("link");
 
-        // Block external image sources — only allow data: URIs on img tags
-        // to prevent tracking pixels and remote content loading.
+        // Filter URLs: allow data: URIs only on img src (inline images),
+        // block all external URLs on img tags (tracking pixel protection),
+        // and strip data: URIs on all other elements (phishing prevention).
         sanitizer.FilterUrl += (_, e) =>
         {
-            if (e.OriginalUrl.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
-                return;
+            var isDataUri = e.OriginalUrl.StartsWith("data:", StringComparison.OrdinalIgnoreCase);
+            var isImgTag = string.Equals(e.Tag.LocalName, "img", StringComparison.OrdinalIgnoreCase);
 
-            // Block external URLs on img tags
+            if (isDataUri)
+            {
+                // Allow data: URIs only on img tags (inline images);
+                // strip on all other elements (e.g., a href) to prevent phishing.
+                if (!isImgTag)
+                    e.SanitizedUrl = null;
+
+                return;
+            }
+
+            // Block external URLs on img tags (tracking pixel protection)
             if (string.Equals(e.Tag.LocalName, "img", StringComparison.OrdinalIgnoreCase))
                 e.SanitizedUrl = null;
         };

--- a/tests/Feirb.Api.Tests/Services/OutgoingHtmlSanitizerTests.cs
+++ b/tests/Feirb.Api.Tests/Services/OutgoingHtmlSanitizerTests.cs
@@ -1,0 +1,76 @@
+using Feirb.Api.Services;
+using FluentAssertions;
+
+namespace Feirb.Api.Tests.Services;
+
+public class OutgoingHtmlSanitizerTests
+{
+    [Fact]
+    public void Sanitize_ScriptTags_Stripped()
+    {
+        var input = "<p>Hello</p><script>alert('xss')</script><p>World</p>";
+        var result = OutgoingHtmlSanitizer.Sanitize(input);
+        result.Should().NotContain("<script");
+        result.Should().Contain("Hello");
+        result.Should().Contain("World");
+    }
+
+    [Fact]
+    public void Sanitize_FormTags_Stripped()
+    {
+        var input = "<form action=\"http://evil.com\"><input type=\"text\"><button>Submit</button></form>";
+        var result = OutgoingHtmlSanitizer.Sanitize(input);
+        result.Should().NotContain("<form");
+        result.Should().NotContain("<input");
+        result.Should().NotContain("<button");
+    }
+
+    [Fact]
+    public void Sanitize_SelectTextareaTags_Stripped()
+    {
+        var input = "<select><option>A</option></select><textarea>Text</textarea>";
+        var result = OutgoingHtmlSanitizer.Sanitize(input);
+        result.Should().NotContain("<select");
+        result.Should().NotContain("<textarea");
+    }
+
+    [Fact]
+    public void Sanitize_DataUriInImgSrc_Preserved()
+    {
+        var input = "<img src=\"data:image/png;base64,abc123\" alt=\"inline\">";
+        var result = OutgoingHtmlSanitizer.Sanitize(input);
+        result.Should().Contain("data:image/png;base64,abc123");
+    }
+
+    [Fact]
+    public void Sanitize_DataUriInAnchorHref_Stripped()
+    {
+        var input = "<a href=\"data:text/html,<script>alert(1)</script>\">Click</a>";
+        var result = OutgoingHtmlSanitizer.Sanitize(input);
+        result.Should().NotContain("data:text/html");
+    }
+
+    [Fact]
+    public void Sanitize_ExternalHttpsLink_Preserved()
+    {
+        var input = "<a href=\"https://example.com\">Link</a>";
+        var result = OutgoingHtmlSanitizer.Sanitize(input);
+        result.Should().Contain("https://example.com");
+    }
+
+    [Fact]
+    public void Sanitize_ExternalHttpLink_Preserved()
+    {
+        var input = "<a href=\"http://example.com\">Link</a>";
+        var result = OutgoingHtmlSanitizer.Sanitize(input);
+        result.Should().Contain("http://example.com");
+    }
+
+    [Fact]
+    public void Sanitize_MailtoLink_Preserved()
+    {
+        var input = "<a href=\"mailto:test@example.com\">Email</a>";
+        var result = OutgoingHtmlSanitizer.Sanitize(input);
+        result.Should().Contain("mailto:test@example.com");
+    }
+}

--- a/tests/Feirb.Web.Tests/Services/HtmlSanitizerTests.cs
+++ b/tests/Feirb.Web.Tests/Services/HtmlSanitizerTests.cs
@@ -162,5 +162,41 @@ public class HtmlSanitizerTests
         var input = "<a href=\"data:text/html,<script>alert(1)</script>\">Click</a>";
         var result = HtmlSanitizer.Sanitize(input);
         result.Should().NotContain("<script");
+        result.Should().NotContain("data:text/html");
+    }
+
+    [Fact]
+    public void Sanitize_VideoTag_Removed()
+    {
+        var input = "<video src=\"http://example.com/video.mp4\"><source src=\"video.mp4\"></video>";
+        var result = HtmlSanitizer.Sanitize(input);
+        result.Should().NotContain("<video");
+        result.Should().NotContain("<source");
+    }
+
+    [Fact]
+    public void Sanitize_AudioTag_Removed()
+    {
+        var input = "<audio src=\"http://example.com/audio.mp3\"></audio>";
+        var result = HtmlSanitizer.Sanitize(input);
+        result.Should().NotContain("<audio");
+    }
+
+    [Fact]
+    public void Sanitize_PictureTag_Removed()
+    {
+        var input = "<picture><source srcset=\"image.webp\"><img src=\"data:image/png;base64,abc\"></picture>";
+        var result = HtmlSanitizer.Sanitize(input);
+        result.Should().NotContain("<picture");
+        result.Should().NotContain("<source");
+    }
+
+    [Fact]
+    public void Sanitize_LinkTag_Removed()
+    {
+        var input = "<link rel=\"stylesheet\" href=\"http://evil.com/track.css\"><p>Content</p>";
+        var result = HtmlSanitizer.Sanitize(input);
+        result.Should().NotContain("<link");
+        result.Should().NotContain("evil.com");
     }
 }


### PR DESCRIPTION
## Summary
- New `HtmlSanitizerBase` in `Feirb.Shared` with common blocked tags (script, form, input, button, select, textarea) and safe URI schemes
- `OutgoingHtmlSanitizer` (API) and `HtmlSanitizer` (Web) both inherit from the shared base
- Each sanitizer documents its context-specific extensions (e.g., data: URIs, media tag blocking)
- Key fix: incoming sanitizer was previously missing explicit `script` tag blocking — now inherited from base

Closes #218

## Test plan
- [ ] Compose and send a mail with inline image — verify image preserved (data: URI allowed)
- [ ] View a received mail with embedded script tags — verify scripts stripped
- [ ] View a received mail with external image URLs — verify tracking pixels blocked
- [ ] Run `dotnet test` — all 383 tests pass
- [ ] Run `dotnet format --verify-no-changes` — clean

Generated with [Claude Code](https://claude.com/claude-code)