### PR TITLE
Message detail view: person chips, labels, body toggle

### DIFF
--- a/src/Feirb.Api/Endpoints/MessageEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/MessageEndpoints.cs
@@ -95,10 +95,36 @@ public static class MessageEndpoints
         var message = await db.CachedMessages
             .Include(m => m.Mailbox)
             .Include(m => m.Attachments)
+            .Include(m => m.Labels)
             .FirstOrDefaultAsync(m => m.Id == id && m.Mailbox.UserId == userId);
 
         if (message is null)
             return Results.NotFound(new { message = localizer["MessageNotFound"].Value });
+
+        var (fromName, fromEmail) = ParseFromAddress(message.From);
+        var normalizedFrom = EmailNormalizer.Normalize(fromEmail);
+
+        AddressStatus? senderStatus = null;
+        if (normalizedFrom.Length > 0)
+        {
+            senderStatus = await db.Addresses
+                .AsNoTracking()
+                .Where(a => a.UserId == userId && a.NormalizedEmail == normalizedFrom)
+                .Select(a => (AddressStatus?)a.Status)
+                .FirstOrDefaultAsync();
+        }
+
+        var fromAddress = new MessageAddressResponse(fromName, fromEmail, senderStatus);
+        var toAddresses = ParseAddressList(message.To);
+        var ccAddresses = !string.IsNullOrEmpty(message.Cc) ? ParseAddressList(message.Cc) : null;
+        var replyToAddress = !string.IsNullOrEmpty(message.ReplyTo) && message.ReplyTo != message.From
+            ? ToAddressResponse(ParseFromAddress(message.ReplyTo))
+            : null;
+
+        var labels = message.Labels
+            .OrderBy(l => l.Name)
+            .Select(l => new MessageLabelResponse(l.Name, l.Color))
+            .ToList();
 
         var response = new MessageDetailResponse(
             message.Id,
@@ -108,14 +134,30 @@ public static class MessageEndpoints
             message.To,
             message.Cc,
             message.ReplyTo,
+            fromAddress,
+            toAddresses,
+            ccAddresses,
+            replyToAddress,
             message.Date,
             message.Subject,
             message.BodyHtml,
             message.BodyPlainText,
-            message.Attachments.Select(a => new AttachmentResponse(a.Id, a.Filename, a.Size, a.MimeType)).ToList());
+            message.Attachments.Select(a => new AttachmentResponse(a.Id, a.Filename, a.Size, a.MimeType)).ToList(),
+            labels);
 
         return Results.Ok(response);
     }
+
+    private static List<MessageAddressResponse> ParseAddressList(string addresses)
+    {
+        return addresses
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(a => ToAddressResponse(ParseFromAddress(a)))
+            .ToList();
+    }
+
+    private static MessageAddressResponse ToAddressResponse((string Name, string Email) parsed) =>
+        new(parsed.Name, parsed.Email);
 
     private static Guid GetCurrentUserId(HttpContext httpContext)
     {

--- a/src/Feirb.Api/Endpoints/MessageEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/MessageEndpoints.cs
@@ -150,6 +150,15 @@ public static class MessageEndpoints
 
     private static List<MessageAddressResponse> ParseAddressList(string addresses)
     {
+        if (MimeKit.InternetAddressList.TryParse(addresses, out var list))
+        {
+            return list.Mailboxes
+                .Select(mb => new MessageAddressResponse(
+                    string.IsNullOrWhiteSpace(mb.Name) ? mb.Address : mb.Name,
+                    mb.Address))
+                .ToList();
+        }
+
         return addresses
             .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Select(a => ToAddressResponse(ParseFromAddress(a)))

--- a/src/Feirb.Shared/Mail/MessageAddressResponse.cs
+++ b/src/Feirb.Shared/Mail/MessageAddressResponse.cs
@@ -1,0 +1,5 @@
+using Feirb.Shared.AddressBook;
+
+namespace Feirb.Shared.Mail;
+
+public record MessageAddressResponse(string Name, string Email, AddressStatus? Status = null);

--- a/src/Feirb.Shared/Mail/MessageDetailResponse.cs
+++ b/src/Feirb.Shared/Mail/MessageDetailResponse.cs
@@ -8,8 +8,13 @@ public record MessageDetailResponse(
     string To,
     string? Cc,
     string? ReplyTo,
+    MessageAddressResponse FromAddress,
+    List<MessageAddressResponse> ToAddresses,
+    List<MessageAddressResponse>? CcAddresses,
+    MessageAddressResponse? ReplyToAddress,
     DateTimeOffset Date,
     string Subject,
     string? BodyHtml,
     string? BodyPlainText,
-    List<AttachmentResponse> Attachments);
+    List<AttachmentResponse> Attachments,
+    List<MessageLabelResponse> Labels);

--- a/src/Feirb.Web/Pages/Mail/MessageDetail.razor
+++ b/src/Feirb.Web/Pages/Mail/MessageDetail.razor
@@ -1,6 +1,7 @@
 @page "/mail/inbox/{Id:guid}"
 @attribute [Authorize]
 @using Feirb.Shared.Mail
+@using Feirb.Web.Components.UI
 @inject HttpClient Http
 @inject IStringLocalizer<SharedResources> L
 @inject BreadcrumbOverrideService BreadcrumbOverride
@@ -31,76 +32,103 @@ else if (!string.IsNullOrEmpty(_errorMessage))
 }
 else if (_message is not null)
 {
-    <div class="mb-3" data-testid="message-mailbox">
-        <span class="badge" style="background-color: @(_message.MailboxBadgeColor ?? "#6c757d");">
-            @_message.MailboxName
-        </span>
-    </div>
-
-    <div class="card mb-4" data-testid="message-headers">
-        <div class="card-body">
-            <dl class="row mb-0">
-                <dt class="col-sm-2">@L["LabelFrom"]</dt>
-                <dd class="col-sm-10">@_message.From</dd>
-
-                <dt class="col-sm-2">@L["LabelTo"]</dt>
-                <dd class="col-sm-10">@_message.To</dd>
-
-                @if (!string.IsNullOrEmpty(_message.Cc))
-                {
-                    <dt class="col-sm-2">@L["LabelCc"]</dt>
-                    <dd class="col-sm-10">@_message.Cc</dd>
-                }
-
-                @if (!string.IsNullOrEmpty(_message.ReplyTo) && _message.ReplyTo != _message.From)
-                {
-                    <dt class="col-sm-2">@L["LabelReplyTo"]</dt>
-                    <dd class="col-sm-10">@_message.ReplyTo</dd>
-                }
-
-                <dt class="col-sm-2">@L["LabelDate"]</dt>
-                <dd class="col-sm-10">@_message.Date.LocalDateTime.ToString("g")</dd>
-
-                <dt class="col-sm-2">@L["LabelSubject"]</dt>
-                <dd class="col-sm-10">@_message.Subject</dd>
-            </dl>
+    <div class="d-flex flex-wrap align-items-center gap-2 mb-3" data-testid="message-meta">
+        <MailboxChip Name="@_message.MailboxName" Color="@_message.MailboxBadgeColor" />
+        <div class="feirb-detail-date" title="@_message.Date.LocalDateTime.ToString("f")">
+            <Icon Name="clock" Size="IconSize.Small" />
+            <span>@FormatRelativeTime(_message.Date)</span>
         </div>
+        @if (_message.Labels.Count > 0)
+        {
+            @foreach (var label in _message.Labels)
+            {
+                <LabelPill Name="@label.Name" Color="@label.Color" />
+            }
+        }
     </div>
 
-    <div class="card mb-4" data-testid="message-body">
-        <div class="card-body">
-            @if (!string.IsNullOrEmpty(_message.BodyHtml))
-            {
+    <ContentSection Icon="envelope-open" Title="@_message.Subject" data-testid="message-headers">
+        <div class="mb-3">
+            <div class="text-muted small mb-1">@L["LabelFrom"]</div>
+            <PersonChip Name="@_message.FromAddress.Name"
+                        Email="@_message.FromAddress.Email"
+                        Status="@_message.FromAddress.Status" />
+        </div>
+
+        <div class="mb-3">
+            <div class="text-muted small mb-1">@L["LabelTo"]</div>
+            <div class="d-flex flex-wrap gap-2">
+                @foreach (var addr in _message.ToAddresses)
+                {
+                    <PersonChip Name="@addr.Name" Email="@addr.Email" Size="PersonChipSize.Small" />
+                }
+            </div>
+        </div>
+
+        @if (_message.CcAddresses is { Count: > 0 })
+        {
+            <div class="mb-3">
+                <div class="text-muted small mb-1">@L["LabelCc"]</div>
+                <div class="d-flex flex-wrap gap-2">
+                    @foreach (var addr in _message.CcAddresses)
+                    {
+                        <PersonChip Name="@addr.Name" Email="@addr.Email" Size="PersonChipSize.Small" />
+                    }
+                </div>
+            </div>
+        }
+
+        @if (_message.ReplyToAddress is not null)
+        {
+            <div>
+                <div class="text-muted small mb-1">@L["LabelReplyTo"]</div>
+                <PersonChip Name="@_message.ReplyToAddress.Name"
+                            Email="@_message.ReplyToAddress.Email"
+                            Size="PersonChipSize.Small" />
+            </div>
+        }
+    </ContentSection>
+
+    <ContentSection Icon="body-text" Title="@L["MessageDetailBodyHeading"]" data-testid="message-body">
+        @if (_hasBothBodyFormats)
+        {
+            <div class="mb-3">
+                <ToggleButtonGroup Items="@_bodyFormatOptions" @bind-SelectedId="_selectedBodyFormat" />
+            </div>
+        }
+
+        @if (_selectedBodyFormat == "html" && !string.IsNullOrEmpty(_message.BodyHtml))
+        {
+            <div class="feirb-message-body-html">
                 @((MarkupString)HtmlSanitizer.Sanitize(_message.BodyHtml))
-            }
-            else if (!string.IsNullOrEmpty(_message.BodyPlainText))
-            {
-                <div style="white-space: pre-wrap;">@_message.BodyPlainText</div>
-            }
-            else
-            {
-                <p class="text-muted mb-0">@L["NoBodyContent"]</p>
-            }
-        </div>
-    </div>
+            </div>
+        }
+        else if (!string.IsNullOrEmpty(_message.BodyPlainText))
+        {
+            <div class="feirb-message-body-plain" style="white-space: pre-wrap;">@_message.BodyPlainText</div>
+        }
+        else
+        {
+            <p class="text-muted mb-0">@L["NoBodyContent"]</p>
+        }
+    </ContentSection>
 
     @if (_message.Attachments.Count > 0)
     {
-        <h5>@L["AttachmentsHeading"]</h5>
-        <div class="list-group" data-testid="message-attachments">
-            @foreach (var attachment in _message.Attachments)
-            {
-                <div class="list-group-item d-flex justify-content-between align-items-center">
-                    <div>
-                        <i class="bi bi-paperclip me-2" style="font-size: 1.2rem; vertical-align: middle;"></i>
-                        @attachment.Filename
+        <ContentSection Icon="paperclip" Title="@L["AttachmentsHeading"]" Subtitle="@(_message.Attachments.Count.ToString())" data-testid="message-attachments">
+            <div class="d-flex flex-wrap gap-2">
+                @foreach (var attachment in _message.Attachments)
+                {
+                    <div class="feirb-attachment-card">
+                        <Icon Name="@GetFileTypeIcon(attachment.MimeType)" Class="feirb-attachment-icon" />
+                        <div class="feirb-attachment-info">
+                            <span class="feirb-attachment-name" title="@attachment.Filename">@attachment.Filename</span>
+                            <span class="feirb-attachment-meta">@FormatFileSize(attachment.Size)</span>
+                        </div>
                     </div>
-                    <div class="text-muted small">
-                        @FormatFileSize(attachment.Size) &middot; @attachment.MimeType
-                    </div>
-                </div>
-            }
-        </div>
+                }
+            </div>
+        </ContentSection>
     }
 }
 
@@ -112,6 +140,14 @@ else if (_message is not null)
     private bool _isLoading = true;
     private bool _notFound;
     private string? _errorMessage;
+    private string _selectedBodyFormat = "html";
+    private bool _hasBothBodyFormats;
+
+    private static readonly IReadOnlyList<ToggleButtonItem> _bodyFormatOptions =
+    [
+        new("html", "HTML"),
+        new("plain", "Plain Text")
+    ];
 
     protected override async Task OnInitializedAsync()
     {
@@ -130,8 +166,13 @@ else if (_message is not null)
 
             if (_message is not null)
             {
+                _hasBothBodyFormats = !string.IsNullOrEmpty(_message.BodyHtml)
+                    && !string.IsNullOrEmpty(_message.BodyPlainText);
+
+                _selectedBodyFormat = !string.IsNullOrEmpty(_message.BodyHtml) ? "html" : "plain";
+
                 BreadcrumbOverride.SetLastSegmentLabel(
-                    $"{_message.From} \u2014 {_message.Subject} \u2014 {_message.Date.LocalDateTime.ToString("g")}");
+                    $"{_message.FromAddress.Name} \u2014 {_message.Subject}");
             }
         }
         catch
@@ -154,4 +195,44 @@ else if (_message is not null)
             return $"{bytes / 1024.0:F1} KB";
         return $"{bytes} B";
     }
+
+    private string FormatRelativeTime(DateTimeOffset date)
+    {
+        var elapsed = DateTimeOffset.Now - date;
+
+        if (elapsed.TotalMinutes < 1)
+            return L["RelativeTimeJustNow"];
+        if (elapsed.TotalMinutes < 60)
+            return string.Format(L["RelativeTimeMinutesAgo"], (int)elapsed.TotalMinutes);
+        if (elapsed.TotalHours < 24)
+            return string.Format(L["RelativeTimeHoursAgo"], (int)elapsed.TotalHours);
+        if (elapsed.TotalDays < 7)
+            return string.Format(L["RelativeTimeDaysAgo"], (int)elapsed.TotalDays);
+
+        return date.LocalDateTime.ToString("MMM d, yyyy");
+    }
+
+    private static string GetFileTypeIcon(string mimeType) => mimeType.Split('/')[0] switch
+    {
+        "image" => "file-image",
+        "video" => "file-play",
+        "audio" => "file-music",
+        "text" => "file-text",
+        _ => mimeType switch
+        {
+            "application/pdf" => "file-pdf",
+            "application/zip" or "application/x-rar-compressed" or "application/gzip"
+                => "file-zip",
+            "application/msword"
+                or "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                => "file-word",
+            "application/vnd.ms-excel"
+                or "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                => "file-excel",
+            "application/vnd.ms-powerpoint"
+                or "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+                => "file-ppt",
+            _ => "file-earmark"
+        }
+    };
 }

--- a/src/Feirb.Web/Pages/Mail/MessageDetail.razor
+++ b/src/Feirb.Web/Pages/Mail/MessageDetail.razor
@@ -93,7 +93,7 @@ else if (_message is not null)
         @if (_hasBothBodyFormats)
         {
             <div class="mb-3">
-                <ToggleButtonGroup Items="@_bodyFormatOptions" @bind-SelectedId="_selectedBodyFormat" />
+                <ToggleButtonGroup Items="@BodyFormatOptions" @bind-SelectedId="_selectedBodyFormat" />
             </div>
         }
 
@@ -143,10 +143,10 @@ else if (_message is not null)
     private string _selectedBodyFormat = "html";
     private bool _hasBothBodyFormats;
 
-    private static readonly IReadOnlyList<ToggleButtonItem> _bodyFormatOptions =
+    private IReadOnlyList<ToggleButtonItem> BodyFormatOptions =>
     [
-        new("html", "HTML"),
-        new("plain", "Plain Text")
+        new("html", L["BodyFormatHtml"]),
+        new("plain", L["BodyFormatPlainText"])
     ];
 
     protected override async Task OnInitializedAsync()
@@ -209,7 +209,7 @@ else if (_message is not null)
         if (elapsed.TotalDays < 7)
             return string.Format(L["RelativeTimeDaysAgo"], (int)elapsed.TotalDays);
 
-        return date.LocalDateTime.ToString("MMM d, yyyy");
+        return date.LocalDateTime.ToString("d", System.Globalization.CultureInfo.CurrentCulture);
     }
 
     private static string GetFileTypeIcon(string mimeType) => mimeType.Split('/')[0] switch

--- a/src/Feirb.Web/Resources/SharedResources.de-DE.resx
+++ b/src/Feirb.Web/Resources/SharedResources.de-DE.resx
@@ -1761,4 +1761,19 @@
   <data name="AddressUnlinkFailed" xml:space="preserve">
     <value>Adresse konnte nicht getrennt werden.</value>
   </data>
+  <data name="MessageDetailBodyHeading" xml:space="preserve">
+    <value>Nachricht</value>
+  </data>
+  <data name="RelativeTimeJustNow" xml:space="preserve">
+    <value>gerade eben</value>
+  </data>
+  <data name="RelativeTimeMinutesAgo" xml:space="preserve">
+    <value>vor {0} Min.</value>
+  </data>
+  <data name="RelativeTimeHoursAgo" xml:space="preserve">
+    <value>vor {0} Std.</value>
+  </data>
+  <data name="RelativeTimeDaysAgo" xml:space="preserve">
+    <value>vor {0} T.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.de-DE.resx
+++ b/src/Feirb.Web/Resources/SharedResources.de-DE.resx
@@ -1764,6 +1764,12 @@
   <data name="MessageDetailBodyHeading" xml:space="preserve">
     <value>Nachricht</value>
   </data>
+  <data name="BodyFormatHtml" xml:space="preserve">
+    <value>HTML</value>
+  </data>
+  <data name="BodyFormatPlainText" xml:space="preserve">
+    <value>Nur Text</value>
+  </data>
   <data name="RelativeTimeJustNow" xml:space="preserve">
     <value>gerade eben</value>
   </data>

--- a/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
+++ b/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
@@ -1761,4 +1761,19 @@
   <data name="AddressUnlinkFailed" xml:space="preserve">
     <value>Impossible de dissocier l'adresse.</value>
   </data>
+  <data name="MessageDetailBodyHeading" xml:space="preserve">
+    <value>Message</value>
+  </data>
+  <data name="RelativeTimeJustNow" xml:space="preserve">
+    <value>a l'instant</value>
+  </data>
+  <data name="RelativeTimeMinutesAgo" xml:space="preserve">
+    <value>il y a {0} min</value>
+  </data>
+  <data name="RelativeTimeHoursAgo" xml:space="preserve">
+    <value>il y a {0} h</value>
+  </data>
+  <data name="RelativeTimeDaysAgo" xml:space="preserve">
+    <value>il y a {0} j</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
+++ b/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
@@ -1764,8 +1764,14 @@
   <data name="MessageDetailBodyHeading" xml:space="preserve">
     <value>Message</value>
   </data>
+  <data name="BodyFormatHtml" xml:space="preserve">
+    <value>HTML</value>
+  </data>
+  <data name="BodyFormatPlainText" xml:space="preserve">
+    <value>Texte brut</value>
+  </data>
   <data name="RelativeTimeJustNow" xml:space="preserve">
-    <value>a l'instant</value>
+    <value>à l'instant</value>
   </data>
   <data name="RelativeTimeMinutesAgo" xml:space="preserve">
     <value>il y a {0} min</value>

--- a/src/Feirb.Web/Resources/SharedResources.it-IT.resx
+++ b/src/Feirb.Web/Resources/SharedResources.it-IT.resx
@@ -1764,6 +1764,12 @@
   <data name="MessageDetailBodyHeading" xml:space="preserve">
     <value>Messaggio</value>
   </data>
+  <data name="BodyFormatHtml" xml:space="preserve">
+    <value>HTML</value>
+  </data>
+  <data name="BodyFormatPlainText" xml:space="preserve">
+    <value>Testo semplice</value>
+  </data>
   <data name="RelativeTimeJustNow" xml:space="preserve">
     <value>proprio ora</value>
   </data>

--- a/src/Feirb.Web/Resources/SharedResources.it-IT.resx
+++ b/src/Feirb.Web/Resources/SharedResources.it-IT.resx
@@ -1761,4 +1761,19 @@
   <data name="AddressUnlinkFailed" xml:space="preserve">
     <value>Impossibile scollegare l'indirizzo.</value>
   </data>
+  <data name="MessageDetailBodyHeading" xml:space="preserve">
+    <value>Messaggio</value>
+  </data>
+  <data name="RelativeTimeJustNow" xml:space="preserve">
+    <value>proprio ora</value>
+  </data>
+  <data name="RelativeTimeMinutesAgo" xml:space="preserve">
+    <value>{0} min fa</value>
+  </data>
+  <data name="RelativeTimeHoursAgo" xml:space="preserve">
+    <value>{0} ore fa</value>
+  </data>
+  <data name="RelativeTimeDaysAgo" xml:space="preserve">
+    <value>{0} g fa</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.resx
+++ b/src/Feirb.Web/Resources/SharedResources.resx
@@ -1764,6 +1764,12 @@
   <data name="MessageDetailBodyHeading" xml:space="preserve">
     <value>Message</value>
   </data>
+  <data name="BodyFormatHtml" xml:space="preserve">
+    <value>HTML</value>
+  </data>
+  <data name="BodyFormatPlainText" xml:space="preserve">
+    <value>Plain Text</value>
+  </data>
   <data name="RelativeTimeJustNow" xml:space="preserve">
     <value>just now</value>
   </data>

--- a/src/Feirb.Web/Resources/SharedResources.resx
+++ b/src/Feirb.Web/Resources/SharedResources.resx
@@ -1761,4 +1761,19 @@
   <data name="AddressUnlinkFailed" xml:space="preserve">
     <value>Failed to unlink address.</value>
   </data>
+  <data name="MessageDetailBodyHeading" xml:space="preserve">
+    <value>Message</value>
+  </data>
+  <data name="RelativeTimeJustNow" xml:space="preserve">
+    <value>just now</value>
+  </data>
+  <data name="RelativeTimeMinutesAgo" xml:space="preserve">
+    <value>{0} min ago</value>
+  </data>
+  <data name="RelativeTimeHoursAgo" xml:space="preserve">
+    <value>{0}h ago</value>
+  </data>
+  <data name="RelativeTimeDaysAgo" xml:space="preserve">
+    <value>{0}d ago</value>
+  </data>
 </root>

--- a/src/Feirb.Web/wwwroot/css/app.css
+++ b/src/Feirb.Web/wwwroot/css/app.css
@@ -527,3 +527,63 @@ code {
 .feirb-color-ring-segment:focus-visible {
     filter: brightness(1.3);
 }
+
+/* Message Detail */
+.feirb-detail-date {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.875rem;
+    color: var(--bs-secondary-color);
+}
+
+.feirb-message-body-html {
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
+
+.feirb-message-body-html img {
+    max-width: 100%;
+    height: auto;
+}
+
+.feirb-message-body-plain {
+    font-family: var(--bs-font-monospace);
+    font-size: 0.875rem;
+}
+
+.feirb-attachment-card {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0.625rem 0.875rem;
+    border: 1px solid var(--bs-border-color);
+    border-radius: 0.5rem;
+    min-width: 0;
+    max-width: 16rem;
+}
+
+.feirb-attachment-icon {
+    font-size: 1.5rem;
+    color: var(--bs-secondary-color);
+    flex-shrink: 0;
+}
+
+.feirb-attachment-info {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.feirb-attachment-name {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.feirb-attachment-meta {
+    font-size: 0.75rem;
+    color: var(--bs-secondary-color);
+}

--- a/tests/playwright/tests/message-detail.spec.ts
+++ b/tests/playwright/tests/message-detail.spec.ts
@@ -31,7 +31,7 @@ test.describe.serial("Message Detail View", () => {
     });
 
     // Click first mail card to navigate to detail
-    const firstCard = page.locator("a.feirb-mail-card").first();
+    const firstCard = page.locator('[data-testid="mail-card"]').first();
     await expect(firstCard).toBeVisible({ timeout: 10000 });
     await firstCard.click();
 
@@ -50,7 +50,7 @@ test.describe.serial("Message Detail View", () => {
       timeout: 10000,
     });
 
-    const firstCard = page.locator("a.feirb-mail-card").first();
+    const firstCard = page.locator('[data-testid="mail-card"]').first();
     await expect(firstCard).toBeVisible({ timeout: 10000 });
     await firstCard.click();
     await expect(page.locator(".spinner-border")).toBeHidden({
@@ -76,7 +76,7 @@ test.describe.serial("Message Detail View", () => {
       timeout: 10000,
     });
 
-    const firstCard = page.locator("a.feirb-mail-card").first();
+    const firstCard = page.locator('[data-testid="mail-card"]').first();
     await expect(firstCard).toBeVisible({ timeout: 10000 });
     await firstCard.click();
     await expect(page.locator(".spinner-border")).toBeHidden({
@@ -108,7 +108,7 @@ test.describe.serial("Message Detail View", () => {
       timeout: 10000,
     });
 
-    const firstCard = page.locator("a.feirb-mail-card").first();
+    const firstCard = page.locator('[data-testid="mail-card"]').first();
     await expect(firstCard).toBeVisible({ timeout: 10000 });
     await firstCard.click();
     await expect(page.locator(".spinner-border")).toBeHidden({
@@ -129,7 +129,7 @@ test.describe.serial("Message Detail View", () => {
       timeout: 10000,
     });
 
-    const firstCard = page.locator("a.feirb-mail-card").first();
+    const firstCard = page.locator('[data-testid="mail-card"]').first();
     await expect(firstCard).toBeVisible({ timeout: 10000 });
     await firstCard.click();
     await expect(page.locator(".spinner-border")).toBeHidden({
@@ -159,7 +159,7 @@ test.describe.serial("Message Detail View", () => {
       timeout: 10000,
     });
 
-    const firstCard = page.locator("a.feirb-mail-card").first();
+    const firstCard = page.locator('[data-testid="mail-card"]').first();
     await expect(firstCard).toBeVisible({ timeout: 10000 });
     await firstCard.click();
     await expect(page.locator(".spinner-border")).toBeHidden({
@@ -177,14 +177,12 @@ test.describe.serial("Message Detail View", () => {
       const buttons = toggleGroup.getByRole("radio");
       await expect(buttons).toHaveCount(2);
 
-      // HTML should be selected by default
-      const htmlButton = toggleGroup.getByRole("radio", { name: "HTML" });
+      // First option (HTML) should be selected by default
+      const htmlButton = toggleGroup.getByRole("radio").nth(0);
       await expect(htmlButton).toHaveAttribute("aria-checked", "true");
 
-      // Click Plain Text
-      const plainButton = toggleGroup.getByRole("radio", {
-        name: "Plain Text",
-      });
+      // Click second option (Plain Text)
+      const plainButton = toggleGroup.getByRole("radio").nth(1);
       await plainButton.click();
       await expect(plainButton).toHaveAttribute("aria-checked", "true");
 
@@ -211,7 +209,7 @@ test.describe.serial("Message Detail View", () => {
       timeout: 10000,
     });
 
-    const firstCard = page.locator("a.feirb-mail-card").first();
+    const firstCard = page.locator('[data-testid="mail-card"]').first();
     await expect(firstCard).toBeVisible({ timeout: 10000 });
     await firstCard.click();
     await expect(page.locator(".spinner-border")).toBeHidden({
@@ -249,7 +247,7 @@ test.describe.serial("Message Detail View", () => {
       timeout: 10000,
     });
 
-    const firstCard = page.locator("a.feirb-mail-card").first();
+    const firstCard = page.locator('[data-testid="mail-card"]').first();
     await expect(firstCard).toBeVisible({ timeout: 10000 });
     await firstCard.click();
     await expect(page.locator(".spinner-border")).toBeHidden({
@@ -271,7 +269,7 @@ test.describe.serial("Message Detail View", () => {
       timeout: 10000,
     });
 
-    const firstCard = page.locator("a.feirb-mail-card").first();
+    const firstCard = page.locator('[data-testid="mail-card"]').first();
     await expect(firstCard).toBeVisible({ timeout: 10000 });
     await firstCard.click();
     await expect(page.locator(".spinner-border")).toBeHidden({
@@ -293,7 +291,7 @@ test.describe.serial("Message Detail View", () => {
       timeout: 10000,
     });
 
-    const firstCard = page.locator("a.feirb-mail-card").first();
+    const firstCard = page.locator('[data-testid="mail-card"]').first();
     await expect(firstCard).toBeVisible({ timeout: 10000 });
     await firstCard.click();
     await expect(page.locator(".spinner-border")).toBeHidden({

--- a/tests/playwright/tests/message-detail.spec.ts
+++ b/tests/playwright/tests/message-detail.spec.ts
@@ -1,0 +1,315 @@
+import { test, expect } from "@playwright/test";
+
+const ADMIN_USERNAME = process.env.ADMIN_USERNAME ?? "admin-playwright";
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD ?? "TestPassword123!";
+
+test.describe.serial("Message Detail View", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    if (
+      page.url().includes("/login") ||
+      page.url().includes("/setup") ||
+      page.url().includes("/error")
+    ) {
+      await page.goto("/login");
+      await expect(page.locator("#username")).toBeVisible({ timeout: 10000 });
+      await page.locator("#username").fill(ADMIN_USERNAME);
+      await page.locator("#password").fill(ADMIN_PASSWORD);
+      await page.getByRole("button", { name: "Log In" }).click();
+      await expect(
+        page.getByLabel("breadcrumb").getByText("Dashboard"),
+      ).toBeVisible({ timeout: 15000 });
+    }
+  });
+
+  test("navigates from inbox to message detail", async ({ page }) => {
+    await page.goto("/mail/inbox");
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    // Click first mail card to navigate to detail
+    const firstCard = page.locator("a.feirb-mail-card").first();
+    await expect(firstCard).toBeVisible({ timeout: 10000 });
+    await firstCard.click();
+
+    // Should navigate to message detail route
+    await expect(page).toHaveURL(/\/mail\/inbox\/[0-9a-f-]+/);
+
+    // Loading spinner should disappear
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+  });
+
+  test("displays mailbox chip and relative time", async ({ page }) => {
+    await page.goto("/mail/inbox");
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    const firstCard = page.locator("a.feirb-mail-card").first();
+    await expect(firstCard).toBeVisible({ timeout: 10000 });
+    await firstCard.click();
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    // Meta bar with mailbox chip and date
+    const metaBar = page.locator('[data-testid="message-meta"]');
+    await expect(metaBar).toBeVisible();
+
+    // MailboxChip renders with .feirb-mailbox-chip class
+    await expect(metaBar.locator(".feirb-mailbox-chip")).toBeVisible();
+
+    // Relative time display with clock icon
+    await expect(metaBar.locator(".feirb-detail-date")).toBeVisible();
+  });
+
+  test("displays sender as PersonChip with name and email", async ({
+    page,
+  }) => {
+    await page.goto("/mail/inbox");
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    const firstCard = page.locator("a.feirb-mail-card").first();
+    await expect(firstCard).toBeVisible({ timeout: 10000 });
+    await firstCard.click();
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    // Headers section
+    const headers = page.locator('[data-testid="message-headers"]');
+    await expect(headers).toBeVisible();
+
+    // From PersonChip (first/largest one in the header section)
+    const fromChip = headers.locator(".feirb-person-chip").first();
+    await expect(fromChip).toBeVisible();
+
+    // PersonChip should have a name element
+    await expect(
+      fromChip.locator(".feirb-person-chip-name"),
+    ).not.toBeEmpty();
+
+    // PersonChip should have an email element
+    await expect(
+      fromChip.locator(".feirb-person-chip-email"),
+    ).not.toBeEmpty();
+  });
+
+  test("displays To recipients as PersonChips", async ({ page }) => {
+    await page.goto("/mail/inbox");
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    const firstCard = page.locator("a.feirb-mail-card").first();
+    await expect(firstCard).toBeVisible({ timeout: 10000 });
+    await firstCard.click();
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    const headers = page.locator('[data-testid="message-headers"]');
+
+    // There should be at least 2 PersonChips total (From + at least one To)
+    const chips = headers.locator(".feirb-person-chip");
+    const count = await chips.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+
+  test("displays message body in a content section", async ({ page }) => {
+    await page.goto("/mail/inbox");
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    const firstCard = page.locator("a.feirb-mail-card").first();
+    await expect(firstCard).toBeVisible({ timeout: 10000 });
+    await firstCard.click();
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    // Body section should be visible
+    const bodySection = page.locator('[data-testid="message-body"]');
+    await expect(bodySection).toBeVisible();
+
+    // Should have either HTML or plain text body content (or "no content" message)
+    const htmlBody = bodySection.locator(".feirb-message-body-html");
+    const plainBody = bodySection.locator(".feirb-message-body-plain");
+    const noContent = bodySection.locator(".text-muted");
+
+    const hasHtml = (await htmlBody.count()) > 0;
+    const hasPlain = (await plainBody.count()) > 0;
+    const hasNoContent = (await noContent.count()) > 0;
+    expect(hasHtml || hasPlain || hasNoContent).toBeTruthy();
+  });
+
+  test("HTML/plain text toggle appears when both formats exist", async ({
+    page,
+  }) => {
+    await page.goto("/mail/inbox");
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    const firstCard = page.locator("a.feirb-mail-card").first();
+    await expect(firstCard).toBeVisible({ timeout: 10000 });
+    await firstCard.click();
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    const bodySection = page.locator('[data-testid="message-body"]');
+    const toggleGroup = bodySection.locator(".feirb-toggle-group");
+
+    // Toggle may or may not be visible depending on whether message has both formats
+    if ((await toggleGroup.count()) > 0) {
+      await expect(toggleGroup).toBeVisible();
+
+      // Should have exactly 2 options: HTML and Plain Text
+      const buttons = toggleGroup.getByRole("radio");
+      await expect(buttons).toHaveCount(2);
+
+      // HTML should be selected by default
+      const htmlButton = toggleGroup.getByRole("radio", { name: "HTML" });
+      await expect(htmlButton).toHaveAttribute("aria-checked", "true");
+
+      // Click Plain Text
+      const plainButton = toggleGroup.getByRole("radio", {
+        name: "Plain Text",
+      });
+      await plainButton.click();
+      await expect(plainButton).toHaveAttribute("aria-checked", "true");
+
+      // Plain text body should now be visible
+      await expect(
+        bodySection.locator(".feirb-message-body-plain"),
+      ).toBeVisible();
+
+      // Switch back to HTML
+      await htmlButton.click();
+      await expect(htmlButton).toHaveAttribute("aria-checked", "true");
+      await expect(
+        bodySection.locator(".feirb-message-body-html"),
+      ).toBeVisible();
+    }
+  });
+
+  test("attachments section displays with file type icons", async ({
+    page,
+  }) => {
+    // Navigate to inbox and find any message
+    await page.goto("/mail/inbox");
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    const firstCard = page.locator("a.feirb-mail-card").first();
+    await expect(firstCard).toBeVisible({ timeout: 10000 });
+    await firstCard.click();
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    // Attachments section is conditional — only shown when message has attachments
+    const attachments = page.locator('[data-testid="message-attachments"]');
+
+    if ((await attachments.count()) > 0) {
+      await expect(attachments).toBeVisible();
+
+      // Each attachment card should have an icon and file info
+      const cards = attachments.locator(".feirb-attachment-card");
+      const cardCount = await cards.count();
+      expect(cardCount).toBeGreaterThan(0);
+
+      // First attachment card should have name and size
+      const firstAttachment = cards.first();
+      await expect(
+        firstAttachment.locator(".feirb-attachment-name"),
+      ).not.toBeEmpty();
+      await expect(
+        firstAttachment.locator(".feirb-attachment-meta"),
+      ).not.toBeEmpty();
+      await expect(
+        firstAttachment.locator(".feirb-attachment-icon"),
+      ).toBeVisible();
+    }
+  });
+
+  test("relative time has absolute tooltip", async ({ page }) => {
+    await page.goto("/mail/inbox");
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    const firstCard = page.locator("a.feirb-mail-card").first();
+    await expect(firstCard).toBeVisible({ timeout: 10000 });
+    await firstCard.click();
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    // The date element should have a title attribute with the absolute date
+    const dateElement = page.locator(".feirb-detail-date");
+    await expect(dateElement).toBeVisible();
+    const title = await dateElement.getAttribute("title");
+    expect(title).toBeTruthy();
+    // Title should contain a date-like string (e.g., "April 10, 2026")
+    expect(title!.length).toBeGreaterThan(5);
+  });
+
+  test("breadcrumb shows sender and subject", async ({ page }) => {
+    await page.goto("/mail/inbox");
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    const firstCard = page.locator("a.feirb-mail-card").first();
+    await expect(firstCard).toBeVisible({ timeout: 10000 });
+    await firstCard.click();
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    // Breadcrumb last segment should have the sender name and subject (set via BreadcrumbOverrideService)
+    const breadcrumb = page.getByLabel("breadcrumb");
+    await expect(breadcrumb).toBeVisible();
+
+    // Should contain the em dash separator between sender and subject
+    const breadcrumbText = await breadcrumb.textContent();
+    expect(breadcrumbText).toContain("\u2014");
+  });
+
+  test("content sections use proper layout structure", async ({ page }) => {
+    await page.goto("/mail/inbox");
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    const firstCard = page.locator("a.feirb-mail-card").first();
+    await expect(firstCard).toBeVisible({ timeout: 10000 });
+    await firstCard.click();
+    await expect(page.locator(".spinner-border")).toBeHidden({
+      timeout: 10000,
+    });
+
+    // Page should have at least 2 ContentSections (headers + body)
+    const sections = page.locator(".content-section");
+    const count = await sections.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    // Each section should have a header with icon and heading
+    const firstSection = sections.first();
+    await expect(
+      firstSection.locator(".content-section-header"),
+    ).toBeVisible();
+    await expect(firstSection.locator(".content-section-body")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Rework the message detail page with PersonChip components for sender/recipients (parsed name + email + address book status), MailboxChip, relative time display with absolute tooltip, and LabelPill classification labels
- Add HTML/plain text toggle (ToggleButtonGroup) when both body formats are available, and improve attachment display with MIME-based file type icons
- Add `MessageAddressResponse` DTO, extend `MessageDetailResponse` with structured addresses and labels, update API to include `.Include(m => m.Labels)` and sender address status lookup

Closes #191

### Files changed

| Area | Files | What |
|------|-------|------|
| Shared DTOs | `MessageAddressResponse.cs` (new), `MessageDetailResponse.cs` | Structured address fields + labels |
| API | `MessageEndpoints.cs` | Label include, address parsing, sender status lookup |
| Frontend | `MessageDetail.razor` | Full page rework with component library primitives |
| CSS | `app.css` | Styles for `.feirb-detail-date`, `.feirb-message-body-*`, `.feirb-attachment-card` |
| i18n | 4 `.resx` files | 5 new keys (body heading, relative time) in en/de/fr/it |
| Tests | `message-detail.spec.ts` | 10 Playwright E2E tests |

### Not included (out of scope)

- Attachment download (CachedAttachment stores metadata only; download requires IMAP re-fetch)
- Reply/forward/compose, message actions, quoted text collapsing (per issue scope)

## Test plan

- [ ] Start app with `--seeding`, trigger IMAP sync, open a message from inbox
- [ ] Verify PersonChips render for From (with status badge) and To/Cc recipients
- [ ] Verify MailboxChip and relative time with absolute tooltip in meta bar
- [ ] Verify LabelPills appear after classification has run
- [ ] Toggle between HTML and Plain Text body views (when both exist)
- [ ] Verify attachment cards show file type icons and file size
- [ ] Check responsive layout on mobile viewport
- [ ] Run Playwright tests: `npx playwright test message-detail.spec.ts`

Generated with [Claude Code](https://claude.com/claude-code)