### PR TITLE
fix(web): add CaptureUnmatchedValues to ContentSection component

### DIFF
--- a/src/Feirb.Web/Components/ContentSection.razor
+++ b/src/Feirb.Web/Components/ContentSection.razor
@@ -1,6 +1,6 @@
 @using Feirb.Web.Components.UI
 
-<div class="content-section mb-4 @Class">
+<div class="content-section mb-4 @Class" @attributes="AdditionalAttributes">
     <div class="content-section-header">
         <Icon Name="@Icon" Size="IconSize.Large" Class="content-section-icon" />
         <Heading Level="HeadingLevel.Small" Subtitle="@Subtitle" Class="mb-0">@Title</Heading>
@@ -16,4 +16,5 @@
     [Parameter] public string? Subtitle { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public string? Class { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 }


### PR DESCRIPTION
## Summary
- `ContentSection` now accepts arbitrary HTML attributes (e.g., `data-testid`) via `CaptureUnmatchedValues`
- Fixes runtime error on MessageDetail page where `data-testid` was passed but not captured

## Test plan
- [ ] Navigate to inbox, open a mail — no error about `data-testid`
- [ ] `data-testid` attributes rendered on ContentSection wrapper div

Generated with [Claude Code](https://claude.com/claude-code)