### PR TITLE
fix(api): start gracefully when Ollama is unavailable

### DIFF
--- a/src/Feirb.Api/Program.cs
+++ b/src/Feirb.Api/Program.cs
@@ -86,7 +86,11 @@ builder.Services.AddManagedJob<ClassificationJob>("classification");
 // AI / LLM — OllamaSharp via Aspire service discovery
 // Connection string name follows Aspire convention: "{ollama-resource}-{model-name}" (tag stripped)
 // Note: OllamaSharp manages its own HttpClient internally, not via IHttpClientFactory
-builder.AddOllamaApiClient("feirb-ollama-qwen3").AddChatClient();
+// Health checks disabled so the API starts gracefully when Ollama is unavailable (#169)
+builder.AddOllamaApiClient("feirb-ollama-qwen3", configureSettings: settings =>
+{
+    settings.DisableHealthChecks = true;
+}).AddChatClient();
 
 
 // Services

--- a/src/Feirb.Api/Services/ClassificationService.cs
+++ b/src/Feirb.Api/Services/ClassificationService.cs
@@ -67,6 +67,11 @@ public class ClassificationService(
             logger.LogWarning(ex, "Ollama unavailable, skipping classification for message {MessageId}", message.Id);
             return ClassificationServiceResult.Skipped;
         }
+        catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            logger.LogWarning(ex, "Ollama request timed out, skipping classification for message {MessageId}", message.Id);
+            return ClassificationServiceResult.Skipped;
+        }
 
         // Parse and validate the response
         return ParseAndValidateResponse(responseText, labels);

--- a/tests/Feirb.Api.Tests/Services/ClassificationServiceTests.cs
+++ b/tests/Feirb.Api.Tests/Services/ClassificationServiceTests.cs
@@ -162,6 +162,27 @@ public class ClassificationServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ClassifyAsync_OllamaTimeout_ReturnsSkippedAsync()
+    {
+        SeedLabels("newsletter");
+        SeedRules("Classify emails");
+
+        var chatClient = Substitute.For<IChatClient>();
+        chatClient.GetResponseAsync(
+            Arg.Any<IEnumerable<ChatMessage>>(),
+            Arg.Any<ChatOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns<ChatResponse>(_ => throw new TaskCanceledException("Request timed out"));
+
+        var service = CreateService(chatClient);
+        var message = CreateMessage();
+
+        var result = await service.ClassifyAsync(message);
+
+        result.IsSkipped.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task ClassifyAsync_MailboxNotFound_ReturnsFailedAsync()
     {
         var service = CreateService(MockChatClient("[]"));


### PR DESCRIPTION
## Summary
- Disable Ollama health checks in DI registration so API starts and reports healthy even when Ollama is unreachable
- Add `TaskCanceledException` catch in `ClassificationService` for connection timeouts (returns Skipped, items retry automatically)
- New test: `ClassifyAsync_OllamaTimeout_ReturnsSkippedAsync`

Closes #169

## Test plan
- [ ] Stop Ollama container, start API — API starts successfully, non-AI endpoints work
- [ ] Classification job runs without crash, logs skip message
- [ ] Start Ollama again — classification resumes on next job run
- [ ] Run `dotnet test` — all tests pass

Generated with [Claude Code](https://claude.com/claude-code)