### PR TITLE
feat(api): JobExecutionLog entity and ManagedJob logging infrastructure

### DIFF
--- a/src/Feirb.Api/Data/Entities/JobExecution.cs
+++ b/src/Feirb.Api/Data/Entities/JobExecution.cs
@@ -9,4 +9,5 @@ public class JobExecution
     public DateTimeOffset? FinishedAt { get; set; }
     public JobExecutionStatus Status { get; set; }
     public string? Error { get; set; }
+    public List<JobExecutionLog> Logs { get; set; } = [];
 }

--- a/src/Feirb.Api/Data/Entities/JobExecutionLog.cs
+++ b/src/Feirb.Api/Data/Entities/JobExecutionLog.cs
@@ -1,0 +1,12 @@
+namespace Feirb.Api.Data.Entities;
+
+public class JobExecutionLog
+{
+    public Guid Id { get; set; }
+    public Guid JobExecutionId { get; set; }
+    public JobExecution JobExecution { get; set; } = null!;
+    public DateTimeOffset Timestamp { get; set; }
+    public JobExecutionLogLevel Level { get; set; }
+    public required string Message { get; set; }
+    public string? Metadata { get; set; }
+}

--- a/src/Feirb.Api/Data/Entities/JobExecutionLogLevel.cs
+++ b/src/Feirb.Api/Data/Entities/JobExecutionLogLevel.cs
@@ -1,0 +1,8 @@
+namespace Feirb.Api.Data.Entities;
+
+public enum JobExecutionLogLevel
+{
+    Info,
+    Warning,
+    Error,
+}

--- a/src/Feirb.Api/Data/FeirbDbContext.cs
+++ b/src/Feirb.Api/Data/FeirbDbContext.cs
@@ -23,6 +23,7 @@ public class FeirbDbContext(DbContextOptions<FeirbDbContext> options) : DbContex
     public DbSet<Avatar> Avatars => Set<Avatar>();
     public DbSet<Contact> Contacts => Set<Contact>();
     public DbSet<Address> Addresses => Set<Address>();
+    public DbSet<JobExecutionLog> JobExecutionLogs => Set<JobExecutionLog>();
     public DbSet<DataProtectionKey> DataProtectionKeys => Set<DataProtectionKey>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -198,6 +199,21 @@ public class FeirbDbContext(DbContextOptions<FeirbDbContext> options) : DbContex
             entity.HasOne(e => e.JobSettings)
                 .WithMany(j => j.Executions)
                 .HasForeignKey(e => e.JobSettingsId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<JobExecutionLog>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasIndex(e => e.JobExecutionId);
+            entity.Property(e => e.Level)
+                .HasConversion<string>()
+                .HasMaxLength(20);
+            entity.Property(e => e.Message).HasMaxLength(4096);
+            entity.Property(e => e.Metadata).HasMaxLength(4096);
+            entity.HasOne(e => e.JobExecution)
+                .WithMany(je => je.Logs)
+                .HasForeignKey(e => e.JobExecutionId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
 

--- a/src/Feirb.Api/Data/Migrations/20260412164522_AddJobExecutionLogs.Designer.cs
+++ b/src/Feirb.Api/Data/Migrations/20260412164522_AddJobExecutionLogs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Feirb.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Feirb.Api.Data.Migrations
 {
     [DbContext(typeof(FeirbDbContext))]
-    partial class FeirbDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260412164522_AddJobExecutionLogs")]
+    partial class AddJobExecutionLogs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Feirb.Api/Data/Migrations/20260412164522_AddJobExecutionLogs.cs
+++ b/src/Feirb.Api/Data/Migrations/20260412164522_AddJobExecutionLogs.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Feirb.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddJobExecutionLogs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "JobExecutionLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    JobExecutionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Timestamp = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Level = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    Message = table.Column<string>(type: "character varying(4096)", maxLength: 4096, nullable: false),
+                    Metadata = table.Column<string>(type: "character varying(4096)", maxLength: 4096, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_JobExecutionLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_JobExecutionLogs_JobExecutions_JobExecutionId",
+                        column: x => x.JobExecutionId,
+                        principalTable: "JobExecutions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_JobExecutionLogs_JobExecutionId",
+                table: "JobExecutionLogs",
+                column: "JobExecutionId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "JobExecutionLogs");
+        }
+    }
+}

--- a/src/Feirb.Api/Services/ClassificationJob.cs
+++ b/src/Feirb.Api/Services/ClassificationJob.cs
@@ -54,7 +54,7 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
         }
 
         logger.LogInformation("Processing {Count} classification queue items", pendingItems.Count);
-        await LogAsync(JobExecutionLogLevel.Info, $"Classification started (batch: {pendingItems.Count} items)");
+        await LogAsync(JobExecutionLogLevel.Info, $"Classification started (batch: {pendingItems.Count} items)", cancellationToken: cancellationToken);
 
         foreach (var item in pendingItems)
         {
@@ -73,7 +73,7 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
                 {
                     // No rules or labels configured, or Ollama unavailable — revert to Pending
                     item.Status = ClassificationQueueItemStatus.Pending;
-                    await LogAsync(JobExecutionLogLevel.Warning, $"Mail '{item.CachedMessage.Subject}' -> skipped (no matching rule)");
+                    await LogAsync(JobExecutionLogLevel.Warning, $"Mail '{item.CachedMessage.Subject}' -> skipped (classifier not configured or unavailable)", cancellationToken: cancellationToken);
                     continue;
                 }
 
@@ -90,7 +90,7 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
                     });
 
                     db.ClassificationQueueItems.Remove(item);
-                    await LogAsync(JobExecutionLogLevel.Info, $"Mail '{item.CachedMessage.Subject}' -> labels: {result.Result}");
+                    await LogAsync(JobExecutionLogLevel.Info, $"Mail '{item.CachedMessage.Subject}' -> labels: {result.Result}", cancellationToken: cancellationToken);
                 }
                 else if (result.Success)
                 {
@@ -104,13 +104,13 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
                     });
 
                     db.ClassificationQueueItems.Remove(item);
-                    await LogAsync(JobExecutionLogLevel.Info, $"Mail '{item.CachedMessage.Subject}' -> labels: []");
+                    await LogAsync(JobExecutionLogLevel.Info, $"Mail '{item.CachedMessage.Subject}' -> labels: []", cancellationToken: cancellationToken);
                 }
                 else
                 {
                     item.Status = ClassificationQueueItemStatus.Failed;
                     item.Error = result.Error;
-                    await LogAsync(JobExecutionLogLevel.Error, $"Mail '{item.CachedMessage.Subject}' -> failed: {result.Error}");
+                    await LogAsync(JobExecutionLogLevel.Error, $"Mail '{item.CachedMessage.Subject}' -> failed: {result.Error}", cancellationToken: cancellationToken);
                 }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
@@ -128,7 +128,7 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
 
         await db.SaveChangesAsync(cancellationToken);
 
-        await LogAsync(JobExecutionLogLevel.Info, $"Batch complete: {classified} classified, {skipped} skipped, {failed} failed");
+        await LogAsync(JobExecutionLogLevel.Info, $"Batch complete: {classified} classified, {skipped} skipped, {failed} failed", cancellationToken: cancellationToken);
 
         logger.LogInformation(
             "Classification complete: {Classified} classified, {Failed} failed, {Skipped} skipped",

--- a/src/Feirb.Api/Services/ClassificationJob.cs
+++ b/src/Feirb.Api/Services/ClassificationJob.cs
@@ -54,6 +54,7 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
         }
 
         logger.LogInformation("Processing {Count} classification queue items", pendingItems.Count);
+        await LogAsync(JobExecutionLogLevel.Info, $"Classification started (batch: {pendingItems.Count} items)");
 
         foreach (var item in pendingItems)
         {
@@ -72,6 +73,7 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
                 {
                     // No rules or labels configured, or Ollama unavailable — revert to Pending
                     item.Status = ClassificationQueueItemStatus.Pending;
+                    await LogAsync(JobExecutionLogLevel.Warning, $"Mail '{item.CachedMessage.Subject}' -> skipped (no matching rule)");
                     continue;
                 }
 
@@ -88,6 +90,7 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
                     });
 
                     db.ClassificationQueueItems.Remove(item);
+                    await LogAsync(JobExecutionLogLevel.Info, $"Mail '{item.CachedMessage.Subject}' -> labels: {result.Result}");
                 }
                 else if (result.Success)
                 {
@@ -101,11 +104,13 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
                     });
 
                     db.ClassificationQueueItems.Remove(item);
+                    await LogAsync(JobExecutionLogLevel.Info, $"Mail '{item.CachedMessage.Subject}' -> labels: []");
                 }
                 else
                 {
                     item.Status = ClassificationQueueItemStatus.Failed;
                     item.Error = result.Error;
+                    await LogAsync(JobExecutionLogLevel.Error, $"Mail '{item.CachedMessage.Subject}' -> failed: {result.Error}");
                 }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
@@ -113,6 +118,7 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
                 logger.LogError(ex, "Classification failed for queue item {QueueItemId}", item.Id);
                 item.Status = ClassificationQueueItemStatus.Failed;
                 item.Error = ex.Message.Length > 4096 ? ex.Message[..4096] : ex.Message;
+                await LogAsync(JobExecutionLogLevel.Error, $"Mail '{item.CachedMessage.Subject}' -> failed: {ex.Message}");
             }
         }
 
@@ -121,6 +127,8 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
         var classified = pendingItems.Count - failed - skipped;
 
         await db.SaveChangesAsync(cancellationToken);
+
+        await LogAsync(JobExecutionLogLevel.Info, $"Batch complete: {classified} classified, {skipped} skipped, {failed} failed");
 
         logger.LogInformation(
             "Classification complete: {Classified} classified, {Failed} failed, {Skipped} skipped",

--- a/src/Feirb.Api/Services/ManagedJob.cs
+++ b/src/Feirb.Api/Services/ManagedJob.cs
@@ -11,6 +11,9 @@ public abstract class ManagedJob(IServiceScopeFactory scopeFactory, ILogger logg
     private const int _consecutiveFailureThreshold = 10;
     private static readonly TimeSpan _staleExecutionCutoff = TimeSpan.FromHours(1);
 
+    private FeirbDbContext? _executionDb;
+    private JobExecution? _currentExecution;
+
     public async Task Execute(IJobExecutionContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -70,6 +73,9 @@ public abstract class ManagedJob(IServiceScopeFactory scopeFactory, ILogger logg
         // check reliably prevents concurrent executions across overlapping triggers.
         await db.SaveChangesAsync(context.CancellationToken);
 
+        _executionDb = db;
+        _currentExecution = execution;
+
         try
         {
             await RunAsync(scope.ServiceProvider, jobSettings, context.CancellationToken);
@@ -105,9 +111,34 @@ public abstract class ManagedJob(IServiceScopeFactory scopeFactory, ILogger logg
             await db.SaveChangesAsync(CancellationToken.None);
             await CheckConsecutiveFailuresAsync(db, jobSettings, scope.ServiceProvider);
         }
+        finally
+        {
+            _executionDb = null;
+            _currentExecution = null;
+        }
     }
 
     protected abstract Task RunAsync(IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken);
+
+    protected async Task LogAsync(JobExecutionLogLevel level, string message, string? metadata = null)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        if (_executionDb is null || _currentExecution is null)
+            return;
+
+        _executionDb.JobExecutionLogs.Add(new JobExecutionLog
+        {
+            Id = Guid.NewGuid(),
+            JobExecutionId = _currentExecution.Id,
+            Timestamp = DateTimeOffset.UtcNow,
+            Level = level,
+            Message = message.Length > 4096 ? message[..4096] : message,
+            Metadata = metadata is not null && metadata.Length > 4096 ? metadata[..4096] : metadata,
+        });
+
+        await _executionDb.SaveChangesAsync();
+    }
 
     private async Task CheckConsecutiveFailuresAsync(
         FeirbDbContext db, JobSettings jobSettings, IServiceProvider serviceProvider)

--- a/src/Feirb.Api/Services/ManagedJob.cs
+++ b/src/Feirb.Api/Services/ManagedJob.cs
@@ -11,8 +11,7 @@ public abstract class ManagedJob(IServiceScopeFactory scopeFactory, ILogger logg
     private const int _consecutiveFailureThreshold = 10;
     private static readonly TimeSpan _staleExecutionCutoff = TimeSpan.FromHours(1);
 
-    private FeirbDbContext? _executionDb;
-    private JobExecution? _currentExecution;
+    private Guid? _currentExecutionId;
 
     public async Task Execute(IJobExecutionContext context)
     {
@@ -73,8 +72,7 @@ public abstract class ManagedJob(IServiceScopeFactory scopeFactory, ILogger logg
         // check reliably prevents concurrent executions across overlapping triggers.
         await db.SaveChangesAsync(context.CancellationToken);
 
-        _executionDb = db;
-        _currentExecution = execution;
+        _currentExecutionId = execution.Id;
 
         try
         {
@@ -113,31 +111,34 @@ public abstract class ManagedJob(IServiceScopeFactory scopeFactory, ILogger logg
         }
         finally
         {
-            _executionDb = null;
-            _currentExecution = null;
+            _currentExecutionId = null;
         }
     }
 
     protected abstract Task RunAsync(IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken);
 
-    protected async Task LogAsync(JobExecutionLogLevel level, string message, string? metadata = null)
+    protected async Task LogAsync(
+        JobExecutionLogLevel level, string message, string? metadata = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        if (_executionDb is null || _currentExecution is null)
+        if (_currentExecutionId is null)
             return;
 
-        _executionDb.JobExecutionLogs.Add(new JobExecutionLog
+        using var logScope = scopeFactory.CreateScope();
+        var logDb = logScope.ServiceProvider.GetRequiredService<FeirbDbContext>();
+
+        logDb.JobExecutionLogs.Add(new JobExecutionLog
         {
             Id = Guid.NewGuid(),
-            JobExecutionId = _currentExecution.Id,
+            JobExecutionId = _currentExecutionId.Value,
             Timestamp = DateTimeOffset.UtcNow,
             Level = level,
             Message = message.Length > 4096 ? message[..4096] : message,
             Metadata = metadata is not null && metadata.Length > 4096 ? metadata[..4096] : metadata,
         });
 
-        await _executionDb.SaveChangesAsync();
+        await logDb.SaveChangesAsync(cancellationToken);
     }
 
     private async Task CheckConsecutiveFailuresAsync(

--- a/tests/Feirb.Api.Tests/Services/ManagedJobTests.cs
+++ b/tests/Feirb.Api.Tests/Services/ManagedJobTests.cs
@@ -157,6 +157,48 @@ public class ManagedJobTests : IDisposable
         await act.Should().NotThrowAsync();
     }
 
+    [Fact]
+    public async Task LogAsync_WritesLogEntryForCurrentExecutionAsync()
+    {
+        var jobSettingsId = SeedJobSettings();
+        var job = CreateLoggingTestJob();
+
+        await job.Execute(CreateJobContext());
+
+        using var db = new FeirbDbContext(_dbOptions);
+        var execution = await db.JobExecutions.AsNoTracking()
+            .FirstAsync(e => e.JobSettingsId == jobSettingsId && e.Status == JobExecutionStatus.Success);
+        var logs = await db.JobExecutionLogs.AsNoTracking()
+            .Where(l => l.JobExecutionId == execution.Id)
+            .OrderBy(l => l.Timestamp)
+            .ToListAsync();
+
+        logs.Should().HaveCount(2);
+        logs[0].Level.Should().Be(JobExecutionLogLevel.Info);
+        logs[0].Message.Should().Be("Test info log");
+        logs[1].Level.Should().Be(JobExecutionLogLevel.Warning);
+        logs[1].Message.Should().Be("Test warning log");
+        logs[1].Metadata.Should().Be("{\"key\":\"value\"}");
+    }
+
+    [Fact]
+    public async Task LogAsync_DoesNotInterfereWithJobEntityChangesAsync()
+    {
+        var jobSettingsId = SeedJobSettings();
+        var job = CreateLoggingTestJob();
+
+        await job.Execute(CreateJobContext());
+
+        using var db = new FeirbDbContext(_dbOptions);
+        var updated = await db.JobSettings.AsNoTracking().FirstAsync(j => j.Id == jobSettingsId);
+        updated.LastStatus.Should().Be(JobExecutionStatus.Success);
+
+        var execution = await db.JobExecutions.AsNoTracking()
+            .FirstAsync(e => e.JobSettingsId == jobSettingsId);
+        execution.Status.Should().Be(JobExecutionStatus.Success);
+        execution.FinishedAt.Should().NotBeNull();
+    }
+
     private Guid SeedJobSettings(bool enabled = false)
     {
         using var db = new FeirbDbContext(_dbOptions);
@@ -180,6 +222,13 @@ public class ManagedJobTests : IDisposable
         return new TestManagedJob(scopeFactory, logger, succeeds, errorMessage);
     }
 
+    private LoggingTestManagedJob CreateLoggingTestJob()
+    {
+        var scopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
+        var logger = NullLoggerFactory.Instance.CreateLogger<LoggingTestManagedJob>();
+        return new LoggingTestManagedJob(scopeFactory, logger);
+    }
+
     private static IJobExecutionContext CreateJobContext()
     {
         var dataMap = new JobDataMap { { ManagedJob.JobNameKey, "TestJob" } };
@@ -200,6 +249,17 @@ public class ManagedJobTests : IDisposable
             if (!succeeds)
                 throw new InvalidOperationException(errorMessage ?? "Test failure");
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class LoggingTestManagedJob(
+        IServiceScopeFactory scopeFactory,
+        ILogger logger) : ManagedJob(scopeFactory, logger)
+    {
+        protected override async Task RunAsync(IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken)
+        {
+            await LogAsync(JobExecutionLogLevel.Info, "Test info log", cancellationToken: cancellationToken);
+            await LogAsync(JobExecutionLogLevel.Warning, "Test warning log", metadata: "{\"key\":\"value\"}", cancellationToken: cancellationToken);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `JobExecutionLog` entity with `JobExecutionLogLevel` enum (Info, Warning, Error) and EF Core migration
- Add `LogAsync(level, message, metadata?)` method to `ManagedJob` base class, available to all job subclasses
- Instrument `ClassificationJob` with structured execution logs: batch start, per-mail classification results, skipped/failed items, and batch summary

Closes #242

## Test plan
- [x] Solution builds without errors
- [x] All 294 tests pass
- [x] Formatting check passes
- [ ] Start app with seeding, trigger classification job, query `JobExecutionLogs` table to verify logs are persisted

Generated with [Claude Code](https://claude.com/claude-code)