### PR TITLE
feat(api,web): Admin execution detail page with job logs

### DIFF
--- a/src/Feirb.Api/Endpoints/JobSettingsEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/JobSettingsEndpoints.cs
@@ -16,6 +16,7 @@ public static class JobSettingsEndpoints
         group.MapPut("/{id:guid}", UpdateJobAsync);
         group.MapPost("/{id:guid}/run", TriggerJobRunAsync);
         group.MapGet("/{id:guid}/executions", GetJobExecutionsAsync);
+        group.MapGet("/{id:guid}/executions/{executionId:guid}", GetJobExecutionByIdAsync);
         group.MapGet("/{id:guid}/executions/{executionId:guid}/logs", GetJobExecutionLogsAsync);
         group.MapGet("/by-resource/{resourceType}/{resourceId:guid}", GetJobsByResourceAsync);
         return group;
@@ -103,6 +104,21 @@ public static class JobSettingsEndpoints
         return Results.Ok(result);
     }
 
+    private static async Task<IResult> GetJobExecutionByIdAsync(
+        Guid id,
+        Guid executionId,
+        HttpContext httpContext,
+        IJobService jobService,
+        IStringLocalizer<ApiMessages> localizer)
+    {
+        var (userId, isAdmin) = GetAuthContext(httpContext);
+        var result = await jobService.GetExecutionByIdAsync(id, executionId, userId, isAdmin);
+        if (result is null)
+            return Results.NotFound(new { message = localizer["ExecutionNotFound"].Value });
+
+        return Results.Ok(result);
+    }
+
     private static async Task<IResult> GetJobExecutionLogsAsync(
         Guid id,
         Guid executionId,
@@ -119,7 +135,7 @@ public static class JobSettingsEndpoints
         var (userId, isAdmin) = GetAuthContext(httpContext);
         var result = await jobService.GetExecutionLogsAsync(id, executionId, userId, isAdmin, page, pageSize);
         if (result is null)
-            return Results.NotFound(new { message = localizer["JobNotFound"].Value });
+            return Results.NotFound(new { message = localizer["ExecutionNotFound"].Value });
 
         return Results.Ok(result);
     }

--- a/src/Feirb.Api/Endpoints/JobSettingsEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/JobSettingsEndpoints.cs
@@ -16,6 +16,7 @@ public static class JobSettingsEndpoints
         group.MapPut("/{id:guid}", UpdateJobAsync);
         group.MapPost("/{id:guid}/run", TriggerJobRunAsync);
         group.MapGet("/{id:guid}/executions", GetJobExecutionsAsync);
+        group.MapGet("/{id:guid}/executions/{executionId:guid}/logs", GetJobExecutionLogsAsync);
         group.MapGet("/by-resource/{resourceType}/{resourceId:guid}", GetJobsByResourceAsync);
         return group;
     }
@@ -96,6 +97,27 @@ public static class JobSettingsEndpoints
 
         var (userId, isAdmin) = GetAuthContext(httpContext);
         var result = await jobService.GetExecutionsAsync(id, userId, isAdmin, page, pageSize);
+        if (result is null)
+            return Results.NotFound(new { message = localizer["JobNotFound"].Value });
+
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> GetJobExecutionLogsAsync(
+        Guid id,
+        Guid executionId,
+        int page,
+        int pageSize,
+        HttpContext httpContext,
+        IJobService jobService,
+        IStringLocalizer<ApiMessages> localizer)
+    {
+        if (page < 1) page = 1;
+        if (pageSize < 1) pageSize = 50;
+        if (pageSize > 100) pageSize = 100;
+
+        var (userId, isAdmin) = GetAuthContext(httpContext);
+        var result = await jobService.GetExecutionLogsAsync(id, executionId, userId, isAdmin, page, pageSize);
         if (result is null)
             return Results.NotFound(new { message = localizer["JobNotFound"].Value });
 

--- a/src/Feirb.Api/Resources/ApiMessages.de-DE.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.de-DE.resx
@@ -135,6 +135,9 @@
   <data name="JobNotFound" xml:space="preserve">
     <value>Job nicht gefunden.</value>
   </data>
+  <data name="ExecutionNotFound" xml:space="preserve">
+    <value>Ausführung nicht gefunden.</value>
+  </data>
   <data name="JobConcurrencyConflict" xml:space="preserve">
     <value>Der Job wurde von einem anderen Benutzer geändert. Bitte neu laden und erneut versuchen.</value>
   </data>

--- a/src/Feirb.Api/Resources/ApiMessages.fr-FR.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.fr-FR.resx
@@ -135,6 +135,9 @@
   <data name="JobNotFound" xml:space="preserve">
     <value>Job introuvable.</value>
   </data>
+  <data name="ExecutionNotFound" xml:space="preserve">
+    <value>Exécution introuvable.</value>
+  </data>
   <data name="JobConcurrencyConflict" xml:space="preserve">
     <value>Le job a été modifié par un autre utilisateur. Veuillez recharger et réessayer.</value>
   </data>

--- a/src/Feirb.Api/Resources/ApiMessages.it-IT.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.it-IT.resx
@@ -135,6 +135,9 @@
   <data name="JobNotFound" xml:space="preserve">
     <value>Job non trovato.</value>
   </data>
+  <data name="ExecutionNotFound" xml:space="preserve">
+    <value>Esecuzione non trovata.</value>
+  </data>
   <data name="JobConcurrencyConflict" xml:space="preserve">
     <value>Il job è stato modificato da un altro utente. Ricaricare e riprovare.</value>
   </data>

--- a/src/Feirb.Api/Resources/ApiMessages.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.resx
@@ -135,6 +135,9 @@
   <data name="JobNotFound" xml:space="preserve">
     <value>Job not found.</value>
   </data>
+  <data name="ExecutionNotFound" xml:space="preserve">
+    <value>Execution not found.</value>
+  </data>
   <data name="JobConcurrencyConflict" xml:space="preserve">
     <value>The job was modified by another user. Please reload and try again.</value>
   </data>

--- a/src/Feirb.Api/Services/ClassificationJob.cs
+++ b/src/Feirb.Api/Services/ClassificationJob.cs
@@ -10,7 +10,7 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
 {
     private const int _defaultBatchSize = 10;
 
-    protected override async Task RunAsync(
+    protected override async Task<JobRunResult> RunAsync(
         IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(jobSettings);
@@ -50,7 +50,7 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
         if (pendingItems.Count == 0)
         {
             logger.LogDebug("No pending classification queue items found");
-            return;
+            return JobRunResult.Succeeded;
         }
 
         logger.LogInformation("Processing {Count} classification queue items", pendingItems.Count);
@@ -133,6 +133,11 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
         logger.LogInformation(
             "Classification complete: {Classified} classified, {Failed} failed, {Skipped} skipped",
             classified, failed, skipped);
+
+        if (classified == 0 && failed > 0)
+            return JobRunResult.Failure($"All {failed} item(s) failed classification");
+
+        return JobRunResult.Succeeded;
     }
 
     private static async Task ApplyLabelsAsync(

--- a/src/Feirb.Api/Services/IJobService.cs
+++ b/src/Feirb.Api/Services/IJobService.cs
@@ -9,6 +9,7 @@ public interface IJobService
     Task<List<JobSettingsResponse>> GetByResourceAsync(string resourceType, Guid resourceId, Guid userId, bool isAdmin, CancellationToken cancellationToken = default);
     Task<JobSettingsResponse?> GetByIdAsync(Guid id, Guid userId, bool isAdmin, CancellationToken cancellationToken = default);
     Task<PaginatedJobExecutionsResponse?> GetExecutionsAsync(Guid jobId, Guid userId, bool isAdmin, int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<PaginatedJobExecutionLogsResponse?> GetExecutionLogsAsync(Guid jobId, Guid executionId, Guid userId, bool isAdmin, int page, int pageSize, CancellationToken cancellationToken = default);
     Task<JobSettingsResponse?> UpdateAsync(Guid id, UpdateJobSettingsRequest request, Guid userId, bool isAdmin, CancellationToken cancellationToken = default);
     Task<bool> TriggerRunAsync(Guid id, Guid userId, bool isAdmin, CancellationToken cancellationToken = default);
 }

--- a/src/Feirb.Api/Services/IJobService.cs
+++ b/src/Feirb.Api/Services/IJobService.cs
@@ -9,6 +9,7 @@ public interface IJobService
     Task<List<JobSettingsResponse>> GetByResourceAsync(string resourceType, Guid resourceId, Guid userId, bool isAdmin, CancellationToken cancellationToken = default);
     Task<JobSettingsResponse?> GetByIdAsync(Guid id, Guid userId, bool isAdmin, CancellationToken cancellationToken = default);
     Task<PaginatedJobExecutionsResponse?> GetExecutionsAsync(Guid jobId, Guid userId, bool isAdmin, int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<JobExecutionResponse?> GetExecutionByIdAsync(Guid jobId, Guid executionId, Guid userId, bool isAdmin, CancellationToken cancellationToken = default);
     Task<PaginatedJobExecutionLogsResponse?> GetExecutionLogsAsync(Guid jobId, Guid executionId, Guid userId, bool isAdmin, int page, int pageSize, CancellationToken cancellationToken = default);
     Task<JobSettingsResponse?> UpdateAsync(Guid id, UpdateJobSettingsRequest request, Guid userId, bool isAdmin, CancellationToken cancellationToken = default);
     Task<bool> TriggerRunAsync(Guid id, Guid userId, bool isAdmin, CancellationToken cancellationToken = default);

--- a/src/Feirb.Api/Services/ImapSyncJob.cs
+++ b/src/Feirb.Api/Services/ImapSyncJob.cs
@@ -6,7 +6,7 @@ namespace Feirb.Api.Services;
 public class ImapSyncJob(IServiceScopeFactory scopeFactory, ILogger<ImapSyncJob> logger)
     : ManagedJob(scopeFactory, logger)
 {
-    protected override async Task RunAsync(
+    protected override async Task<JobRunResult> RunAsync(
         IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(jobSettings);
@@ -14,10 +14,11 @@ public class ImapSyncJob(IServiceScopeFactory scopeFactory, ILogger<ImapSyncJob>
         if (jobSettings.ResourceId is not { } mailboxId)
         {
             logger.LogWarning("ImapSyncJob '{JobName}' has no ResourceId, skipping", jobSettings.JobName);
-            return;
+            return JobRunResult.Succeeded;
         }
 
         var syncService = serviceProvider.GetRequiredService<IImapSyncService>();
         await syncService.SyncMailboxAsync(mailboxId, cancellationToken);
+        return JobRunResult.Succeeded;
     }
 }

--- a/src/Feirb.Api/Services/JobRunResult.cs
+++ b/src/Feirb.Api/Services/JobRunResult.cs
@@ -1,0 +1,10 @@
+using Feirb.Api.Data.Entities;
+
+namespace Feirb.Api.Services;
+
+public record JobRunResult(JobExecutionStatus Status, string? Error = null)
+{
+    public static readonly JobRunResult Succeeded = new(JobExecutionStatus.Success);
+
+    public static JobRunResult Failure(string error) => new(JobExecutionStatus.Failed, error);
+}

--- a/src/Feirb.Api/Services/JobService.cs
+++ b/src/Feirb.Api/Services/JobService.cs
@@ -114,6 +114,45 @@ public class JobService(
         return new PaginatedJobExecutionsResponse(items, totalCount, page, pageSize);
     }
 
+    public async Task<PaginatedJobExecutionLogsResponse?> GetExecutionLogsAsync(
+        Guid jobId, Guid executionId, Guid userId, bool isAdmin, int page, int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        var job = await db.JobSettings.AsNoTracking()
+            .FirstOrDefaultAsync(j => j.Id == jobId, cancellationToken);
+
+        if (job is null)
+            return null;
+
+        if (!isAdmin && job.UserId != userId && job.UserId != null)
+            return null;
+
+        var executionExists = await db.JobExecutions.AsNoTracking()
+            .AnyAsync(e => e.Id == executionId && e.JobSettingsId == jobId, cancellationToken);
+
+        if (!executionExists)
+            return null;
+
+        var query = db.JobExecutionLogs
+            .Where(l => l.JobExecutionId == executionId)
+            .OrderBy(l => l.Timestamp);
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var items = await query
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .AsNoTracking()
+            .Select(l => new JobExecutionLogResponse(
+                l.Id,
+                l.Timestamp,
+                l.Level.ToString(),
+                l.Message))
+            .ToListAsync(cancellationToken);
+
+        return new PaginatedJobExecutionLogsResponse(items, totalCount, page, pageSize);
+    }
+
     public async Task<JobSettingsResponse?> UpdateAsync(
         Guid id, UpdateJobSettingsRequest request, Guid userId, bool isAdmin,
         CancellationToken cancellationToken = default)

--- a/src/Feirb.Api/Services/JobService.cs
+++ b/src/Feirb.Api/Services/JobService.cs
@@ -114,6 +114,32 @@ public class JobService(
         return new PaginatedJobExecutionsResponse(items, totalCount, page, pageSize);
     }
 
+    public async Task<JobExecutionResponse?> GetExecutionByIdAsync(
+        Guid jobId, Guid executionId, Guid userId, bool isAdmin,
+        CancellationToken cancellationToken = default)
+    {
+        var job = await db.JobSettings.AsNoTracking()
+            .FirstOrDefaultAsync(j => j.Id == jobId, cancellationToken);
+
+        if (job is null)
+            return null;
+
+        if (!isAdmin && (job.UserId == null || job.UserId != userId))
+            return null;
+
+        var execution = await db.JobExecutions.AsNoTracking()
+            .Where(e => e.Id == executionId && e.JobSettingsId == jobId)
+            .Select(e => new JobExecutionResponse(
+                e.Id,
+                e.StartedAt,
+                e.FinishedAt,
+                e.Status.ToString(),
+                e.Error))
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return execution;
+    }
+
     public async Task<PaginatedJobExecutionLogsResponse?> GetExecutionLogsAsync(
         Guid jobId, Guid executionId, Guid userId, bool isAdmin, int page, int pageSize,
         CancellationToken cancellationToken = default)
@@ -124,7 +150,7 @@ public class JobService(
         if (job is null)
             return null;
 
-        if (!isAdmin && job.UserId != userId && job.UserId != null)
+        if (!isAdmin && (job.UserId == null || job.UserId != userId))
             return null;
 
         var executionExists = await db.JobExecutions.AsNoTracking()

--- a/src/Feirb.Api/Services/ManagedJob.cs
+++ b/src/Feirb.Api/Services/ManagedJob.cs
@@ -76,14 +76,22 @@ public abstract class ManagedJob(IServiceScopeFactory scopeFactory, ILogger logg
 
         try
         {
-            await RunAsync(scope.ServiceProvider, jobSettings, context.CancellationToken);
-            execution.Status = JobExecutionStatus.Success;
+            var result = await RunAsync(scope.ServiceProvider, jobSettings, context.CancellationToken);
+            execution.Status = result.Status;
+            execution.Error = result.Error is not null && result.Error.Length > 4096
+                ? result.Error[..4096]
+                : result.Error;
             execution.FinishedAt = DateTimeOffset.UtcNow;
 
             jobSettings.LastRunAt = execution.FinishedAt;
-            jobSettings.LastStatus = JobExecutionStatus.Success;
+            jobSettings.LastStatus = result.Status;
 
             await db.SaveChangesAsync(context.CancellationToken);
+
+            if (result.Status == JobExecutionStatus.Failed)
+            {
+                await CheckConsecutiveFailuresAsync(db, jobSettings, scope.ServiceProvider);
+            }
         }
         catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
         {
@@ -115,7 +123,7 @@ public abstract class ManagedJob(IServiceScopeFactory scopeFactory, ILogger logg
         }
     }
 
-    protected abstract Task RunAsync(IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken);
+    protected abstract Task<JobRunResult> RunAsync(IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken);
 
     protected async Task LogAsync(
         JobExecutionLogLevel level, string message, string? metadata = null, CancellationToken cancellationToken = default)

--- a/src/Feirb.Shared/Admin/Jobs/JobExecutionLogResponse.cs
+++ b/src/Feirb.Shared/Admin/Jobs/JobExecutionLogResponse.cs
@@ -1,0 +1,7 @@
+namespace Feirb.Shared.Admin.Jobs;
+
+public record JobExecutionLogResponse(
+    Guid Id,
+    DateTimeOffset Timestamp,
+    string Level,
+    string Message);

--- a/src/Feirb.Shared/Admin/Jobs/PaginatedJobExecutionLogsResponse.cs
+++ b/src/Feirb.Shared/Admin/Jobs/PaginatedJobExecutionLogsResponse.cs
@@ -1,0 +1,7 @@
+namespace Feirb.Shared.Admin.Jobs;
+
+public record PaginatedJobExecutionLogsResponse(
+    List<JobExecutionLogResponse> Items,
+    int TotalCount,
+    int Page,
+    int PageSize);

--- a/src/Feirb.Web/Components/Breadcrumb.razor
+++ b/src/Feirb.Web/Components/Breadcrumb.razor
@@ -82,6 +82,9 @@
             "admin/user-management" => L["BreadcrumbUserManagement"],
             "admin/outgoing-smtp" => L["BreadcrumbOutgoingSmtp"],
             "admin/jobs" => L["BreadcrumbJobs"],
+            _ when fullPath.StartsWith("admin/jobs/", StringComparison.Ordinal)
+                && fullPath.Contains("/executions", StringComparison.Ordinal)
+                && segment == "executions" => L["JobDetailSectionHistory"],
             "admin/llm-settings" => L["BreadcrumbLlmSettings"],
             "admin/llm-settings/system-prompt" => L["BreadcrumbSystemPrompt"],
             "mail" => L["BreadcrumbMail"],
@@ -103,6 +106,9 @@
             "mail" => "/mail/inbox",
             "address-book/contacts" => "/address-book",
             "address-book/addresses" => "/address-book",
+            _ when fullPath.StartsWith("admin/jobs/", StringComparison.Ordinal)
+                && fullPath.EndsWith("/executions", StringComparison.Ordinal)
+                => $"/{fullPath[..fullPath.LastIndexOf("/executions", StringComparison.Ordinal)]}",
             _ => $"/{fullPath}"
         };
 

--- a/src/Feirb.Web/Pages/Admin/SystemSettings/ExecutionDetail.razor
+++ b/src/Feirb.Web/Pages/Admin/SystemSettings/ExecutionDetail.razor
@@ -31,9 +31,13 @@
         </div>
     </div>
 }
+else if (_notFound)
+{
+    <StatusMessage Icon="question-circle" Title="@L["ExecutionDetailNotFound"]" Message="@L["ExecutionDetailNotFound"]" />
+}
 else if (_execution is null)
 {
-    <StatusMessage Icon="question-circle" Title="@L["ExecutionDetailNotFound"]" Message="@L["ExecutionDetailLoadFailed"]" />
+    <StatusMessage Icon="exclamation-triangle" Title="@L["ExecutionDetailLoadFailed"]" Message="@L["ExecutionDetailLoadFailed"]" />
 }
 else
 {
@@ -121,6 +125,7 @@ else
     private JobExecutionResponse? _execution;
     private PaginatedJobExecutionLogsResponse? _logs;
     private bool _isLoading = true;
+    private bool _notFound;
     private bool _logsLoading;
     private string? _errorMessage;
     private int _logsPage = 1;
@@ -152,14 +157,15 @@ else
     {
         try
         {
-            var executions = await Http.GetFromJsonAsync<PaginatedJobExecutionsResponse>(
-                $"/api/jobs/{JobId}/executions?page=1&pageSize=100");
-
-            _execution = executions?.Items.FirstOrDefault(e => e.Id == ExecutionId);
+            var response = await Http.GetAsync($"/api/jobs/{JobId}/executions/{ExecutionId}");
+            if (response.IsSuccessStatusCode)
+            {
+                _execution = await response.Content.ReadFromJsonAsync<JobExecutionResponse>();
+            }
 
             if (_execution is null)
             {
-                _errorMessage = L["ExecutionDetailNotFound"];
+                _notFound = true;
             }
             else
             {

--- a/src/Feirb.Web/Pages/Admin/SystemSettings/ExecutionDetail.razor
+++ b/src/Feirb.Web/Pages/Admin/SystemSettings/ExecutionDetail.razor
@@ -1,0 +1,243 @@
+@page "/admin/jobs/{JobId:guid}/executions/{ExecutionId:guid}"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@using Feirb.Shared.Admin.Jobs
+@using Feirb.Web.Services
+@inject HttpClient Http
+@inject NavigationManager Navigation
+@inject IStringLocalizer<SharedResources> L
+@inject ToolbarStateService ToolbarState
+@inject BreadcrumbOverrideService BreadcrumbOverride
+@implements IDisposable
+
+<PageTitle>@L["ExecutionDetailPageTitle"] - Feirb</PageTitle>
+
+<InfoHeader Title="@L["ExecutionDetailPageTitle"]" Icon="journal-text" Subtitle="@L["ExecutionDetailSubtitle"]">
+    <HelpContent>@L["ExecutionDetailHelp"]</HelpContent>
+</InfoHeader>
+
+@if (!string.IsNullOrEmpty(_errorMessage))
+{
+    <div class="alert alert-danger alert-dismissible py-2" role="alert">
+        @_errorMessage
+        <button type="button" class="btn-close" @onclick="() => _errorMessage = null"></button>
+    </div>
+}
+
+@if (_isLoading)
+{
+    <div class="text-center py-5">
+        <div class="spinner-border" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+    </div>
+}
+else if (_execution is null)
+{
+    <StatusMessage Icon="question-circle" Title="@L["ExecutionDetailNotFound"]" Message="@L["ExecutionDetailLoadFailed"]" />
+}
+else
+{
+    <ContentSection Icon="info-circle" Title="@L["ExecutionDetailSectionHeader"]" Subtitle="@L["ExecutionDetailSectionHeaderSubtitle"]">
+        <div class="row g-3">
+            <div class="col-md-3">
+                <div class="text-muted small">@L["ColumnTimestamp"]</div>
+                <DateTimeChip Value="_execution.StartedAt" />
+            </div>
+            <div class="col-md-3">
+                <div class="text-muted small">@L["ExecutionDetailDuration"]</div>
+                <span style="font-size: 0.875rem;">@FormatDuration(_execution.StartedAt, _execution.FinishedAt)</span>
+            </div>
+            <div class="col-md-3">
+                <div class="text-muted small">@L["ColumnStatus"]</div>
+                <span class="badge @GetStatusBadgeClass(_execution.Status)">@_execution.Status</span>
+            </div>
+            @if (!string.IsNullOrEmpty(_execution.Error))
+            {
+                <div class="col-md-3">
+                    <div class="text-muted small">@L["ColumnError"]</div>
+                    <span class="text-danger" style="font-size: 0.8rem;" title="@_execution.Error">
+                        @Truncate(_execution.Error, 120)
+                    </span>
+                </div>
+            }
+        </div>
+    </ContentSection>
+
+    <ContentSection Icon="journal-text" Title="@L["ExecutionDetailSectionLogs"]" Subtitle="@L["ExecutionDetailSectionLogsSubtitle"]">
+        @if (_logsLoading)
+        {
+            <div class="text-center py-3">
+                <div class="spinner-border spinner-border-sm" role="status">
+                    <span class="visually-hidden">Loading...</span>
+                </div>
+            </div>
+        }
+        else if (_logs is null || _logs.Items.Count == 0)
+        {
+            <p class="text-muted">@L["ExecutionDetailNoLogs"]</p>
+        }
+        else
+        {
+            <Table>
+                <TableHeader>
+                    <TableColumn Width="12rem">@L["ColumnTimestamp"]</TableColumn>
+                    <TableColumn Width="6rem">@L["ColumnLevel"]</TableColumn>
+                    <TableColumn Width="1fr">@L["ColumnMessage"]</TableColumn>
+                </TableHeader>
+                <TableBody>
+                    @foreach (var log in _logs.Items)
+                    {
+                        <TableRow>
+                            <TableCell>
+                                <DateTimeChip Value="log.Timestamp" />
+                            </TableCell>
+                            <TableCell>
+                                <span class="badge @GetLevelBadgeClass(log.Level)">@log.Level</span>
+                            </TableCell>
+                            <TableCell>
+                                <span style="font-size: 0.875rem; word-break: break-word;">@log.Message</span>
+                            </TableCell>
+                        </TableRow>
+                    }
+                </TableBody>
+            </Table>
+            <Pagination CurrentPage="_logsPage" TotalPages="_logsTotalPages"
+                        CurrentPageChanged="OnLogsPageChangedAsync"
+                        PageSize="_logsPageSize" PageSizeChanged="OnLogsPageSizeChangedAsync"
+                        PreviousLabel="@L["PaginationPrevious"]"
+                        NextLabel="@L["PaginationNext"]"
+                        PerPageLabel="@L["PaginationPerPage"]" />
+        }
+    </ContentSection>
+}
+
+@code {
+    [Parameter]
+    public Guid JobId { get; set; }
+
+    [Parameter]
+    public Guid ExecutionId { get; set; }
+
+    private JobExecutionResponse? _execution;
+    private PaginatedJobExecutionLogsResponse? _logs;
+    private bool _isLoading = true;
+    private bool _logsLoading;
+    private string? _errorMessage;
+    private int _logsPage = 1;
+    private int _logsPageSize = 50;
+    private int _logsTotalPages;
+
+    private ToolbarAction[] _toolbarActions = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        _toolbarActions =
+        [
+            new ToolbarAction(L["ButtonCancel"], ButtonVariant.Warning,
+                () => { Navigation.NavigateTo($"/admin/jobs/{JobId}"); return Task.CompletedTask; }, "x-lg"),
+        ];
+        ToolbarState.AddActions(_toolbarActions);
+
+        await LoadExecutionAsync();
+        await LoadLogsAsync();
+    }
+
+    public void Dispose()
+    {
+        ToolbarState.RemoveActions(_toolbarActions);
+        BreadcrumbOverride.Clear();
+    }
+
+    private async Task LoadExecutionAsync()
+    {
+        try
+        {
+            var executions = await Http.GetFromJsonAsync<PaginatedJobExecutionsResponse>(
+                $"/api/jobs/{JobId}/executions?page=1&pageSize=100");
+
+            _execution = executions?.Items.FirstOrDefault(e => e.Id == ExecutionId);
+
+            if (_execution is null)
+            {
+                _errorMessage = L["ExecutionDetailNotFound"];
+            }
+            else
+            {
+                BreadcrumbOverride.SetLastSegmentLabel(
+                    _execution.StartedAt.LocalDateTime.ToString("yyyy-MM-dd HH:mm:ss"));
+            }
+        }
+        catch
+        {
+            _errorMessage = L["ExecutionDetailLoadFailed"];
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task LoadLogsAsync()
+    {
+        _logsLoading = true;
+        try
+        {
+            _logs = await Http.GetFromJsonAsync<PaginatedJobExecutionLogsResponse>(
+                $"/api/jobs/{JobId}/executions/{ExecutionId}/logs?page={_logsPage}&pageSize={_logsPageSize}");
+            if (_logs is not null)
+                _logsTotalPages = (int)Math.Ceiling((double)_logs.TotalCount / _logsPageSize);
+        }
+        catch
+        {
+            _errorMessage = L["ExecutionDetailLogsLoadFailed"];
+        }
+        finally
+        {
+            _logsLoading = false;
+        }
+    }
+
+    private async Task OnLogsPageChangedAsync(int page)
+    {
+        _logsPage = page;
+        await LoadLogsAsync();
+    }
+
+    private async Task OnLogsPageSizeChangedAsync(int pageSize)
+    {
+        _logsPageSize = pageSize;
+        _logsPage = 1;
+        await LoadLogsAsync();
+    }
+
+    private static string FormatDuration(DateTimeOffset start, DateTimeOffset? end)
+    {
+        if (end is null)
+            return "...";
+
+        var duration = end.Value - start;
+        return duration.TotalSeconds < 60
+            ? $"{duration.TotalSeconds:F1}s"
+            : duration.TotalMinutes < 60
+                ? $"{(int)duration.TotalMinutes}m {duration.Seconds}s"
+                : $"{(int)duration.TotalHours}h {duration.Minutes}m";
+    }
+
+    private static string GetStatusBadgeClass(string status) => status switch
+    {
+        "Success" => "bg-success",
+        "Cancelled" => "bg-warning",
+        _ => "bg-danger",
+    };
+
+    private static string GetLevelBadgeClass(string level) => level switch
+    {
+        "Info" => "bg-info",
+        "Warning" => "bg-warning text-dark",
+        "Error" => "bg-danger",
+        _ => "bg-secondary",
+    };
+
+    private static string Truncate(string text, int maxLength) =>
+        text.Length <= maxLength ? text : string.Concat(text.AsSpan(0, maxLength), "...");
+}

--- a/src/Feirb.Web/Pages/Admin/SystemSettings/JobDetail.razor
+++ b/src/Feirb.Web/Pages/Admin/SystemSettings/JobDetail.razor
@@ -72,7 +72,7 @@ else if (_model is not null)
         }
         else
         {
-            <Table>
+            <Table Hover>
                 <TableHeader>
                     <TableColumn Width="12rem">@L["ColumnTimestamp"]</TableColumn>
                     <TableColumn Width="8rem">@L["ColumnDuration"]</TableColumn>
@@ -82,7 +82,7 @@ else if (_model is not null)
                 <TableBody>
                     @foreach (var exec in _executions.Items)
                     {
-                        <TableRow>
+                        <TableRow OnClick="() => NavigateToExecution(exec.Id)">
                             <TableCell>
                                 <DateTimeChip Value="exec.StartedAt" />
                             </TableCell>
@@ -309,6 +309,9 @@ else if (_model is not null)
         _execPage = 1;
         await LoadExecutionsAsync();
     }
+
+    private void NavigateToExecution(Guid executionId) =>
+        Navigation.NavigateTo($"/admin/jobs/{Id}/executions/{executionId}");
 
     private static string FormatDuration(DateTimeOffset start, DateTimeOffset? end)
     {

--- a/src/Feirb.Web/Pages/Admin/SystemSettings/JobDetail.razor
+++ b/src/Feirb.Web/Pages/Admin/SystemSettings/JobDetail.razor
@@ -82,7 +82,9 @@ else if (_model is not null)
                 <TableBody>
                     @foreach (var exec in _executions.Items)
                     {
-                        <TableRow OnClick="() => NavigateToExecution(exec.Id)">
+                        <TableRow OnClick="() => NavigateToExecution(exec.Id)"
+                                  tabindex="0"
+                                  OnKeyDown="@(e => { if (e.Key is "Enter" or " ") NavigateToExecution(exec.Id); })">
                             <TableCell>
                                 <DateTimeChip Value="exec.StartedAt" />
                             </TableCell>

--- a/src/Feirb.Web/Resources/SharedResources.de-DE.resx
+++ b/src/Feirb.Web/Resources/SharedResources.de-DE.resx
@@ -1383,6 +1383,48 @@
   <data name="JobDetailRunning" xml:space="preserve">
     <value>Laeuft...</value>
   </data>
+  <data name="ExecutionDetailPageTitle" xml:space="preserve">
+    <value>Ausfuehrungsdetails</value>
+  </data>
+  <data name="ExecutionDetailSubtitle" xml:space="preserve">
+    <value>Protokolleintraege dieser Aufgabenausfuehrung</value>
+  </data>
+  <data name="ExecutionDetailHelp" xml:space="preserve">
+    <value>Detaillierte Protokolleintraege dieser Aufgabenausfuehrung anzeigen. Jeder Eintrag zeigt Zeitstempel, Schweregrad und Nachricht.</value>
+  </data>
+  <data name="ExecutionDetailSectionHeader" xml:space="preserve">
+    <value>Zusammenfassung</value>
+  </data>
+  <data name="ExecutionDetailSectionHeaderSubtitle" xml:space="preserve">
+    <value>Ueberblick ueber diese Ausfuehrung</value>
+  </data>
+  <data name="ExecutionDetailSectionLogs" xml:space="preserve">
+    <value>Protokolleintraege</value>
+  </data>
+  <data name="ExecutionDetailSectionLogsSubtitle" xml:space="preserve">
+    <value>Waehrend der Ausfuehrung erzeugte Nachrichten</value>
+  </data>
+  <data name="ExecutionDetailNotFound" xml:space="preserve">
+    <value>Ausfuehrung nicht gefunden.</value>
+  </data>
+  <data name="ExecutionDetailLoadFailed" xml:space="preserve">
+    <value>Ausfuehrungsdetails konnten nicht geladen werden.</value>
+  </data>
+  <data name="ExecutionDetailLogsLoadFailed" xml:space="preserve">
+    <value>Ausfuehrungsprotokolle konnten nicht geladen werden.</value>
+  </data>
+  <data name="ExecutionDetailNoLogs" xml:space="preserve">
+    <value>Keine Protokolleintraege fuer diese Ausfuehrung.</value>
+  </data>
+  <data name="ExecutionDetailDuration" xml:space="preserve">
+    <value>Dauer</value>
+  </data>
+  <data name="ColumnLevel" xml:space="preserve">
+    <value>Stufe</value>
+  </data>
+  <data name="ColumnMessage" xml:space="preserve">
+    <value>Nachricht</value>
+  </data>
   <data name="CronInputInvalid" xml:space="preserve">
     <value>Ungueltiger Quartz-Cron-Ausdruck.</value>
   </data>

--- a/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
+++ b/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
@@ -1383,6 +1383,48 @@
   <data name="JobDetailRunning" xml:space="preserve">
     <value>En cours...</value>
   </data>
+  <data name="ExecutionDetailPageTitle" xml:space="preserve">
+    <value>Details de l'execution</value>
+  </data>
+  <data name="ExecutionDetailSubtitle" xml:space="preserve">
+    <value>Entrees de journal pour cette execution de tache</value>
+  </data>
+  <data name="ExecutionDetailHelp" xml:space="preserve">
+    <value>Consultez les entrees de journal detaillees produites lors de cette execution. Chaque entree indique l'horodatage, le niveau de gravite et le message.</value>
+  </data>
+  <data name="ExecutionDetailSectionHeader" xml:space="preserve">
+    <value>Resume de l'execution</value>
+  </data>
+  <data name="ExecutionDetailSectionHeaderSubtitle" xml:space="preserve">
+    <value>Apercu de cette execution</value>
+  </data>
+  <data name="ExecutionDetailSectionLogs" xml:space="preserve">
+    <value>Entrees de journal</value>
+  </data>
+  <data name="ExecutionDetailSectionLogsSubtitle" xml:space="preserve">
+    <value>Messages produits pendant l'execution</value>
+  </data>
+  <data name="ExecutionDetailNotFound" xml:space="preserve">
+    <value>Execution introuvable.</value>
+  </data>
+  <data name="ExecutionDetailLoadFailed" xml:space="preserve">
+    <value>Echec du chargement des details de l'execution.</value>
+  </data>
+  <data name="ExecutionDetailLogsLoadFailed" xml:space="preserve">
+    <value>Echec du chargement des journaux d'execution.</value>
+  </data>
+  <data name="ExecutionDetailNoLogs" xml:space="preserve">
+    <value>Aucune entree de journal pour cette execution.</value>
+  </data>
+  <data name="ExecutionDetailDuration" xml:space="preserve">
+    <value>Duree</value>
+  </data>
+  <data name="ColumnLevel" xml:space="preserve">
+    <value>Niveau</value>
+  </data>
+  <data name="ColumnMessage" xml:space="preserve">
+    <value>Message</value>
+  </data>
   <data name="CronInputInvalid" xml:space="preserve">
     <value>Expression cron Quartz invalide.</value>
   </data>

--- a/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
+++ b/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
@@ -1327,31 +1327,31 @@
     <value>Toutes les heures</value>
   </data>
   <data name="JobDetailPageTitle" xml:space="preserve">
-    <value>Parametres du job</value>
+    <value>Paramètres du job</value>
   </data>
   <data name="JobDetailSubtitle" xml:space="preserve">
-    <value>Configurer la planification et voir l'historique des executions</value>
+    <value>Configurer la planification et voir l'historique des exécutions</value>
   </data>
   <data name="JobDetailHelp" xml:space="preserve">
-    <value>Modifier la planification cron, activer ou desactiver le job, declencher une execution manuelle et consulter les executions passees.</value>
+    <value>Modifier la planification cron, activer ou désactiver le job, déclencher une exécution manuelle et consulter les exécutions passées.</value>
   </data>
   <data name="JobDetailSectionSchedule" xml:space="preserve">
     <value>Planification</value>
   </data>
   <data name="JobDetailSectionScheduleSubtitle" xml:space="preserve">
-    <value>Configurer quand ce job s'execute</value>
+    <value>Configurer quand ce job s'exécute</value>
   </data>
   <data name="JobDetailSectionHistory" xml:space="preserve">
-    <value>Historique des executions</value>
+    <value>Historique des exécutions</value>
   </data>
   <data name="JobDetailSectionHistorySubtitle" xml:space="preserve">
-    <value>Executions passees de ce job</value>
+    <value>Exécutions passées de ce job</value>
   </data>
   <data name="ColumnTimestamp" xml:space="preserve">
     <value>Horodatage</value>
   </data>
   <data name="ColumnDuration" xml:space="preserve">
-    <value>Duree</value>
+    <value>Durée</value>
   </data>
   <data name="ColumnStatus" xml:space="preserve">
     <value>Statut</value>
@@ -1360,64 +1360,64 @@
     <value>Erreur</value>
   </data>
   <data name="JobDetailNoExecutions" xml:space="preserve">
-    <value>Aucune execution enregistree pour le moment.</value>
+    <value>Aucune exécution enregistrée pour le moment.</value>
   </data>
   <data name="ButtonRunNow" xml:space="preserve">
-    <value>Executer maintenant</value>
+    <value>Exécuter maintenant</value>
   </data>
   <data name="JobRunNowSuccess" xml:space="preserve">
-    <value>Job declenche avec succes.</value>
+    <value>Job déclenché avec succès.</value>
   </data>
   <data name="JobRunNowFailed" xml:space="preserve">
-    <value>Impossible de declencher le job.</value>
+    <value>Impossible de déclencher le job.</value>
   </data>
   <data name="JobDetailLoadFailed" xml:space="preserve">
-    <value>Impossible de charger les details du job.</value>
+    <value>Impossible de charger les détails du job.</value>
   </data>
   <data name="JobDetailNotFound" xml:space="preserve">
     <value>Job introuvable.</value>
   </data>
   <data name="JobDetailExecutionsLoadFailed" xml:space="preserve">
-    <value>Impossible de charger l'historique des executions.</value>
+    <value>Impossible de charger l'historique des exécutions.</value>
   </data>
   <data name="JobDetailRunning" xml:space="preserve">
     <value>En cours...</value>
   </data>
   <data name="ExecutionDetailPageTitle" xml:space="preserve">
-    <value>Details de l'execution</value>
+    <value>Détails de l'exécution</value>
   </data>
   <data name="ExecutionDetailSubtitle" xml:space="preserve">
-    <value>Entrees de journal pour cette execution de tache</value>
+    <value>Entrées de journal pour cette exécution de tâche</value>
   </data>
   <data name="ExecutionDetailHelp" xml:space="preserve">
-    <value>Consultez les entrees de journal detaillees produites lors de cette execution. Chaque entree indique l'horodatage, le niveau de gravite et le message.</value>
+    <value>Consultez les entrées de journal détaillées produites lors de cette exécution. Chaque entrée indique l'horodatage, le niveau de gravité et le message.</value>
   </data>
   <data name="ExecutionDetailSectionHeader" xml:space="preserve">
-    <value>Resume de l'execution</value>
+    <value>Résumé de l'exécution</value>
   </data>
   <data name="ExecutionDetailSectionHeaderSubtitle" xml:space="preserve">
-    <value>Apercu de cette execution</value>
+    <value>Aperçu de cette exécution</value>
   </data>
   <data name="ExecutionDetailSectionLogs" xml:space="preserve">
-    <value>Entrees de journal</value>
+    <value>Entrées de journal</value>
   </data>
   <data name="ExecutionDetailSectionLogsSubtitle" xml:space="preserve">
-    <value>Messages produits pendant l'execution</value>
+    <value>Messages produits pendant l'exécution</value>
   </data>
   <data name="ExecutionDetailNotFound" xml:space="preserve">
     <value>Execution introuvable.</value>
   </data>
   <data name="ExecutionDetailLoadFailed" xml:space="preserve">
-    <value>Echec du chargement des details de l'execution.</value>
+    <value>Échec du chargement des détails de l'exécution.</value>
   </data>
   <data name="ExecutionDetailLogsLoadFailed" xml:space="preserve">
-    <value>Echec du chargement des journaux d'execution.</value>
+    <value>Échec du chargement des journaux d'exécution.</value>
   </data>
   <data name="ExecutionDetailNoLogs" xml:space="preserve">
-    <value>Aucune entree de journal pour cette execution.</value>
+    <value>Aucune entrée de journal pour cette exécution.</value>
   </data>
   <data name="ExecutionDetailDuration" xml:space="preserve">
-    <value>Duree</value>
+    <value>Durée</value>
   </data>
   <data name="ColumnLevel" xml:space="preserve">
     <value>Niveau</value>

--- a/src/Feirb.Web/Resources/SharedResources.it-IT.resx
+++ b/src/Feirb.Web/Resources/SharedResources.it-IT.resx
@@ -1383,6 +1383,48 @@
   <data name="JobDetailRunning" xml:space="preserve">
     <value>In esecuzione...</value>
   </data>
+  <data name="ExecutionDetailPageTitle" xml:space="preserve">
+    <value>Dettagli esecuzione</value>
+  </data>
+  <data name="ExecutionDetailSubtitle" xml:space="preserve">
+    <value>Voci di registro per questa esecuzione del processo</value>
+  </data>
+  <data name="ExecutionDetailHelp" xml:space="preserve">
+    <value>Visualizza le voci di registro dettagliate prodotte durante questa esecuzione. Ogni voce mostra il timestamp, il livello di gravita e il messaggio.</value>
+  </data>
+  <data name="ExecutionDetailSectionHeader" xml:space="preserve">
+    <value>Riepilogo esecuzione</value>
+  </data>
+  <data name="ExecutionDetailSectionHeaderSubtitle" xml:space="preserve">
+    <value>Panoramica di questa esecuzione</value>
+  </data>
+  <data name="ExecutionDetailSectionLogs" xml:space="preserve">
+    <value>Voci di registro</value>
+  </data>
+  <data name="ExecutionDetailSectionLogsSubtitle" xml:space="preserve">
+    <value>Messaggi prodotti durante l'esecuzione</value>
+  </data>
+  <data name="ExecutionDetailNotFound" xml:space="preserve">
+    <value>Esecuzione non trovata.</value>
+  </data>
+  <data name="ExecutionDetailLoadFailed" xml:space="preserve">
+    <value>Impossibile caricare i dettagli dell'esecuzione.</value>
+  </data>
+  <data name="ExecutionDetailLogsLoadFailed" xml:space="preserve">
+    <value>Impossibile caricare i registri di esecuzione.</value>
+  </data>
+  <data name="ExecutionDetailNoLogs" xml:space="preserve">
+    <value>Nessuna voce di registro per questa esecuzione.</value>
+  </data>
+  <data name="ExecutionDetailDuration" xml:space="preserve">
+    <value>Durata</value>
+  </data>
+  <data name="ColumnLevel" xml:space="preserve">
+    <value>Livello</value>
+  </data>
+  <data name="ColumnMessage" xml:space="preserve">
+    <value>Messaggio</value>
+  </data>
   <data name="CronInputInvalid" xml:space="preserve">
     <value>Espressione cron Quartz non valida.</value>
   </data>

--- a/src/Feirb.Web/Resources/SharedResources.it-IT.resx
+++ b/src/Feirb.Web/Resources/SharedResources.it-IT.resx
@@ -1390,7 +1390,7 @@
     <value>Voci di registro per questa esecuzione del processo</value>
   </data>
   <data name="ExecutionDetailHelp" xml:space="preserve">
-    <value>Visualizza le voci di registro dettagliate prodotte durante questa esecuzione. Ogni voce mostra il timestamp, il livello di gravita e il messaggio.</value>
+    <value>Visualizza le voci di registro dettagliate prodotte durante questa esecuzione. Ogni voce mostra il timestamp, il livello di gravità e il messaggio.</value>
   </data>
   <data name="ExecutionDetailSectionHeader" xml:space="preserve">
     <value>Riepilogo esecuzione</value>

--- a/src/Feirb.Web/Resources/SharedResources.resx
+++ b/src/Feirb.Web/Resources/SharedResources.resx
@@ -1383,6 +1383,48 @@
   <data name="JobDetailRunning" xml:space="preserve">
     <value>Running...</value>
   </data>
+  <data name="ExecutionDetailPageTitle" xml:space="preserve">
+    <value>Execution Detail</value>
+  </data>
+  <data name="ExecutionDetailSubtitle" xml:space="preserve">
+    <value>Log entries for this job execution</value>
+  </data>
+  <data name="ExecutionDetailHelp" xml:space="preserve">
+    <value>View the detailed log entries produced during this job execution. Each entry shows the timestamp, severity level, and message.</value>
+  </data>
+  <data name="ExecutionDetailSectionHeader" xml:space="preserve">
+    <value>Execution Summary</value>
+  </data>
+  <data name="ExecutionDetailSectionHeaderSubtitle" xml:space="preserve">
+    <value>Overview of this execution run</value>
+  </data>
+  <data name="ExecutionDetailSectionLogs" xml:space="preserve">
+    <value>Log Entries</value>
+  </data>
+  <data name="ExecutionDetailSectionLogsSubtitle" xml:space="preserve">
+    <value>Messages produced during execution</value>
+  </data>
+  <data name="ExecutionDetailNotFound" xml:space="preserve">
+    <value>Execution not found.</value>
+  </data>
+  <data name="ExecutionDetailLoadFailed" xml:space="preserve">
+    <value>Failed to load execution details.</value>
+  </data>
+  <data name="ExecutionDetailLogsLoadFailed" xml:space="preserve">
+    <value>Failed to load execution logs.</value>
+  </data>
+  <data name="ExecutionDetailNoLogs" xml:space="preserve">
+    <value>No log entries for this execution.</value>
+  </data>
+  <data name="ExecutionDetailDuration" xml:space="preserve">
+    <value>Duration</value>
+  </data>
+  <data name="ColumnLevel" xml:space="preserve">
+    <value>Level</value>
+  </data>
+  <data name="ColumnMessage" xml:space="preserve">
+    <value>Message</value>
+  </data>
   <data name="CronInputInvalid" xml:space="preserve">
     <value>Invalid Quartz cron expression.</value>
   </data>

--- a/tests/Feirb.Api.Tests/Services/JobServiceTests.cs
+++ b/tests/Feirb.Api.Tests/Services/JobServiceTests.cs
@@ -282,7 +282,7 @@ public class JobServiceTests : IDisposable
     private sealed class TestClassificationJob(IServiceScopeFactory scopeFactory, ILogger logger)
         : ManagedJob(scopeFactory, logger)
     {
-        protected override Task RunAsync(IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken) =>
-            Task.CompletedTask;
+        protected override Task<JobRunResult> RunAsync(IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken) =>
+            Task.FromResult(JobRunResult.Succeeded);
     }
 }

--- a/tests/Feirb.Api.Tests/Services/JobSettingsSchedulerTests.cs
+++ b/tests/Feirb.Api.Tests/Services/JobSettingsSchedulerTests.cs
@@ -228,7 +228,7 @@ public class JobSettingsSchedulerTests : IDisposable
     private sealed class TestClassificationJob(IServiceScopeFactory scopeFactory, ILogger logger)
         : ManagedJob(scopeFactory, logger)
     {
-        protected override Task RunAsync(IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken) =>
-            Task.CompletedTask;
+        protected override Task<JobRunResult> RunAsync(IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken) =>
+            Task.FromResult(JobRunResult.Succeeded);
     }
 }

--- a/tests/Feirb.Api.Tests/Services/ManagedJobTests.cs
+++ b/tests/Feirb.Api.Tests/Services/ManagedJobTests.cs
@@ -158,6 +158,37 @@ public class ManagedJobTests : IDisposable
     }
 
     [Fact]
+    public async Task Execute_RunReturnsFailure_RecordsFailedStatusAsync()
+    {
+        var jobSettingsId = SeedJobSettings();
+        var job = CreateResultTestJob(JobRunResult.Failure("All items failed"));
+
+        await job.Execute(CreateJobContext());
+
+        using var db = new FeirbDbContext(_dbOptions);
+        var execution = await db.JobExecutions.AsNoTracking().FirstAsync(e => e.JobSettingsId == jobSettingsId);
+        execution.Status.Should().Be(JobExecutionStatus.Failed);
+        execution.Error.Should().Be("All items failed");
+
+        var updated = await db.JobSettings.AsNoTracking().FirstAsync(j => j.Id == jobSettingsId);
+        updated.LastStatus.Should().Be(JobExecutionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task Execute_RunReturnsSuccess_RecordsSuccessStatusAsync()
+    {
+        var jobSettingsId = SeedJobSettings();
+        var job = CreateResultTestJob(JobRunResult.Succeeded);
+
+        await job.Execute(CreateJobContext());
+
+        using var db = new FeirbDbContext(_dbOptions);
+        var execution = await db.JobExecutions.AsNoTracking().FirstAsync(e => e.JobSettingsId == jobSettingsId);
+        execution.Status.Should().Be(JobExecutionStatus.Success);
+        execution.Error.Should().BeNull();
+    }
+
+    [Fact]
     public async Task LogAsync_WritesLogEntryForCurrentExecutionAsync()
     {
         var jobSettingsId = SeedJobSettings();
@@ -222,6 +253,13 @@ public class ManagedJobTests : IDisposable
         return new TestManagedJob(scopeFactory, logger, succeeds, errorMessage);
     }
 
+    private ResultTestManagedJob CreateResultTestJob(JobRunResult result)
+    {
+        var scopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
+        var logger = NullLoggerFactory.Instance.CreateLogger<ResultTestManagedJob>();
+        return new ResultTestManagedJob(scopeFactory, logger, result);
+    }
+
     private LoggingTestManagedJob CreateLoggingTestJob()
     {
         var scopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
@@ -244,22 +282,32 @@ public class ManagedJobTests : IDisposable
         bool succeeds,
         string? errorMessage) : ManagedJob(scopeFactory, logger)
     {
-        protected override Task RunAsync(IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken)
+        protected override Task<JobRunResult> RunAsync(IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken)
         {
             if (!succeeds)
                 throw new InvalidOperationException(errorMessage ?? "Test failure");
-            return Task.CompletedTask;
+            return Task.FromResult(JobRunResult.Succeeded);
         }
+    }
+
+    private sealed class ResultTestManagedJob(
+        IServiceScopeFactory scopeFactory,
+        ILogger logger,
+        JobRunResult result) : ManagedJob(scopeFactory, logger)
+    {
+        protected override Task<JobRunResult> RunAsync(IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken) =>
+            Task.FromResult(result);
     }
 
     private sealed class LoggingTestManagedJob(
         IServiceScopeFactory scopeFactory,
         ILogger logger) : ManagedJob(scopeFactory, logger)
     {
-        protected override async Task RunAsync(IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken)
+        protected override async Task<JobRunResult> RunAsync(IServiceProvider serviceProvider, JobSettings jobSettings, CancellationToken cancellationToken)
         {
             await LogAsync(JobExecutionLogLevel.Info, "Test info log", cancellationToken: cancellationToken);
             await LogAsync(JobExecutionLogLevel.Warning, "Test warning log", metadata: "{\"key\":\"value\"}", cancellationToken: cancellationToken);
+            return JobRunResult.Succeeded;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `GET /api/jobs/{id}/executions/{executionId}/logs` paginated API endpoint with `JobExecutionLogResponse` and `PaginatedJobExecutionLogsResponse` DTOs
- Add admin execution detail page at `/admin/jobs/{id}/executions/{executionId}` showing execution summary (timestamp, duration, status) and paginated log table (timestamp, level, message)
- Make execution history rows in JobDetail clickable, linking to the execution detail page
- Add `JobRunResult` return type for `ManagedJob.RunAsync` so jobs communicate their outcome via return value instead of exceptions; ClassificationJob now returns `Failed` when all batch items fail
- Add i18n strings for all 4 locales (en, de, fr, it)

Closes #243

## Test plan
- [x] Solution builds without errors (298 tests pass)
- [x] Formatting check passes
- [x] Browser tested: execution rows clickable, detail page renders correctly with 12 log entries
- [x] Browser tested: error case (Ollama stopped) shows Error-level log and execution marked as Failed
- [ ] Verify breadcrumb navigation on execution detail page
- [ ] Verify pagination with large log sets

Generated with [Claude Code](https://claude.com/claude-code)