### PR TITLE
feat(api,web): inbox classification status (#244)

### DIFF
--- a/docs/component-library.md
+++ b/docs/component-library.md
@@ -491,6 +491,25 @@ Centered empty/error state display with icon, title, message, and optional actio
 
 Use for empty lists, 404 pages, and loading failures. For inline errors inside forms, use Bootstrap alert classes or `ValidationMessage`.
 
+## StatusBanner
+
+Page-level banner with icon and message. Maps variants to Bootstrap `alert-*` classes. Use at the top of a page to surface conditions that affect how the page data should be interpreted (e.g. paused background jobs, pending work).
+
+```razor
+<StatusBanner Variant="StatusBannerVariant.Warning" Icon="pause-circle">
+    @L["InboxBannerJobStoppedWithCount", pendingCount]
+</StatusBanner>
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `Variant` | `StatusBannerVariant` | `Info` | Visual variant: `Info`, `Warning`, `Danger`, `Success` |
+| `Icon` | `string` (required) | — | Bootstrap Icon name without `bi-` prefix |
+| `ChildContent` | `RenderFragment` (required) | — | Banner message content |
+| `Class` | `string?` | `null` | Extra CSS classes |
+
+Banner is not dismissible — auto-clears when the underlying condition changes. For transient user feedback (save/delete), use `NotificationService` instead.
+
 ## RecipientInput
 
 Tokenizing input for email recipients with PersonChip tokens, paste-splitting, and autocomplete. Used in Compose.

--- a/src/Feirb.Api/Endpoints/MessageEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/MessageEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Feirb.Api.Data;
+using Feirb.Api.Data.Entities;
 using Feirb.Api.Resources;
 using Feirb.Shared.AddressBook;
 using Feirb.Shared.Mail;
@@ -60,6 +61,24 @@ public static class MessageEndpoints
                 .Select(a => new { a.NormalizedEmail, a.Status })
                 .ToDictionaryAsync(x => x.NormalizedEmail, x => x.Status, StringComparer.Ordinal);
 
+        var pageMessageIds = items.Select(m => m.Id).ToList();
+
+        var queueStatusByMessageId = pageMessageIds.Count == 0
+            ? new Dictionary<Guid, ClassificationQueueItemStatus>()
+            : await db.ClassificationQueueItems
+                .AsNoTracking()
+                .Where(q => pageMessageIds.Contains(q.CachedMessageId))
+                .Select(q => new { q.CachedMessageId, q.Status })
+                .ToDictionaryAsync(x => x.CachedMessageId, x => x.Status);
+
+        var classifiedMessageIds = pageMessageIds.Count == 0
+            ? new HashSet<Guid>()
+            : (await db.ClassificationResults
+                .AsNoTracking()
+                .Where(r => pageMessageIds.Contains(r.CachedMessageId))
+                .Select(r => r.CachedMessageId)
+                .ToListAsync()).ToHashSet();
+
         var mapped = parsedSenders.Select(p =>
         {
             var m = p.Item;
@@ -69,10 +88,45 @@ public static class MessageEndpoints
                 ? s
                 : null;
             var labels = m.Labels.Select(l => new MessageLabelResponse(l.Name, l.Color)).ToList();
-            return new MessageListItemResponse(m.Id, m.MailboxName, m.BadgeColor, name, email, senderStatus, m.Subject, summaryPlaceholder, m.Date, IsRead: false, m.HasAttachments, labels);
+            var classificationStatus = ResolveClassificationStatus(m.Id, queueStatusByMessageId, classifiedMessageIds);
+            return new MessageListItemResponse(m.Id, m.MailboxName, m.BadgeColor, name, email, senderStatus, m.Subject, summaryPlaceholder, m.Date, IsRead: false, m.HasAttachments, labels, classificationStatus);
         }).ToList();
 
-        return Results.Ok(new PaginatedResponse<MessageListItemResponse>(mapped, page, pageSize, totalCount));
+        var pendingCount = await db.ClassificationQueueItems
+            .AsNoTracking()
+            .Where(q => q.CachedMessage.Mailbox.UserId == userId
+                && (q.Status == ClassificationQueueItemStatus.Pending || q.Status == ClassificationQueueItemStatus.Processing))
+            .CountAsync();
+
+        var jobPaused = !await db.JobSettings
+            .AsNoTracking()
+            .Where(j => j.JobName == "Classification")
+            .Select(j => j.Enabled)
+            .FirstOrDefaultAsync();
+
+        return Results.Ok(new MessageListResponse(mapped, page, pageSize, totalCount, pendingCount, jobPaused));
+    }
+
+    private static ClassificationStatus ResolveClassificationStatus(
+        Guid messageId,
+        Dictionary<Guid, ClassificationQueueItemStatus> queueStatusByMessageId,
+        HashSet<Guid> classifiedMessageIds)
+    {
+        if (queueStatusByMessageId.TryGetValue(messageId, out var queueStatus))
+        {
+            return queueStatus switch
+            {
+                ClassificationQueueItemStatus.Pending => ClassificationStatus.Pending,
+                ClassificationQueueItemStatus.Processing => ClassificationStatus.Processing,
+                ClassificationQueueItemStatus.Failed => ClassificationStatus.Failed,
+                ClassificationQueueItemStatus.Classified => ClassificationStatus.Classified,
+                _ => ClassificationStatus.NotClassified,
+            };
+        }
+
+        return classifiedMessageIds.Contains(messageId)
+            ? ClassificationStatus.Classified
+            : ClassificationStatus.NotClassified;
     }
 
     private static (string Name, string Email) ParseFromAddress(string from)

--- a/src/Feirb.Api/Services/JobSettingsScheduler.cs
+++ b/src/Feirb.Api/Services/JobSettingsScheduler.cs
@@ -31,6 +31,7 @@ public class JobSettingsScheduler(
             var db = scope.ServiceProvider.GetRequiredService<FeirbDbContext>();
 
             await RecoverOrphanedExecutionsAsync(db, stoppingToken);
+            await RecoverStuckClassificationItemsAsync(db, stoppingToken);
 
             var jobs = await db.JobSettings
                 .Where(j => j.Enabled)
@@ -162,6 +163,26 @@ public class JobSettingsScheduler(
 
         logger.LogWarning(
             "Recovered {Count} orphaned job execution(s) interrupted by app restart", orphaned.Count);
+    }
+
+    private async Task RecoverStuckClassificationItemsAsync(FeirbDbContext db, CancellationToken cancellationToken)
+    {
+        var stuckItems = await db.ClassificationQueueItems
+            .Where(q => q.Status == ClassificationQueueItemStatus.Processing)
+            .ToListAsync(cancellationToken);
+
+        if (stuckItems.Count == 0)
+            return;
+
+        foreach (var item in stuckItems)
+        {
+            item.Status = ClassificationQueueItemStatus.Pending;
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        logger.LogWarning(
+            "Reset {Count} classification queue item(s) from Processing to Pending on startup", stuckItems.Count);
     }
 
     private static JobKey GetJobKey(string jobName) => new($"managed-{jobName}", _groupName);

--- a/src/Feirb.Api/Services/JobSettingsScheduler.cs
+++ b/src/Feirb.Api/Services/JobSettingsScheduler.cs
@@ -1,4 +1,5 @@
 using Feirb.Api.Data;
+using Feirb.Api.Data.Entities;
 using Microsoft.EntityFrameworkCore;
 using Quartz;
 
@@ -28,6 +29,8 @@ public class JobSettingsScheduler(
 
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<FeirbDbContext>();
+
+            await RecoverOrphanedExecutionsAsync(db, stoppingToken);
 
             var jobs = await db.JobSettings
                 .Where(j => j.Enabled)
@@ -124,6 +127,41 @@ public class JobSettingsScheduler(
         await scheduler.ScheduleJob(job, trigger, cancellationToken);
         logger.LogDebug("Scheduled managed job '{JobName}' (type '{JobType}') with cron '{Cron}'",
             jobName, jobType, cronExpression);
+    }
+
+    private async Task RecoverOrphanedExecutionsAsync(FeirbDbContext db, CancellationToken cancellationToken)
+    {
+        var orphaned = await db.JobExecutions
+            .Where(e => e.FinishedAt == null)
+            .ToListAsync(cancellationToken);
+
+        if (orphaned.Count == 0)
+            return;
+
+        var now = DateTimeOffset.UtcNow;
+        var affectedJobIds = orphaned.Select(e => e.JobSettingsId).Distinct().ToList();
+
+        foreach (var execution in orphaned)
+        {
+            execution.Status = JobExecutionStatus.Failed;
+            execution.Error = "Execution interrupted (app restart)";
+            execution.FinishedAt = now;
+        }
+
+        var affectedJobs = await db.JobSettings
+            .Where(j => affectedJobIds.Contains(j.Id))
+            .ToListAsync(cancellationToken);
+
+        foreach (var job in affectedJobs)
+        {
+            job.LastRunAt = now;
+            job.LastStatus = JobExecutionStatus.Failed;
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        logger.LogWarning(
+            "Recovered {Count} orphaned job execution(s) interrupted by app restart", orphaned.Count);
     }
 
     private static JobKey GetJobKey(string jobName) => new($"managed-{jobName}", _groupName);

--- a/src/Feirb.Shared/Mail/ClassificationStatus.cs
+++ b/src/Feirb.Shared/Mail/ClassificationStatus.cs
@@ -1,0 +1,10 @@
+namespace Feirb.Shared.Mail;
+
+public enum ClassificationStatus
+{
+    NotClassified,
+    Pending,
+    Processing,
+    Classified,
+    Failed,
+}

--- a/src/Feirb.Shared/Mail/MessageListItemResponse.cs
+++ b/src/Feirb.Shared/Mail/MessageListItemResponse.cs
@@ -14,4 +14,5 @@ public record MessageListItemResponse(
     DateTimeOffset Date,
     bool IsRead,
     bool HasAttachments,
-    List<MessageLabelResponse> Labels);
+    List<MessageLabelResponse> Labels,
+    ClassificationStatus ClassificationStatus);

--- a/src/Feirb.Shared/Mail/MessageListResponse.cs
+++ b/src/Feirb.Shared/Mail/MessageListResponse.cs
@@ -1,0 +1,9 @@
+namespace Feirb.Shared.Mail;
+
+public record MessageListResponse(
+    List<MessageListItemResponse> Items,
+    int Page,
+    int PageSize,
+    int TotalCount,
+    int PendingCount,
+    bool JobPaused);

--- a/src/Feirb.Web/Components/MailCard.razor
+++ b/src/Feirb.Web/Components/MailCard.razor
@@ -12,6 +12,7 @@
 
         <MailSubjectChip Subject="@Subject"
                          Summary="@(Mode is MailCardMode.Medium or MailCardMode.Small ? Summary : null)"
+                         SummaryClass="@SummaryClass"
                          IsRead="IsRead"
                          HasAttachments="false" />
 
@@ -50,6 +51,10 @@
     /// <summary>Mail summary text (shown in Medium mode).</summary>
     [Parameter]
     public string? Summary { get; set; }
+
+    /// <summary>Additional CSS class applied to the summary text.</summary>
+    [Parameter]
+    public string? SummaryClass { get; set; }
 
     /// <summary>Mail labels to display.</summary>
     [Parameter]

--- a/src/Feirb.Web/Components/UI/MailSubjectChip.razor
+++ b/src/Feirb.Web/Components/UI/MailSubjectChip.razor
@@ -13,7 +13,7 @@
         </div>
         @if (!string.IsNullOrEmpty(Summary))
         {
-            <span class="feirb-mail-subject-chip-summary">@Summary</span>
+            <span class="feirb-mail-subject-chip-summary @SummaryClass">@Summary</span>
         }
     </div>
 </div>
@@ -26,6 +26,10 @@
     /// <summary>AI-generated summary text.</summary>
     [Parameter]
     public string? Summary { get; set; }
+
+    /// <summary>Additional CSS class applied to the summary span (e.g. <c>text-danger</c>).</summary>
+    [Parameter]
+    public string? SummaryClass { get; set; }
 
     /// <summary>Whether the mail has been read.</summary>
     [Parameter]

--- a/src/Feirb.Web/Components/UI/StatusBanner.razor
+++ b/src/Feirb.Web/Components/UI/StatusBanner.razor
@@ -1,0 +1,37 @@
+@namespace Feirb.Web.Components.UI
+
+@* Page-level status banner with icon and message. Maps variants to Bootstrap alert classes. *@
+<div class="alert @VariantCss feirb-status-banner @Class" role="alert" @attributes="AdditionalAttributes">
+    <Icon Name="@Icon" Class="feirb-status-banner-icon" />
+    <span class="feirb-status-banner-content">@ChildContent</span>
+</div>
+
+@code {
+    /// <summary>Visual variant. Maps to Bootstrap <c>alert-*</c> classes.</summary>
+    [Parameter]
+    public StatusBannerVariant Variant { get; set; } = StatusBannerVariant.Info;
+
+    /// <summary>Bootstrap Icon name without the <c>bi-</c> prefix.</summary>
+    [Parameter, EditorRequired]
+    public string Icon { get; set; } = "";
+
+    /// <summary>Banner message content.</summary>
+    [Parameter, EditorRequired]
+    public RenderFragment ChildContent { get; set; } = default!;
+
+    /// <summary>Additional CSS classes.</summary>
+    [Parameter]
+    public string? Class { get; set; }
+
+    /// <summary>Additional HTML attributes (e.g. <c>data-testid</c>).</summary>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string VariantCss => Variant switch
+    {
+        StatusBannerVariant.Warning => "alert-warning",
+        StatusBannerVariant.Danger => "alert-danger",
+        StatusBannerVariant.Success => "alert-success",
+        _ => "alert-info",
+    };
+}

--- a/src/Feirb.Web/Components/UI/StatusBanner.razor.css
+++ b/src/Feirb.Web/Components/UI/StatusBanner.razor.css
@@ -1,0 +1,16 @@
+.feirb-status-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    padding: 0.625rem 0.875rem;
+}
+
+.feirb-status-banner-content {
+    flex: 1;
+    line-height: 1.4;
+}
+
+::deep .feirb-status-banner-icon {
+    flex-shrink: 0;
+}

--- a/src/Feirb.Web/Components/UI/UIEnums.cs
+++ b/src/Feirb.Web/Components/UI/UIEnums.cs
@@ -70,3 +70,12 @@ public enum MailCardMode
     Small,
     Row
 }
+
+/// <summary>Visual variant for <see cref="StatusBanner"/>. Maps to Bootstrap <c>alert-*</c> classes.</summary>
+public enum StatusBannerVariant
+{
+    Info,
+    Warning,
+    Danger,
+    Success
+}

--- a/src/Feirb.Web/Layout/ShowcaseLayout.razor
+++ b/src/Feirb.Web/Layout/ShowcaseLayout.razor
@@ -122,7 +122,8 @@
         new(
         [
             new("bell", "Toast", Href: "components-showcase/toast"),
-            new("exclamation-circle", "StatusMessage", Href: "components-showcase/status-message")
+            new("exclamation-circle", "StatusMessage", Href: "components-showcase/status-message"),
+            new("info-circle", "StatusBanner", Href: "components-showcase/status-banner")
         ], Label: "Feedback")
     ];
 }

--- a/src/Feirb.Web/Pages/ComponentsShowcase.razor
+++ b/src/Feirb.Web/Pages/ComponentsShowcase.razor
@@ -83,6 +83,9 @@
     case "status-message":
         <ShowcaseStatusMessage />
         break;
+    case "status-banner":
+        <ShowcaseStatusBanner />
+        break;
     case "recipient-input":
         <ShowcaseRecipientInput />
         break;

--- a/src/Feirb.Web/Pages/Inbox.razor
+++ b/src/Feirb.Web/Pages/Inbox.razor
@@ -16,6 +16,26 @@
     <HelpContent>@L["PageHelpInbox"]</HelpContent>
 </InfoHeader>
 
+@if (_messages is not null && _messages.JobPaused)
+{
+    <StatusBanner Variant="StatusBannerVariant.Warning" Icon="pause-circle" data-testid="inbox-banner-paused">
+        @if (_messages.PendingCount > 0)
+        {
+            @string.Format(L["InboxBannerJobStoppedWithCount"], _messages.PendingCount)
+        }
+        else
+        {
+            @L["InboxBannerJobStopped"]
+        }
+    </StatusBanner>
+}
+else if (_messages is not null && _messages.PendingCount > 0)
+{
+    <StatusBanner Variant="StatusBannerVariant.Info" Icon="hourglass-split" data-testid="inbox-banner-pending">
+        @string.Format(L["InboxBannerUnclassifiedCount"], _messages.PendingCount)
+    </StatusBanner>
+}
+
 @if (_isLoading)
 {
     <div class="text-center py-5">
@@ -43,7 +63,8 @@ else if (UseCardLayout)
                       SenderEmail="@msg.FromEmail"
                       SenderStatus="@msg.SenderStatus"
                       Subject="@msg.Subject"
-                      Summary="@msg.Summary"
+                      Summary="@ResolveSummary(msg)"
+                      SummaryClass="@ResolveSummaryClass(msg)"
                       Labels="@msg.Labels.Select(l => new MailCardLabel(l.Name, l.Color)).ToList()"
                       ReceivedAt="msg.Date.LocalDateTime"
                       IsRead="msg.IsRead"
@@ -86,7 +107,8 @@ else
                         </TableCell>
                         <TableCell Class="inbox-subject-cell">
                             <MailSubjectChip Subject="@msg.Subject"
-                                             Summary="@msg.Summary"
+                                             Summary="@ResolveSummary(msg)"
+                                             SummaryClass="@ResolveSummaryClass(msg)"
                                              IsRead="msg.IsRead"
                                              HasAttachments="msg.HasAttachments" />
                         </TableCell>
@@ -130,7 +152,7 @@ else
 @code {
     private const int CardLayoutBreakpoint = 1100;
 
-    private PaginatedResponse<MessageListItemResponse>? _messages;
+    private MessageListResponse? _messages;
     private bool _isLoading = true;
     private string? _errorMessage;
     private int _currentPage = 1;
@@ -163,7 +185,7 @@ else
         _errorMessage = null;
         try
         {
-            _messages = await Http.GetFromJsonAsync<PaginatedResponse<MessageListItemResponse>>(
+            _messages = await Http.GetFromJsonAsync<MessageListResponse>(
                 $"/api/mail/messages?page={_currentPage}&pageSize={_pageSize}");
         }
         catch
@@ -197,6 +219,17 @@ else
 
     private void NavigateToMessage(Guid id) =>
         Navigation.NavigateTo($"/mail/inbox/{id}");
+
+    private string? ResolveSummary(MessageListItemResponse msg) => msg.ClassificationStatus switch
+    {
+        ClassificationStatus.Pending or ClassificationStatus.Processing => L["ClassificationOngoing"],
+        ClassificationStatus.Failed => L["ClassificationFailed"],
+        ClassificationStatus.NotClassified => L["ClassificationNotClassified"],
+        _ => msg.Summary,
+    };
+
+    private static string? ResolveSummaryClass(MessageListItemResponse msg) =>
+        msg.ClassificationStatus == ClassificationStatus.Failed ? "text-danger" : null;
 
     public void Dispose() => Viewport.OnResize -= OnViewportResize;
 }

--- a/src/Feirb.Web/Pages/Showcase/ShowcaseStatusBanner.razor
+++ b/src/Feirb.Web/Pages/Showcase/ShowcaseStatusBanner.razor
@@ -1,0 +1,82 @@
+@using Feirb.Web.Components.UI
+@inject IJSRuntime JS
+
+<InfoHeader Title="StatusBanner" Icon="info-circle" Subtitle="Page-level status banner with icon and message" />
+
+<Card Class="mb-3 p-4">
+    <Heading Level="HeadingLevel.Small">Info</Heading>
+    <p>Page-level banner that reports state context to the user. Maps variants to Bootstrap <code>alert-*</code> classes. Use at the top of a page, between the <code>InfoHeader</code> and the page content, to surface conditions that affect how the page data should be interpreted (e.g. paused background jobs, pending work).</p>
+    <Table Size="TableSize.Small">
+        <TableHeader>
+            <TableColumn>Parameter</TableColumn>
+            <TableColumn>Type</TableColumn>
+            <TableColumn>Default</TableColumn>
+            <TableColumn>Description</TableColumn>
+        </TableHeader>
+        <TableBody>
+            <TableRow><TableCell><code>Variant</code></TableCell><TableCell><code>StatusBannerVariant</code></TableCell><TableCell><code>Info</code></TableCell><TableCell>Visual variant: Info, Warning, Danger, Success</TableCell></TableRow>
+            <TableRow><TableCell><code>Icon</code></TableCell><TableCell><code>string</code></TableCell><TableCell>required</TableCell><TableCell>Bootstrap Icon name without <code>bi-</code> prefix</TableCell></TableRow>
+            <TableRow><TableCell><code>ChildContent</code></TableCell><TableCell><code>RenderFragment</code></TableCell><TableCell>required</TableCell><TableCell>Banner message content</TableCell></TableRow>
+            <TableRow><TableCell><code>Class</code></TableCell><TableCell><code>string?</code></TableCell><TableCell><code>null</code></TableCell><TableCell>Extra CSS classes</TableCell></TableRow>
+        </TableBody>
+    </Table>
+</Card>
+
+<Card Class="mb-3 p-4">
+    <Heading Level="HeadingLevel.Small">Preview</Heading>
+    <div class="row g-2 mb-3">
+        <div class="col-md-4">
+            <label class="form-label">Variant</label>
+            <select class="form-select form-select-sm" @bind="_variant">
+                <option value="@StatusBannerVariant.Info">Info</option>
+                <option value="@StatusBannerVariant.Warning">Warning</option>
+                <option value="@StatusBannerVariant.Danger">Danger</option>
+                <option value="@StatusBannerVariant.Success">Success</option>
+            </select>
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">Icon</label>
+            <input type="text" class="form-control form-control-sm" @bind="_icon" />
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">Message</label>
+            <input type="text" class="form-control form-control-sm" @bind="_message" />
+        </div>
+    </div>
+    <div class="showcase-preview-area">
+        <StatusBanner Variant="_variant" Icon="@_icon">@_message</StatusBanner>
+    </div>
+</Card>
+
+<Card Class="mb-3 p-4">
+    <Heading Level="HeadingLevel.Small">Variants</Heading>
+    <StatusBanner Variant="StatusBannerVariant.Info" Icon="hourglass-split">Unclassified mails: 12</StatusBanner>
+    <StatusBanner Variant="StatusBannerVariant.Warning" Icon="pause-circle">Classification job is stopped — 12 mails unclassified</StatusBanner>
+    <StatusBanner Variant="StatusBannerVariant.Danger" Icon="exclamation-triangle">Sync failed for 2 mailboxes.</StatusBanner>
+    <StatusBanner Variant="StatusBannerVariant.Success" Icon="check-circle">All mailboxes are in sync.</StatusBanner>
+</Card>
+
+<Card Class="p-4">
+    <Heading Level="HeadingLevel.Small">Code</Heading>
+    <pre><code class="language-xml" @ref="_codeElement"></code></pre>
+</Card>
+
+@code {
+    private StatusBannerVariant _variant = StatusBannerVariant.Info;
+    private string _icon = "hourglass-split";
+    private string _message = "Unclassified mails: 12";
+    private ElementReference _codeElement;
+    private string? _lastHighlightedCode;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        var code = CurrentCode;
+        if (code == _lastHighlightedCode) return;
+        _lastHighlightedCode = code;
+        try { await JS.InvokeVoidAsync("highlightCode", _codeElement, code); }
+        catch (JSException) { }
+    }
+
+    private string CurrentCode =>
+        $"""<StatusBanner Variant="StatusBannerVariant.{_variant}" Icon="{_icon}">{_message}</StatusBanner>""";
+}

--- a/src/Feirb.Web/Resources/SharedResources.de-DE.resx
+++ b/src/Feirb.Web/Resources/SharedResources.de-DE.resx
@@ -1839,4 +1839,22 @@
   <data name="RelativeTimeDaysAgo" xml:space="preserve">
     <value>vor {0} T.</value>
   </data>
+  <data name="InboxBannerUnclassifiedCount" xml:space="preserve">
+    <value>Nicht klassifizierte Mails: {0}</value>
+  </data>
+  <data name="InboxBannerJobStopped" xml:space="preserve">
+    <value>Klassifizierungs-Job ist gestoppt</value>
+  </data>
+  <data name="InboxBannerJobStoppedWithCount" xml:space="preserve">
+    <value>Klassifizierungs-Job ist gestoppt — {0} nicht klassifizierte Mails</value>
+  </data>
+  <data name="ClassificationOngoing" xml:space="preserve">
+    <value>Klassifizierung läuft…</value>
+  </data>
+  <data name="ClassificationFailed" xml:space="preserve">
+    <value>Klassifizierung fehlgeschlagen</value>
+  </data>
+  <data name="ClassificationNotClassified" xml:space="preserve">
+    <value>Nicht klassifiziert</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
+++ b/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
@@ -1839,4 +1839,22 @@
   <data name="RelativeTimeDaysAgo" xml:space="preserve">
     <value>il y a {0} j</value>
   </data>
+  <data name="InboxBannerUnclassifiedCount" xml:space="preserve">
+    <value>Mails non classés : {0}</value>
+  </data>
+  <data name="InboxBannerJobStopped" xml:space="preserve">
+    <value>Le travail de classification est arrêté</value>
+  </data>
+  <data name="InboxBannerJobStoppedWithCount" xml:space="preserve">
+    <value>Le travail de classification est arrêté — {0} mails non classés</value>
+  </data>
+  <data name="ClassificationOngoing" xml:space="preserve">
+    <value>Classification en cours…</value>
+  </data>
+  <data name="ClassificationFailed" xml:space="preserve">
+    <value>Échec de la classification</value>
+  </data>
+  <data name="ClassificationNotClassified" xml:space="preserve">
+    <value>Non classé</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.it-IT.resx
+++ b/src/Feirb.Web/Resources/SharedResources.it-IT.resx
@@ -1839,4 +1839,22 @@
   <data name="RelativeTimeDaysAgo" xml:space="preserve">
     <value>{0} g fa</value>
   </data>
+  <data name="InboxBannerUnclassifiedCount" xml:space="preserve">
+    <value>Mail non classificate: {0}</value>
+  </data>
+  <data name="InboxBannerJobStopped" xml:space="preserve">
+    <value>Il lavoro di classificazione è fermo</value>
+  </data>
+  <data name="InboxBannerJobStoppedWithCount" xml:space="preserve">
+    <value>Il lavoro di classificazione è fermo — {0} mail non classificate</value>
+  </data>
+  <data name="ClassificationOngoing" xml:space="preserve">
+    <value>Classificazione in corso…</value>
+  </data>
+  <data name="ClassificationFailed" xml:space="preserve">
+    <value>Classificazione non riuscita</value>
+  </data>
+  <data name="ClassificationNotClassified" xml:space="preserve">
+    <value>Non classificata</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.resx
+++ b/src/Feirb.Web/Resources/SharedResources.resx
@@ -1839,4 +1839,22 @@
   <data name="RelativeTimeDaysAgo" xml:space="preserve">
     <value>{0}d ago</value>
   </data>
+  <data name="InboxBannerUnclassifiedCount" xml:space="preserve">
+    <value>Unclassified mails: {0}</value>
+  </data>
+  <data name="InboxBannerJobStopped" xml:space="preserve">
+    <value>Classification job is stopped</value>
+  </data>
+  <data name="InboxBannerJobStoppedWithCount" xml:space="preserve">
+    <value>Classification job is stopped — {0} mails unclassified</value>
+  </data>
+  <data name="ClassificationOngoing" xml:space="preserve">
+    <value>Classification ongoing…</value>
+  </data>
+  <data name="ClassificationFailed" xml:space="preserve">
+    <value>Classification failed</value>
+  </data>
+  <data name="ClassificationNotClassified" xml:space="preserve">
+    <value>Not classified</value>
+  </data>
 </root>

--- a/tests/Feirb.Api.Tests/Endpoints/MessageEndpointsTests.cs
+++ b/tests/Feirb.Api.Tests/Endpoints/MessageEndpointsTests.cs
@@ -41,7 +41,7 @@ public class MessageEndpointsTests : IDisposable
         var response = await _client.GetAsync("/api/mail/messages");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<PaginatedResponse<MessageListItemResponse>>();
+        var result = await response.Content.ReadFromJsonAsync<MessageListResponse>();
         result.Should().NotBeNull();
         result!.Items.Should().BeEmpty();
         result.TotalCount.Should().Be(0);
@@ -64,7 +64,7 @@ public class MessageEndpointsTests : IDisposable
         var response = await _client.GetAsync("/api/mail/messages");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<PaginatedResponse<MessageListItemResponse>>();
+        var result = await response.Content.ReadFromJsonAsync<MessageListResponse>();
         result!.Items.Should().HaveCount(3);
         result.Items[0].Subject.Should().Be("New Message");
         result.Items[1].Subject.Should().Be("Mid Message");
@@ -87,7 +87,7 @@ public class MessageEndpointsTests : IDisposable
         var response = await _client.GetAsync("/api/mail/messages?page=2&pageSize=2");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<PaginatedResponse<MessageListItemResponse>>();
+        var result = await response.Content.ReadFromJsonAsync<MessageListResponse>();
         result!.Items.Should().HaveCount(2);
         result.Page.Should().Be(2);
         result.PageSize.Should().Be(2);
@@ -110,7 +110,7 @@ public class MessageEndpointsTests : IDisposable
         _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", userTokens!.AccessToken);
 
         var response = await _client.GetAsync("/api/mail/messages");
-        var result = await response.Content.ReadFromJsonAsync<PaginatedResponse<MessageListItemResponse>>();
+        var result = await response.Content.ReadFromJsonAsync<MessageListResponse>();
         result!.Items.Should().BeEmpty();
     }
 
@@ -197,7 +197,7 @@ public class MessageEndpointsTests : IDisposable
         var response = await _client.GetAsync("/api/mail/messages");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<PaginatedResponse<MessageListItemResponse>>();
+        var result = await response.Content.ReadFromJsonAsync<MessageListResponse>();
         result!.Items.Should().HaveCount(1);
         result.Items[0].Labels.Should().HaveCount(2);
         result.Items[0].Labels[0].Name.Should().Be("Newsletter");
@@ -217,9 +217,101 @@ public class MessageEndpointsTests : IDisposable
         var response = await _client.GetAsync("/api/mail/messages");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<PaginatedResponse<MessageListItemResponse>>();
+        var result = await response.Content.ReadFromJsonAsync<MessageListResponse>();
         result!.Items.Should().HaveCount(1);
         result.Items[0].Labels.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListMessages_NoQueueOrResult_ReturnsNotClassifiedAsync()
+    {
+        var tokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+        var mailboxId = await CreateMailboxAsync("Test", "test@test.com");
+        await SeedMessagesAsync(mailboxId, [("Message", "sender@test.com", DateTimeOffset.UtcNow)]);
+
+        var response = await _client.GetAsync("/api/mail/messages");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<MessageListResponse>();
+        result!.Items[0].ClassificationStatus.Should().Be(ClassificationStatus.NotClassified);
+        result.PendingCount.Should().Be(0);
+        result.JobPaused.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ListMessages_WithQueueAndResult_ReturnsCorrectStatusesAsync()
+    {
+        var tokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+        var mailboxId = await CreateMailboxAsync("Test", "test@test.com");
+        var messageIds = await SeedMessagesAsync(mailboxId, [
+            ("Pending", "sender@test.com", DateTimeOffset.UtcNow.AddMinutes(-5)),
+            ("Processing", "sender@test.com", DateTimeOffset.UtcNow.AddMinutes(-4)),
+            ("Failed", "sender@test.com", DateTimeOffset.UtcNow.AddMinutes(-3)),
+            ("Classified", "sender@test.com", DateTimeOffset.UtcNow.AddMinutes(-2)),
+            ("NotClassified", "sender@test.com", DateTimeOffset.UtcNow.AddMinutes(-1)),
+        ]);
+
+        await SeedQueueItemAsync(messageIds[0], ClassificationQueueItemStatus.Pending);
+        await SeedQueueItemAsync(messageIds[1], ClassificationQueueItemStatus.Processing);
+        await SeedQueueItemAsync(messageIds[2], ClassificationQueueItemStatus.Failed);
+        await SeedClassificationResultAsync(messageIds[3]);
+
+        var response = await _client.GetAsync("/api/mail/messages");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<MessageListResponse>();
+        var bySubject = result!.Items.ToDictionary(i => i.Subject, i => i.ClassificationStatus);
+        bySubject["Pending"].Should().Be(ClassificationStatus.Pending);
+        bySubject["Processing"].Should().Be(ClassificationStatus.Processing);
+        bySubject["Failed"].Should().Be(ClassificationStatus.Failed);
+        bySubject["Classified"].Should().Be(ClassificationStatus.Classified);
+        bySubject["NotClassified"].Should().Be(ClassificationStatus.NotClassified);
+        result.PendingCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ListMessages_PendingCount_ExcludesOtherUsersAsync()
+    {
+        var adminTokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminTokens.AccessToken);
+
+        var adminMailboxId = await CreateMailboxAsync("Admin", "admin@test.com");
+        var adminMessageIds = await SeedMessagesAsync(adminMailboxId, [("Admin", "admin@test.com", DateTimeOffset.UtcNow)]);
+        await SeedQueueItemAsync(adminMessageIds[0], ClassificationQueueItemStatus.Pending);
+
+        await _client.PostAsJsonAsync("/api/auth/register", new RegisterRequest("user2", "user2@test.com", "Password123!"));
+        var loginResponse = await _client.PostAsJsonAsync("/api/auth/login", new LoginRequest("user2", "Password123!"));
+        var userTokens = await loginResponse.Content.ReadFromJsonAsync<TokenResponse>();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", userTokens!.AccessToken);
+
+        var response = await _client.GetAsync("/api/mail/messages");
+        var result = await response.Content.ReadFromJsonAsync<MessageListResponse>();
+        result!.PendingCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ListMessages_JobEnabled_ReturnsJobPausedFalseAsync()
+    {
+        var tokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<FeirbDbContext>();
+            var job = await db.JobSettings.FirstAsync(j => j.JobName == "Classification");
+            job.Enabled = true;
+            await db.SaveChangesAsync();
+        }
+
+        var response = await _client.GetAsync("/api/mail/messages");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<MessageListResponse>();
+        result!.JobPaused.Should().BeFalse();
     }
 
     // --- Helper Methods ---
@@ -303,6 +395,38 @@ public class MessageEndpointsTests : IDisposable
             message.Labels.Add(label);
         }
 
+        await db.SaveChangesAsync();
+    }
+
+    private async Task SeedQueueItemAsync(Guid messageId, ClassificationQueueItemStatus status)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<FeirbDbContext>();
+
+        db.ClassificationQueueItems.Add(new CachedMessageClassificationQueueItem
+        {
+            Id = Guid.NewGuid(),
+            CachedMessageId = messageId,
+            Status = status,
+            Ordinal = 0,
+            AttemptNumber = 0,
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task SeedClassificationResultAsync(Guid messageId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<FeirbDbContext>();
+
+        db.ClassificationResults.Add(new ClassificationResult
+        {
+            Id = Guid.NewGuid(),
+            CachedMessageId = messageId,
+            Result = "{}",
+            ClassifiedAt = DateTimeOffset.UtcNow,
+        });
         await db.SaveChangesAsync();
     }
 

--- a/tests/Feirb.Api.Tests/Services/JobSettingsSchedulerTests.cs
+++ b/tests/Feirb.Api.Tests/Services/JobSettingsSchedulerTests.cs
@@ -1,6 +1,7 @@
 using Feirb.Api.Data;
 using Feirb.Api.Data.Entities;
 using Feirb.Api.Services;
+using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -187,6 +188,66 @@ public class JobSettingsSchedulerTests : IDisposable
             Arg.Any<IJobDetail>(), Arg.Any<ITrigger>(), Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task ExecuteAsync_MarksOrphanedExecutionsAsFailedOnStartupAsync()
+    {
+        var jobId = SeedJobSettings("job-a", "classification", enabled: true);
+        var orphanStarted = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var orphanId = SeedJobExecution(jobId, startedAt: orphanStarted, finishedAt: null, status: JobExecutionStatus.Success);
+
+        var schedulerRequested = new TaskCompletionSource();
+        _schedulerFactory.GetScheduler(Arg.Any<CancellationToken>())
+            .Returns(_quartzScheduler)
+            .AndDoes(_ => schedulerRequested.TrySetResult());
+
+        var sut = CreateScheduler(withClassificationJob: true);
+        await sut.StartAsync(CancellationToken.None);
+        await schedulerRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        JobExecution? recovered = null;
+        JobSettings? updatedJob = null;
+        for (var attempt = 0; attempt < 50; attempt++)
+        {
+            using var verifyDb = new FeirbDbContext(_dbOptions);
+            recovered = await verifyDb.JobExecutions.FindAsync(orphanId);
+            updatedJob = await verifyDb.JobSettings.FindAsync(jobId);
+            if (recovered?.FinishedAt is not null) break;
+            await Task.Delay(50);
+        }
+        await sut.StopAsync(CancellationToken.None);
+
+        recovered.Should().NotBeNull();
+        recovered!.Status.Should().Be(JobExecutionStatus.Failed);
+        recovered.FinishedAt.Should().NotBeNull();
+        recovered.Error.Should().Contain("interrupted");
+        updatedJob!.LastStatus.Should().Be(JobExecutionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_LeavesCompletedExecutionsAloneAsync()
+    {
+        var jobId = SeedJobSettings("job-a", "classification", enabled: true);
+        var completedId = SeedJobExecution(
+            jobId,
+            startedAt: DateTimeOffset.UtcNow.AddMinutes(-10),
+            finishedAt: DateTimeOffset.UtcNow.AddMinutes(-9),
+            status: JobExecutionStatus.Success);
+
+        var completed = new TaskCompletionSource();
+        _quartzScheduler.ScheduleJob(Arg.Any<IJobDetail>(), Arg.Any<ITrigger>(), Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(DateTimeOffset.UtcNow)
+            .AndDoes(_ => completed.TrySetResult());
+
+        var sut = CreateScheduler(withClassificationJob: true);
+        await sut.StartAsync(CancellationToken.None);
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await sut.StopAsync(CancellationToken.None);
+
+        using var verifyDb = new FeirbDbContext(_dbOptions);
+        var unchanged = await verifyDb.JobExecutions.FindAsync(completedId);
+        unchanged!.Status.Should().Be(JobExecutionStatus.Success);
+    }
+
     // --- Helpers ---
 
     private JobSettingsScheduler CreateScheduler(bool withClassificationJob)
@@ -202,12 +263,13 @@ public class JobSettingsSchedulerTests : IDisposable
             NullLoggerFactory.Instance.CreateLogger<JobSettingsScheduler>());
     }
 
-    private void SeedJobSettings(string jobName, string jobType, bool enabled)
+    private Guid SeedJobSettings(string jobName, string jobType, bool enabled)
     {
         using var db = new FeirbDbContext(_dbOptions);
+        var id = Guid.NewGuid();
         db.JobSettings.Add(new JobSettings
         {
-            Id = Guid.NewGuid(),
+            Id = id,
             JobName = jobName,
             JobType = jobType,
             Description = $"Test job {jobName}",
@@ -215,6 +277,23 @@ public class JobSettingsSchedulerTests : IDisposable
             Enabled = enabled,
         });
         db.SaveChanges();
+        return id;
+    }
+
+    private Guid SeedJobExecution(Guid jobSettingsId, DateTimeOffset startedAt, DateTimeOffset? finishedAt, JobExecutionStatus status)
+    {
+        using var db = new FeirbDbContext(_dbOptions);
+        var id = Guid.NewGuid();
+        db.JobExecutions.Add(new JobExecution
+        {
+            Id = id,
+            JobSettingsId = jobSettingsId,
+            StartedAt = startedAt,
+            FinishedAt = finishedAt,
+            Status = status,
+        });
+        db.SaveChanges();
+        return id;
     }
 
     private static ManagedJobRegistry CreateRegistryWithClassification()

--- a/tests/Feirb.Api.Tests/Services/JobSettingsSchedulerTests.cs
+++ b/tests/Feirb.Api.Tests/Services/JobSettingsSchedulerTests.cs
@@ -224,6 +224,40 @@ public class JobSettingsSchedulerTests : IDisposable
     }
 
     [Fact]
+    public async Task ExecuteAsync_ResetsStuckClassificationQueueItemsAsync()
+    {
+        SeedJobSettings("job-a", "classification", enabled: true);
+        var stuckId = SeedClassificationQueueItem(ClassificationQueueItemStatus.Processing);
+        var pendingId = SeedClassificationQueueItem(ClassificationQueueItemStatus.Pending);
+
+        var schedulerRequested = new TaskCompletionSource();
+        _schedulerFactory.GetScheduler(Arg.Any<CancellationToken>())
+            .Returns(_quartzScheduler)
+            .AndDoes(_ => schedulerRequested.TrySetResult());
+
+        var sut = CreateScheduler(withClassificationJob: true);
+        await sut.StartAsync(CancellationToken.None);
+        await schedulerRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        CachedMessageClassificationQueueItem? recovered = null;
+        for (var attempt = 0; attempt < 50; attempt++)
+        {
+            using var verifyDb = new FeirbDbContext(_dbOptions);
+            recovered = await verifyDb.ClassificationQueueItems.FindAsync(stuckId);
+            if (recovered?.Status == ClassificationQueueItemStatus.Pending) break;
+            await Task.Delay(50);
+        }
+        await sut.StopAsync(CancellationToken.None);
+
+        using var finalDb = new FeirbDbContext(_dbOptions);
+        var stuck = await finalDb.ClassificationQueueItems.FindAsync(stuckId);
+        var pending = await finalDb.ClassificationQueueItems.FindAsync(pendingId);
+
+        stuck!.Status.Should().Be(ClassificationQueueItemStatus.Pending);
+        pending!.Status.Should().Be(ClassificationQueueItemStatus.Pending);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_LeavesCompletedExecutionsAloneAsync()
     {
         var jobId = SeedJobSettings("job-a", "classification", enabled: true);
@@ -275,6 +309,23 @@ public class JobSettingsSchedulerTests : IDisposable
             Description = $"Test job {jobName}",
             Cron = "0 * * * * ?",
             Enabled = enabled,
+        });
+        db.SaveChanges();
+        return id;
+    }
+
+    private Guid SeedClassificationQueueItem(ClassificationQueueItemStatus status)
+    {
+        using var db = new FeirbDbContext(_dbOptions);
+        var id = Guid.NewGuid();
+        db.ClassificationQueueItems.Add(new CachedMessageClassificationQueueItem
+        {
+            Id = id,
+            CachedMessageId = Guid.NewGuid(),
+            Status = status,
+            Ordinal = 0,
+            AttemptNumber = 1,
+            CreatedAt = DateTimeOffset.UtcNow,
         });
         db.SaveChanges();
         return id;


### PR DESCRIPTION
## Summary
- Surface classification status in the inbox: banner for job-paused / pending-count, per-row text for pending/processing/failed/notClassified. No polling — F5 to refresh (per parent #230).
- Extend `GET /api/mail/messages` envelope with `pendingCount` and `jobPaused`; add per-message `classificationStatus` enum.
- New `StatusBanner` UI primitive (Info/Warning/Danger/Success) with showcase page and component-library entry.
- **Drive-by fix:** recover orphaned `JobExecution` rows (`FinishedAt IS NULL`) on app startup — the 1-hour "already running" guard was blocking every scheduled run after any unclean restart, which is also what let me catch the bug while testing #244.

Closes #244

## Test plan
- [ ] Open `/mail/inbox` with classification job disabled → Warning banner shows "Classification job is stopped" (+ count suffix when pending > 0)
- [ ] With job enabled and pending queue items → Info banner shows "Unclassified mails: N"
- [ ] With job enabled and zero pending → no banner
- [ ] Per-row text for each status: pending/processing ("Classification ongoing…", muted), failed ("Classification failed", red), notClassified ("Not classified", muted), classified (existing summary rendering)
- [ ] Card layout (< 1100px) and table layout both show banner and per-row states
- [ ] Kill Aspire mid-classification (e.g. `kill -9` the API process), restart → orphaned execution is marked Failed on startup and the next scheduled run proceeds
- [ ] `dotnet test Feirb.sln` passes (415 tests)
- [ ] `dotnet format Feirb.sln --verify-no-changes` passes