### PR TITLE
chore: gitignore Claude Code worktrees and local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ tests/playwright/dist/
 
 # Claude Code runtime state
 .claude/scheduled_tasks.lock
+.claude/worktrees/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add \`.claude/worktrees/\` (auto-created agent worktrees) to .gitignore
- Add \`.claude/settings.local.json\` (personal permission overrides) to .gitignore — was previously only covered by some contributors' global gitignore

## Test plan
- [ ] \`git check-ignore .claude/worktrees/\` returns the path
- [ ] \`git check-ignore .claude/settings.local.json\` returns the path