### PR TITLE
feat(api,web): on-demand single-mail classify with preview/apply (#231)

### DIFF
--- a/docs/component-library.md
+++ b/docs/component-library.md
@@ -88,6 +88,49 @@ Icon-only circular button. Requires `AriaLabel` for WCAG AA.
 | `Title` | `string?` | `null` | Tooltip (falls back to AriaLabel) |
 | `Class` | `string?` | `null` | Extra CSS classes |
 
+## DropdownButton
+
+Trigger button that opens a small action menu on click. Use when a single action has two or three closely-related variants and you want to keep the toolbar/page header compact (e.g. *Preview* vs *Apply Now* on a Classify action). The menu closes on outside click, Escape, or after an item is selected.
+
+```razor
+<DropdownButton Label="Classify" Icon="magic" Items="_classifyItems" />
+
+@code {
+    private IReadOnlyList<DropdownButtonItem> _classifyItems =
+    [
+        new("Preview", EventCallback.Factory.Create(this, OpenPreview), Icon: "eye"),
+        new("Apply Now", EventCallback.Factory.Create(this, OpenApply), Icon: "check-lg"),
+    ];
+}
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `Label` | `string?` | `null` | Trigger button text (omit for icon-only) |
+| `Icon` | `string?` | `null` | Bootstrap Icon name on the trigger (without `bi-` prefix) |
+| `Variant` | `ButtonVariant` | `Primary` | Trigger visual variant |
+| `Size` | `ButtonSize` | `Medium` | Trigger size |
+| `Disabled` | `bool` | `false` | Disables the trigger and prevents the menu from opening |
+| `Items` | `IReadOnlyList<DropdownButtonItem>` (required) | — | Menu items |
+| `Title` | `string?` | `null` | Tooltip on the trigger |
+| `TestId` | `string?` | `null` | `data-testid` on the trigger button |
+| `MenuTestId` | `string?` | `null` | `data-testid` on the menu container |
+| `Class` | `string?` | `null` | Extra CSS classes on the wrapper |
+
+### DropdownButtonItem Record
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Label` | `string` (required) | — | Display text |
+| `OnClick` | `EventCallback` (required) | — | Async callback fired when the item is selected |
+| `Icon` | `string?` | `null` | Bootstrap Icon name without `bi-` prefix |
+| `Disabled` | `bool` | `false` | Disabled item — rendered greyed-out and not clickable |
+| `TestId` | `string?` | `null` | `data-testid` on the menu item button |
+
+**Primitives used:** `Button` (trigger), `Icon` (caret + item icons)
+
+**Accessibility:** Trigger has `aria-haspopup="menu"` and `aria-expanded` reflecting open state. The menu has `role="menu"` and items have `role="menuitem"`.
+
 ## Card
 
 Minimal card container.

--- a/src/Feirb.Api/Endpoints/MailTestEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/MailTestEndpoints.cs
@@ -78,7 +78,7 @@ public static class MailTestEndpoints
             try
             {
                 if (request.RequiresAuth)
-                    await client.AuthenticateAsync(request.Username, request.Password);
+                    await client.AuthenticateAsync(request.Username ?? string.Empty, request.Password ?? string.Empty);
             }
             catch (AuthenticationException ex)
             {

--- a/src/Feirb.Api/Endpoints/MessageEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/MessageEndpoints.cs
@@ -246,7 +246,20 @@ public static class MessageEndpoints
 
         var detailed = await classificationService.ClassifyDetailedAsync(message, cancellationToken);
 
-        // Empty rules/labels: skipped — return success with empty labels so the UI
+        // Backend unavailable (Ollama down or timeout) — surface as a hard failure so the
+        // UI shows an error toast instead of the "no rules configured" help dialog.
+        if (detailed.IsSkipped && detailed.SkipReason == ClassificationSkipReason.BackendUnavailable)
+        {
+            return Results.Ok(new ClassifyMessageResponse(
+                Success: false,
+                Labels: [],
+                Applied: false,
+                Error: localizer["ClassificationAiUnavailable"].Value,
+                Prompt: null,
+                RawResponse: null));
+        }
+
+        // No rules/labels configured: skipped — return success with empty labels so the UI
         // can show the "No classification rules configured" help text.
         if (detailed.IsSkipped)
         {
@@ -255,10 +268,8 @@ public static class MessageEndpoints
                 Labels: [],
                 Applied: false,
                 Error: null,
-                Prompt: dryRun && detailed.Prompt is not null
-                    ? new ClassifyPrompt(detailed.Prompt.System, detailed.Prompt.User)
-                    : null,
-                RawResponse: dryRun ? detailed.RawResponse : null));
+                Prompt: null,
+                RawResponse: null));
         }
 
         // Hard failure: surface the error and skip applying.
@@ -280,7 +291,7 @@ public static class MessageEndpoints
         var applied = false;
         if (!dryRun && labelNames.Count > 0)
         {
-            await ApplyLabelsAsync(db, message, labelNames, cancellationToken);
+            await MessageLabelApplier.ApplyAsync(db, message, labelNames, cancellationToken);
             applied = true;
         }
 
@@ -331,31 +342,6 @@ public static class MessageEndpoints
         catch (JsonException)
         {
             return [];
-        }
-    }
-
-    private static async Task ApplyLabelsAsync(
-        FeirbDbContext db,
-        CachedMessage message,
-        IReadOnlyList<string> labelNames,
-        CancellationToken cancellationToken)
-    {
-        var normalized = labelNames.Select(n => n.ToLowerInvariant()).ToArray();
-        var matchingLabels = await db.Labels
-            .Where(l => l.UserId == message.Mailbox.UserId && normalized.Contains(l.Name))
-            .ToListAsync(cancellationToken);
-
-        if (!db.Entry(message).Collection(m => m.Labels).IsLoaded)
-        {
-            await db.Entry(message).Collection(m => m.Labels).LoadAsync(cancellationToken);
-        }
-
-        foreach (var label in matchingLabels)
-        {
-            if (!message.Labels.Any(l => l.Id == label.Id))
-            {
-                message.Labels.Add(label);
-            }
         }
     }
 

--- a/src/Feirb.Api/Endpoints/MessageEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/MessageEndpoints.cs
@@ -1,7 +1,9 @@
 using System.Security.Claims;
+using System.Text.Json;
 using Feirb.Api.Data;
 using Feirb.Api.Data.Entities;
 using Feirb.Api.Resources;
+using Feirb.Api.Services;
 using Feirb.Shared.AddressBook;
 using Feirb.Shared.Mail;
 using Microsoft.EntityFrameworkCore;
@@ -15,6 +17,7 @@ public static class MessageEndpoints
     {
         group.MapGet("/messages", ListMessagesAsync);
         group.MapGet("/messages/{id:guid}", GetMessageAsync);
+        group.MapPost("/messages/{id:guid}/classify", ClassifyMessageAsync);
         return group;
     }
 
@@ -221,6 +224,140 @@ public static class MessageEndpoints
 
     private static MessageAddressResponse ToAddressResponse((string Name, string Email) parsed) =>
         new(parsed.Name, parsed.Email);
+
+    private static async Task<IResult> ClassifyMessageAsync(
+        Guid id,
+        HttpContext httpContext,
+        FeirbDbContext db,
+        IClassificationService classificationService,
+        IStringLocalizer<ApiMessages> localizer,
+        CancellationToken cancellationToken,
+        bool dryRun = true)
+    {
+        var userId = GetCurrentUserId(httpContext);
+
+        var message = await db.CachedMessages
+            .Include(m => m.Mailbox)
+            .Include(m => m.Labels)
+            .FirstOrDefaultAsync(m => m.Id == id && m.Mailbox.UserId == userId, cancellationToken);
+
+        if (message is null)
+            return Results.NotFound(new { message = localizer["MessageNotFound"].Value });
+
+        var detailed = await classificationService.ClassifyDetailedAsync(message, cancellationToken);
+
+        // Empty rules/labels: skipped — return success with empty labels so the UI
+        // can show the "No classification rules configured" help text.
+        if (detailed.IsSkipped)
+        {
+            return Results.Ok(new ClassifyMessageResponse(
+                Success: true,
+                Labels: [],
+                Applied: false,
+                Error: null,
+                Prompt: dryRun && detailed.Prompt is not null
+                    ? new ClassifyPrompt(detailed.Prompt.System, detailed.Prompt.User)
+                    : null,
+                RawResponse: dryRun ? detailed.RawResponse : null));
+        }
+
+        // Hard failure: surface the error and skip applying.
+        if (!detailed.Success)
+        {
+            return Results.Ok(new ClassifyMessageResponse(
+                Success: false,
+                Labels: [],
+                Applied: false,
+                Error: detailed.Error ?? localizer["ClassificationFailed"].Value,
+                Prompt: dryRun && detailed.Prompt is not null
+                    ? new ClassifyPrompt(detailed.Prompt.System, detailed.Prompt.User)
+                    : null,
+                RawResponse: dryRun ? detailed.RawResponse : null));
+        }
+
+        var labelNames = ParseLabelNames(detailed.Result);
+
+        var applied = false;
+        if (!dryRun && labelNames.Count > 0)
+        {
+            await ApplyLabelsAsync(db, message, labelNames, cancellationToken);
+            applied = true;
+        }
+
+        if (!dryRun)
+        {
+            // Mirror the job: persist a ClassificationResult marker even for empty-label
+            // outcomes so the message is considered classified.
+            db.ClassificationResults.Add(new ClassificationResult
+            {
+                Id = Guid.NewGuid(),
+                CachedMessageId = message.Id,
+                Result = detailed.Result ?? "[]",
+                ClassifiedAt = DateTimeOffset.UtcNow,
+            });
+
+            // If the message was queued (e.g. Pending/Failed), drop the queue item so it
+            // won't be re-classified by the background job.
+            var queueItem = await db.ClassificationQueueItems
+                .FirstOrDefaultAsync(q => q.CachedMessageId == message.Id, cancellationToken);
+            if (queueItem is not null)
+                db.ClassificationQueueItems.Remove(queueItem);
+
+            await db.SaveChangesAsync(cancellationToken);
+            applied = true;
+        }
+
+        return Results.Ok(new ClassifyMessageResponse(
+            Success: true,
+            Labels: labelNames,
+            Applied: applied,
+            Error: null,
+            Prompt: dryRun && detailed.Prompt is not null
+                ? new ClassifyPrompt(detailed.Prompt.System, detailed.Prompt.User)
+                : null,
+            RawResponse: dryRun ? detailed.RawResponse : null));
+    }
+
+    private static IReadOnlyList<string> ParseLabelNames(string? resultJson)
+    {
+        if (string.IsNullOrWhiteSpace(resultJson))
+            return [];
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<string[]>(resultJson) ?? [];
+            return parsed.Where(n => !string.IsNullOrWhiteSpace(n)).ToList();
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static async Task ApplyLabelsAsync(
+        FeirbDbContext db,
+        CachedMessage message,
+        IReadOnlyList<string> labelNames,
+        CancellationToken cancellationToken)
+    {
+        var normalized = labelNames.Select(n => n.ToLowerInvariant()).ToArray();
+        var matchingLabels = await db.Labels
+            .Where(l => l.UserId == message.Mailbox.UserId && normalized.Contains(l.Name))
+            .ToListAsync(cancellationToken);
+
+        if (!db.Entry(message).Collection(m => m.Labels).IsLoaded)
+        {
+            await db.Entry(message).Collection(m => m.Labels).LoadAsync(cancellationToken);
+        }
+
+        foreach (var label in matchingLabels)
+        {
+            if (!message.Labels.Any(l => l.Id == label.Id))
+            {
+                message.Labels.Add(label);
+            }
+        }
+    }
 
     private static Guid GetCurrentUserId(HttpContext httpContext)
     {

--- a/src/Feirb.Api/Endpoints/SetupEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/SetupEndpoints.cs
@@ -76,7 +76,7 @@ public static class SetupEndpoints
             var tlsOptions = TlsModeConverter.ToSecureSocketOptions(request.TlsMode);
             await client.ConnectAsync(request.Host, request.Port, tlsOptions);
             if (request.RequiresAuth)
-                await client.AuthenticateAsync(request.Username, request.Password);
+                await client.AuthenticateAsync(request.Username ?? string.Empty, request.Password ?? string.Empty);
             await client.DisconnectAsync(quit: true);
             return Results.Ok(new TestSmtpResponse(true, null));
         }

--- a/src/Feirb.Api/Feirb.Api.csproj
+++ b/src/Feirb.Api/Feirb.Api.csproj
@@ -15,11 +15,11 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
     <PackageReference Include="CommunityToolkit.Aspire.OllamaSharp" Version="13.1.1" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
-    <PackageReference Include="MailKit" Version="4.15.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.6" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Feirb.Api/Resources/ApiMessages.de-DE.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.de-DE.resx
@@ -216,4 +216,7 @@
   <data name="AddressStatusInvalid" xml:space="preserve">
     <value>Ungültiger Adress-Status-Wert.</value>
   </data>
+  <data name="ClassificationFailed" xml:space="preserve">
+    <value>Klassifizierung fehlgeschlagen.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.de-DE.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.de-DE.resx
@@ -219,4 +219,7 @@
   <data name="ClassificationFailed" xml:space="preserve">
     <value>Klassifizierung fehlgeschlagen.</value>
   </data>
+  <data name="ClassificationAiUnavailable" xml:space="preserve">
+    <value>Der KI-Klassifizierungsdienst ist nicht verfügbar. Bitte später erneut versuchen.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.fr-FR.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.fr-FR.resx
@@ -219,4 +219,7 @@
   <data name="ClassificationFailed" xml:space="preserve">
     <value>Échec de la classification.</value>
   </data>
+  <data name="ClassificationAiUnavailable" xml:space="preserve">
+    <value>Le service de classification IA est indisponible. Veuillez réessayer plus tard.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.fr-FR.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.fr-FR.resx
@@ -216,4 +216,7 @@
   <data name="AddressStatusInvalid" xml:space="preserve">
     <value>Valeur de statut d'adresse invalide.</value>
   </data>
+  <data name="ClassificationFailed" xml:space="preserve">
+    <value>Échec de la classification.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.it-IT.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.it-IT.resx
@@ -219,4 +219,7 @@
   <data name="ClassificationFailed" xml:space="preserve">
     <value>Classificazione non riuscita.</value>
   </data>
+  <data name="ClassificationAiUnavailable" xml:space="preserve">
+    <value>Il servizio di classificazione AI non è disponibile. Riprovare più tardi.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.it-IT.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.it-IT.resx
@@ -216,4 +216,7 @@
   <data name="AddressStatusInvalid" xml:space="preserve">
     <value>Valore di stato indirizzo non valido.</value>
   </data>
+  <data name="ClassificationFailed" xml:space="preserve">
+    <value>Classificazione non riuscita.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.resx
@@ -219,4 +219,7 @@
   <data name="ClassificationFailed" xml:space="preserve">
     <value>Classification failed.</value>
   </data>
+  <data name="ClassificationAiUnavailable" xml:space="preserve">
+    <value>AI classification service is unavailable. Please try again later.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Resources/ApiMessages.resx
+++ b/src/Feirb.Api/Resources/ApiMessages.resx
@@ -216,4 +216,7 @@
   <data name="AddressStatusInvalid" xml:space="preserve">
     <value>Invalid address status value.</value>
   </data>
+  <data name="ClassificationFailed" xml:space="preserve">
+    <value>Classification failed.</value>
+  </data>
 </root>

--- a/src/Feirb.Api/Services/ClassificationJob.cs
+++ b/src/Feirb.Api/Services/ClassificationJob.cs
@@ -147,29 +147,7 @@ public class ClassificationJob(IServiceScopeFactory scopeFactory, ILogger<Classi
         if (rawLabelNames is null || rawLabelNames.Length == 0)
             return;
 
-        var labelNames = rawLabelNames.Where(n => !string.IsNullOrWhiteSpace(n)).Select(n => n.ToLowerInvariant()).ToArray();
-
-        var mailbox = message.Mailbox ?? await db.Mailboxes
-            .AsNoTracking()
-            .FirstAsync(m => m.Id == message.MailboxId, cancellationToken);
-
-        var matchingLabels = await db.Labels
-            .Where(l => l.UserId == mailbox.UserId && labelNames.Contains(l.Name))
-            .ToListAsync(cancellationToken);
-
-        // Ensure the Labels collection is loaded
-        if (!db.Entry(message).Collection(m => m.Labels).IsLoaded)
-        {
-            await db.Entry(message).Collection(m => m.Labels).LoadAsync(cancellationToken);
-        }
-
-        foreach (var label in matchingLabels)
-        {
-            if (!message.Labels.Any(l => l.Id == label.Id))
-            {
-                message.Labels.Add(label);
-            }
-        }
+        await MessageLabelApplier.ApplyAsync(db, message, rawLabelNames, cancellationToken);
     }
 
     private int GetBatchSize(JobSettings jobSettings)

--- a/src/Feirb.Api/Services/ClassificationService.cs
+++ b/src/Feirb.Api/Services/ClassificationService.cs
@@ -17,6 +17,17 @@ public class ClassificationService(
     public async Task<ClassificationServiceResult> ClassifyAsync(
         CachedMessage message, CancellationToken cancellationToken = default)
     {
+        var detailed = await ClassifyDetailedAsync(message, cancellationToken);
+
+        if (detailed.IsSkipped)
+            return ClassificationServiceResult.Skipped;
+
+        return new ClassificationServiceResult(detailed.Success, detailed.Result, detailed.Error);
+    }
+
+    public async Task<ClassificationDetailedResult> ClassifyDetailedAsync(
+        CachedMessage message, CancellationToken cancellationToken = default)
+    {
         ArgumentNullException.ThrowIfNull(message);
 
         // Determine the user who owns this message via mailbox
@@ -26,7 +37,7 @@ public class ClassificationService(
 
         if (mailbox is null)
         {
-            return new ClassificationServiceResult(false, null, "Mailbox not found for message.");
+            return new ClassificationDetailedResult(false, null, "Mailbox not found for message.", null, null);
         }
 
         var userId = mailbox.UserId;
@@ -39,7 +50,7 @@ public class ClassificationService(
 
         if (rules.Count == 0)
         {
-            return ClassificationServiceResult.Skipped;
+            return ClassificationDetailedResult.Skipped;
         }
 
         // Load user's label names for validation
@@ -50,11 +61,18 @@ public class ClassificationService(
 
         if (labels.Count == 0)
         {
-            return ClassificationServiceResult.Skipped;
+            return ClassificationDetailedResult.Skipped;
         }
 
-        // Build and send the LLM request
-        var chatMessages = BuildPrompt(message, rules, labels);
+        // Build the LLM prompt
+        var systemPrompt = BuildSystemPrompt(rules, labels);
+        var userPrompt = BuildUserPrompt(message);
+        var prompt = new ClassificationPrompt(systemPrompt, userPrompt);
+        var chatMessages = new List<ChatMessage>
+        {
+            new(ChatRole.System, systemPrompt),
+            new(ChatRole.User, userPrompt),
+        };
 
         string responseText;
         try
@@ -65,16 +83,17 @@ public class ClassificationService(
         catch (HttpRequestException ex)
         {
             logger.LogWarning(ex, "Ollama unavailable, skipping classification for message {MessageId}", message.Id);
-            return ClassificationServiceResult.Skipped;
+            return ClassificationDetailedResult.Skipped;
         }
         catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
         {
             logger.LogWarning(ex, "Ollama request timed out, skipping classification for message {MessageId}", message.Id);
-            return ClassificationServiceResult.Skipped;
+            return ClassificationDetailedResult.Skipped;
         }
 
         // Parse and validate the response
-        return ParseAndValidateResponse(responseText, labels);
+        var parsed = ParseAndValidateResponse(responseText, labels);
+        return new ClassificationDetailedResult(parsed.Success, parsed.Result, parsed.Error, prompt, responseText);
     }
 
     internal static IList<ChatMessage> BuildPrompt(

--- a/src/Feirb.Api/Services/ClassificationService.cs
+++ b/src/Feirb.Api/Services/ClassificationService.cs
@@ -83,12 +83,12 @@ public class ClassificationService(
         catch (HttpRequestException ex)
         {
             logger.LogWarning(ex, "Ollama unavailable, skipping classification for message {MessageId}", message.Id);
-            return ClassificationDetailedResult.Skipped;
+            return ClassificationDetailedResult.BackendUnavailable("Classification service unavailable.");
         }
         catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
         {
             logger.LogWarning(ex, "Ollama request timed out, skipping classification for message {MessageId}", message.Id);
-            return ClassificationDetailedResult.Skipped;
+            return ClassificationDetailedResult.BackendUnavailable("Classification request timed out.");
         }
 
         // Parse and validate the response

--- a/src/Feirb.Api/Services/IClassificationService.cs
+++ b/src/Feirb.Api/Services/IClassificationService.cs
@@ -5,6 +5,13 @@ namespace Feirb.Api.Services;
 public interface IClassificationService
 {
     Task<ClassificationServiceResult> ClassifyAsync(CachedMessage message, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Like <see cref="ClassifyAsync"/> but also returns the prompt and the raw LLM
+    /// response for diagnostics/preview purposes. Used by the on-demand single-mail
+    /// classification endpoint.
+    /// </summary>
+    Task<ClassificationDetailedResult> ClassifyDetailedAsync(CachedMessage message, CancellationToken cancellationToken = default);
 }
 
 public record ClassificationServiceResult(bool Success, string? Result, string? Error)
@@ -13,3 +20,20 @@ public record ClassificationServiceResult(bool Success, string? Result, string? 
 
     public bool IsSkipped { get; init; }
 }
+
+/// <summary>Outcome of a detailed classification including the LLM prompt and raw response.</summary>
+public record ClassificationDetailedResult(
+    bool Success,
+    string? Result,
+    string? Error,
+    ClassificationPrompt? Prompt,
+    string? RawResponse)
+{
+    public static ClassificationDetailedResult Skipped { get; } =
+        new(true, null, null, null, null) { IsSkipped = true };
+
+    public bool IsSkipped { get; init; }
+}
+
+/// <summary>Materialized system + user prompt sent to the LLM.</summary>
+public record ClassificationPrompt(string System, string User);

--- a/src/Feirb.Api/Services/IClassificationService.cs
+++ b/src/Feirb.Api/Services/IClassificationService.cs
@@ -21,6 +21,18 @@ public record ClassificationServiceResult(bool Success, string? Result, string? 
     public bool IsSkipped { get; init; }
 }
 
+/// <summary>
+/// Why a classification was skipped. Lets callers distinguish "user has no rules
+/// configured" (a normal state, surface help UI) from "backend is down" (an error,
+/// surface failure UI). <see cref="NotApplicable"/> means the result is not a skip.
+/// </summary>
+public enum ClassificationSkipReason
+{
+    NotApplicable,
+    NoConfiguration,
+    BackendUnavailable,
+}
+
 /// <summary>Outcome of a detailed classification including the LLM prompt and raw response.</summary>
 public record ClassificationDetailedResult(
     bool Success,
@@ -29,10 +41,17 @@ public record ClassificationDetailedResult(
     ClassificationPrompt? Prompt,
     string? RawResponse)
 {
+    /// <summary>Skipped because the user has no classification rules or labels configured.</summary>
     public static ClassificationDetailedResult Skipped { get; } =
-        new(true, null, null, null, null) { IsSkipped = true };
+        new(true, null, null, null, null) { IsSkipped = true, SkipReason = ClassificationSkipReason.NoConfiguration };
+
+    /// <summary>Skipped because the LLM backend (Ollama) is unavailable or timed out.</summary>
+    public static ClassificationDetailedResult BackendUnavailable(string? error = null) =>
+        new(true, null, error, null, null) { IsSkipped = true, SkipReason = ClassificationSkipReason.BackendUnavailable };
 
     public bool IsSkipped { get; init; }
+
+    public ClassificationSkipReason SkipReason { get; init; } = ClassificationSkipReason.NotApplicable;
 }
 
 /// <summary>Materialized system + user prompt sent to the LLM.</summary>

--- a/src/Feirb.Api/Services/ImapSyncService.cs
+++ b/src/Feirb.Api/Services/ImapSyncService.cs
@@ -51,7 +51,8 @@ public class ImapSyncService(
             await client.ConnectAsync(mailbox.ImapHost, mailbox.ImapPort, tlsOptions, cancellationToken);
             await client.AuthenticateAsync(mailbox.ImapUsername, password, cancellationToken);
 
-            var inbox = client.Inbox;
+            var inbox = client.Inbox ?? throw new InvalidOperationException(
+                $"IMAP server for mailbox {mailboxId} returned no Inbox folder.");
             await inbox.OpenAsync(FolderAccess.ReadOnly, cancellationToken);
 
             var lastSeenUid = await GetLastSeenUidAsync(db, mailboxId, cancellationToken);

--- a/src/Feirb.Api/Services/MessageLabelApplier.cs
+++ b/src/Feirb.Api/Services/MessageLabelApplier.cs
@@ -1,0 +1,56 @@
+using Feirb.Api.Data;
+using Feirb.Api.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Feirb.Api.Services;
+
+/// <summary>
+/// Shared logic for attaching label names to a <see cref="CachedMessage"/>.
+/// Used by both <c>ClassificationJob</c> (batch path) and the on-demand classify endpoint.
+/// Does not call <c>SaveChangesAsync</c> — callers are responsible for committing.
+/// </summary>
+internal static class MessageLabelApplier
+{
+    public static async Task ApplyAsync(
+        FeirbDbContext db,
+        CachedMessage message,
+        IReadOnlyList<string> labelNames,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(message);
+        ArgumentNullException.ThrowIfNull(labelNames);
+
+        if (labelNames.Count == 0)
+            return;
+
+        var normalized = labelNames
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Select(n => n.ToLowerInvariant())
+            .ToArray();
+
+        if (normalized.Length == 0)
+            return;
+
+        var mailbox = message.Mailbox ?? await db.Mailboxes
+            .AsNoTracking()
+            .FirstAsync(m => m.Id == message.MailboxId, cancellationToken);
+
+        var matchingLabels = await db.Labels
+            .Where(l => l.UserId == mailbox.UserId && normalized.Contains(l.Name))
+            .ToListAsync(cancellationToken);
+
+        if (!db.Entry(message).Collection(m => m.Labels).IsLoaded)
+        {
+            await db.Entry(message).Collection(m => m.Labels).LoadAsync(cancellationToken);
+        }
+
+        foreach (var label in matchingLabels)
+        {
+            if (!message.Labels.Any(l => l.Id == label.Id))
+            {
+                message.Labels.Add(label);
+            }
+        }
+    }
+}

--- a/src/Feirb.Api/Services/NoopClassificationService.cs
+++ b/src/Feirb.Api/Services/NoopClassificationService.cs
@@ -4,13 +4,19 @@ namespace Feirb.Api.Services;
 
 public class NoopClassificationService : IClassificationService
 {
+    // The Result must be a JSON array of label names to match the contract
+    // ClassificationService.ParseAndValidateResponse establishes and that the classify
+    // endpoint persists into ClassificationResult.Result. "[]" means "classified, no
+    // labels apply" — the safest no-op outcome.
+    private const string _emptyLabels = "[]";
+
     public Task<ClassificationServiceResult> ClassifyAsync(CachedMessage message, CancellationToken cancellationToken = default) =>
-        Task.FromResult(new ClassificationServiceResult(Success: true, Result: "noop-classification", Error: null));
+        Task.FromResult(new ClassificationServiceResult(Success: true, Result: _emptyLabels, Error: null));
 
     public Task<ClassificationDetailedResult> ClassifyDetailedAsync(CachedMessage message, CancellationToken cancellationToken = default) =>
         Task.FromResult(new ClassificationDetailedResult(
             Success: true,
-            Result: "noop-classification",
+            Result: _emptyLabels,
             Error: null,
             Prompt: null,
             RawResponse: null));

--- a/src/Feirb.Api/Services/NoopClassificationService.cs
+++ b/src/Feirb.Api/Services/NoopClassificationService.cs
@@ -6,4 +6,12 @@ public class NoopClassificationService : IClassificationService
 {
     public Task<ClassificationServiceResult> ClassifyAsync(CachedMessage message, CancellationToken cancellationToken = default) =>
         Task.FromResult(new ClassificationServiceResult(Success: true, Result: "noop-classification", Error: null));
+
+    public Task<ClassificationDetailedResult> ClassifyDetailedAsync(CachedMessage message, CancellationToken cancellationToken = default) =>
+        Task.FromResult(new ClassificationDetailedResult(
+            Success: true,
+            Result: "noop-classification",
+            Error: null,
+            Prompt: null,
+            RawResponse: null));
 }

--- a/src/Feirb.ServiceDefaults/Feirb.ServiceDefaults.csproj
+++ b/src/Feirb.ServiceDefaults/Feirb.ServiceDefaults.csproj
@@ -12,11 +12,11 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Feirb.Shared/Mail/ClassifyMessageResponse.cs
+++ b/src/Feirb.Shared/Mail/ClassifyMessageResponse.cs
@@ -13,7 +13,10 @@ namespace Feirb.Shared.Mail;
 /// (no rules/labels configured).
 /// </param>
 /// <param name="Applied">
-/// True when labels were persisted to the message (only possible with <c>dryRun=false</c>).
+/// True when the classify action was committed to the database (only possible with
+/// <c>dryRun=false</c>). A classification marker is persisted regardless of matches,
+/// so <c>Applied</c> may be true even if <see cref="Labels"/> is empty — callers
+/// should not assume a label change occurred.
 /// </param>
 /// <param name="Error">Error message when <see cref="Success"/> is false; otherwise null.</param>
 /// <param name="Prompt">

--- a/src/Feirb.Shared/Mail/ClassifyMessageResponse.cs
+++ b/src/Feirb.Shared/Mail/ClassifyMessageResponse.cs
@@ -1,0 +1,34 @@
+namespace Feirb.Shared.Mail;
+
+/// <summary>
+/// Response for the on-demand single-mail classify endpoint
+/// (<c>POST /api/mail/messages/{id}/classify</c>).
+/// </summary>
+/// <param name="Success">
+/// True when the classifier produced a result (even an empty list of labels).
+/// False when an error occurred (e.g. AI service unavailable, malformed LLM response).
+/// </param>
+/// <param name="Labels">
+/// Recognized label names. Empty list means no labels apply or classifier was skipped
+/// (no rules/labels configured).
+/// </param>
+/// <param name="Applied">
+/// True when labels were persisted to the message (only possible with <c>dryRun=false</c>).
+/// </param>
+/// <param name="Error">Error message when <see cref="Success"/> is false; otherwise null.</param>
+/// <param name="Prompt">
+/// Materialized prompt sent to the LLM. Populated for <c>dryRun=true</c> only — null in apply mode.
+/// </param>
+/// <param name="RawResponse">
+/// Verbatim text returned by the LLM, before parsing. Populated for <c>dryRun=true</c> only.
+/// </param>
+public record ClassifyMessageResponse(
+    bool Success,
+    IReadOnlyList<string> Labels,
+    bool Applied,
+    string? Error,
+    ClassifyPrompt? Prompt,
+    string? RawResponse);
+
+/// <summary>System + user prompt sent to the LLM.</summary>
+public record ClassifyPrompt(string System, string User);

--- a/src/Feirb.Web/Components/Toolbar.razor
+++ b/src/Feirb.Web/Components/Toolbar.razor
@@ -1,9 +1,20 @@
 @inject ToolbarStateService ToolbarState
 @implements IDisposable
 
-@if (ToolbarState.Actions.Count > 0)
+@if (ToolbarState.Actions.Count > 0 || ToolbarState.DropdownActions.Count > 0)
 {
     <div class="toolbar-actions" data-testid="toolbar">
+        @foreach (var action in ToolbarState.DropdownActions)
+        {
+            <DropdownButton @key="action"
+                            Label="@action.Label"
+                            Icon="@action.Icon"
+                            Variant="action.Variant"
+                            Size="ButtonSize.Small"
+                            Items="action.Items"
+                            TestId="@action.TestId"
+                            MenuTestId="@action.MenuTestId" />
+        }
         @foreach (var action in ToolbarState.Actions)
         {
             <Button @key="action" Variant="action.Variant" Size="ButtonSize.Small" Icon="@action.Icon" OnClick="action.OnClickAsync">

--- a/src/Feirb.Web/Components/UI/DropdownButton.razor
+++ b/src/Feirb.Web/Components/UI/DropdownButton.razor
@@ -114,11 +114,14 @@
         if (Disabled)
             return;
 
-        _open = !_open;
-        OnParametersSet();
-
         if (_open)
         {
+            await CloseInternalAsync();
+        }
+        else
+        {
+            _open = true;
+            OnParametersSet();
             await EnsureOutsideClickHandlerAsync();
         }
     }
@@ -128,24 +131,27 @@
         if (item.Disabled)
             return;
 
-        _open = false;
-        OnParametersSet();
-        StateHasChanged();
+        await CloseInternalAsync();
 
         if (item.OnClick.HasDelegate)
             await item.OnClick.InvokeAsync();
     }
 
     [JSInvokable]
-    public Task CloseAsync()
+    public async Task CloseAsync()
     {
         if (!_open)
-            return Task.CompletedTask;
+            return;
 
+        await CloseInternalAsync();
+    }
+
+    private async Task CloseInternalAsync()
+    {
         _open = false;
         OnParametersSet();
+        await DetachOutsideClickHandlerAsync();
         StateHasChanged();
-        return Task.CompletedTask;
     }
 
     private async Task EnsureOutsideClickHandlerAsync()
@@ -165,16 +171,24 @@
         }
     }
 
+    private async Task DetachOutsideClickHandlerAsync()
+    {
+        if (_outsideClickHandle is null)
+            return;
+
+        try { await _outsideClickHandle.InvokeVoidAsync("detach"); }
+        catch (JSException) { }
+        catch (JSDisconnectedException) { }
+
+        try { await _outsideClickHandle.DisposeAsync(); }
+        catch (JSDisconnectedException) { }
+
+        _outsideClickHandle = null;
+    }
+
     public async ValueTask DisposeAsync()
     {
-        if (_outsideClickHandle is not null)
-        {
-            try { await _outsideClickHandle.InvokeVoidAsync("detach"); }
-            catch (JSException) { }
-            catch (JSDisconnectedException) { }
-            await _outsideClickHandle.DisposeAsync();
-        }
-
+        await DetachOutsideClickHandlerAsync();
         _selfRef?.Dispose();
     }
 }

--- a/src/Feirb.Web/Components/UI/DropdownButton.razor
+++ b/src/Feirb.Web/Components/UI/DropdownButton.razor
@@ -1,0 +1,180 @@
+@namespace Feirb.Web.Components.UI
+@implements IAsyncDisposable
+@inject IJSRuntime Js
+
+@* Button that opens a dropdown menu of actions on click. *@
+<div class="feirb-dropdown @(_open ? "open" : "") @Class" @ref="_root">
+    <Button Variant="Variant"
+            Size="Size"
+            Icon="@Icon"
+            Disabled="Disabled"
+            OnClick="ToggleAsync"
+            Title="@Title"
+            AdditionalAttributes="@_buttonAttributes">
+        @if (!string.IsNullOrEmpty(Label))
+        {
+            <span>@Label</span>
+        }
+        <Icon Name="caret-down-fill" Size="IconSize.Small" Class="feirb-dropdown-caret" />
+    </Button>
+
+    @if (_open)
+    {
+        <div class="feirb-dropdown-menu" role="menu" data-testid="@(MenuTestId ?? null)">
+            @foreach (var item in Items)
+            {
+                <button type="button"
+                        class="feirb-dropdown-menu-item"
+                        role="menuitem"
+                        disabled="@item.Disabled"
+                        data-testid="@(item.TestId ?? null)"
+                        @onclick="() => HandleItemClickAsync(item)">
+                    @if (!string.IsNullOrEmpty(item.Icon))
+                    {
+                        <Icon Name="@item.Icon" Size="IconSize.Small" Class="me-2" />
+                    }
+                    <span>@item.Label</span>
+                </button>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    /// <summary>Trigger button label. May be omitted for icon-only triggers.</summary>
+    [Parameter]
+    public string? Label { get; set; }
+
+    /// <summary>Optional Bootstrap Icon name (without <c>bi-</c> prefix) shown left of the label.</summary>
+    [Parameter]
+    public string? Icon { get; set; }
+
+    /// <summary>Trigger button visual variant.</summary>
+    [Parameter]
+    public ButtonVariant Variant { get; set; } = ButtonVariant.Primary;
+
+    /// <summary>Trigger button size.</summary>
+    [Parameter]
+    public ButtonSize Size { get; set; } = ButtonSize.Medium;
+
+    /// <summary>Disables the trigger and prevents the menu from opening.</summary>
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    /// <summary>Tooltip for the trigger button.</summary>
+    [Parameter]
+    public string? Title { get; set; }
+
+    /// <summary>Optional <c>data-testid</c> for the trigger button.</summary>
+    [Parameter]
+    public string? TestId { get; set; }
+
+    /// <summary>Optional <c>data-testid</c> for the dropdown menu container.</summary>
+    [Parameter]
+    public string? MenuTestId { get; set; }
+
+    /// <summary>Menu items rendered when the dropdown is open.</summary>
+    [Parameter, EditorRequired]
+    public IReadOnlyList<DropdownButtonItem> Items { get; set; } = [];
+
+    /// <summary>Extra CSS classes on the wrapper.</summary>
+    [Parameter]
+    public string? Class { get; set; }
+
+    private bool _open;
+    private ElementReference _root;
+    private DotNetObjectReference<DropdownButton>? _selfRef;
+    private IJSObjectReference? _outsideClickHandle;
+
+    private Dictionary<string, object>? _buttonAttributes;
+
+    protected override void OnParametersSet()
+    {
+        if (TestId is not null)
+        {
+            _buttonAttributes = new Dictionary<string, object>(StringComparer.Ordinal)
+            {
+                ["data-testid"] = TestId,
+                ["aria-haspopup"] = "menu",
+                ["aria-expanded"] = _open ? "true" : "false",
+            };
+        }
+        else
+        {
+            _buttonAttributes = new Dictionary<string, object>(StringComparer.Ordinal)
+            {
+                ["aria-haspopup"] = "menu",
+                ["aria-expanded"] = _open ? "true" : "false",
+            };
+        }
+    }
+
+    private async Task ToggleAsync()
+    {
+        if (Disabled)
+            return;
+
+        _open = !_open;
+        OnParametersSet();
+
+        if (_open)
+        {
+            await EnsureOutsideClickHandlerAsync();
+        }
+    }
+
+    private async Task HandleItemClickAsync(DropdownButtonItem item)
+    {
+        if (item.Disabled)
+            return;
+
+        _open = false;
+        OnParametersSet();
+        StateHasChanged();
+
+        if (item.OnClick.HasDelegate)
+            await item.OnClick.InvokeAsync();
+    }
+
+    [JSInvokable]
+    public Task CloseAsync()
+    {
+        if (!_open)
+            return Task.CompletedTask;
+
+        _open = false;
+        OnParametersSet();
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    private async Task EnsureOutsideClickHandlerAsync()
+    {
+        if (_outsideClickHandle is not null)
+            return;
+
+        _selfRef ??= DotNetObjectReference.Create(this);
+        try
+        {
+            _outsideClickHandle = await Js.InvokeAsync<IJSObjectReference>(
+                "feirbDropdown.attach", _root, _selfRef);
+        }
+        catch (JSException)
+        {
+            // JS isn't available (e.g. prerendering); user can still close via toggle.
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_outsideClickHandle is not null)
+        {
+            try { await _outsideClickHandle.InvokeVoidAsync("detach"); }
+            catch (JSException) { }
+            catch (JSDisconnectedException) { }
+            await _outsideClickHandle.DisposeAsync();
+        }
+
+        _selfRef?.Dispose();
+    }
+}

--- a/src/Feirb.Web/Components/UI/DropdownButtonItem.cs
+++ b/src/Feirb.Web/Components/UI/DropdownButtonItem.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Feirb.Web.Components.UI;
+
+/// <summary>
+/// One item in a <see cref="DropdownButton"/> menu.
+/// </summary>
+/// <param name="Label">Display text.</param>
+/// <param name="OnClick">Async callback fired when the item is selected.</param>
+/// <param name="Icon">Optional Bootstrap Icon name (without <c>bi-</c> prefix).</param>
+/// <param name="Disabled">When true the item is rendered greyed-out and not clickable.</param>
+/// <param name="TestId">Optional <c>data-testid</c> for the menu item button.</param>
+public sealed record DropdownButtonItem(
+    string Label,
+    EventCallback OnClick,
+    string? Icon = null,
+    bool Disabled = false,
+    string? TestId = null);

--- a/src/Feirb.Web/Feirb.Web.csproj
+++ b/src/Feirb.Web/Feirb.Web.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="CronExpressionDescriptor" Version="2.45.0" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />

--- a/src/Feirb.Web/Layout/ShowcaseLayout.razor
+++ b/src/Feirb.Web/Layout/ShowcaseLayout.razor
@@ -90,6 +90,7 @@
             new("type-h1", "Heading", Href: "components-showcase/heading"),
             new("hand-index-thumb", "Button", Href: "components-showcase/button"),
             new("circle", "CircularButton", Href: "components-showcase/circular-button"),
+            new("caret-down-square", "DropdownButton", Href: "components-showcase/dropdown-button"),
             new("card-text", "Card", Href: "components-showcase/card")
         ], Label: "Primitives"),
         new(

--- a/src/Feirb.Web/Pages/ComponentsShowcase.razor
+++ b/src/Feirb.Web/Pages/ComponentsShowcase.razor
@@ -23,6 +23,9 @@
     case "circular-button":
         <ShowcaseCircularButton />
         break;
+    case "dropdown-button":
+        <ShowcaseDropdownButton />
+        break;
     case "card":
         <ShowcaseCard />
         break;

--- a/src/Feirb.Web/Pages/Mail/MessageDetail.razor
+++ b/src/Feirb.Web/Pages/Mail/MessageDetail.razor
@@ -5,6 +5,9 @@
 @inject HttpClient Http
 @inject IStringLocalizer<SharedResources> L
 @inject BreadcrumbOverrideService BreadcrumbOverride
+@inject ToolbarStateService ToolbarState
+@inject NotificationService Notifications
+@inject NavigationManager Navigation
 @implements IDisposable
 
 <PageTitle>@L["PageTitleMessageDetail"]</PageTitle>
@@ -132,6 +135,170 @@ else if (_message is not null)
     }
 }
 
+@* Classify Preview Modal *@
+@if (_showPreviewModal)
+{
+    <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);" data-testid="classify-preview-modal">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">@L["ClassifyPreviewTitle"]</h5>
+                    <button type="button" class="btn-close" @onclick="CloseModals" aria-label="@L["ClassifyButtonClose"]"></button>
+                </div>
+                <div class="modal-body">
+                    @if (_classifyInProgress)
+                    {
+                        <div class="d-flex align-items-center gap-2 text-muted">
+                            <span class="spinner-border spinner-border-sm" role="status"></span>
+                            <span>@L["ClassificationOngoing"]</span>
+                        </div>
+                    }
+                    else if (_lastResult is null)
+                    {
+                        <div class="alert alert-danger mb-0" role="alert">@L["ClassifyToastRequestFailed"]</div>
+                    }
+                    else if (!_lastResult.Success)
+                    {
+                        <div class="alert alert-danger" role="alert" data-testid="classify-preview-error">
+                            @string.Format(L["ClassifyErrorPrefix"], _lastResult.Error ?? L["ClassifyServiceUnavailable"])
+                        </div>
+                        @RenderPromptDetails(_lastResult)
+                    }
+                    else
+                    {
+                        <div class="mb-3">
+                            <div class="text-muted small mb-1">@L["ClassifyPreviewLabelsHeading"]</div>
+                            @if (_lastResult.Labels.Count == 0)
+                            {
+                                <p class="text-muted mb-0" data-testid="classify-preview-no-labels">@L["ClassifyPreviewNoLabels"]</p>
+                            }
+                            else
+                            {
+                                <div class="d-flex flex-wrap gap-2" data-testid="classify-preview-labels">
+                                    @foreach (var labelName in _lastResult.Labels)
+                                    {
+                                        <LabelPill Name="@labelName" Color="@LookupLabelColor(labelName)" />
+                                    }
+                                </div>
+                            }
+                        </div>
+                        @RenderPromptDetails(_lastResult)
+                    }
+                </div>
+                <div class="modal-footer">
+                    <Button Variant="ButtonVariant.Secondary" OnClick="CloseModals">@L["ClassifyButtonClose"]</Button>
+                    @if (_lastResult is { Success: true } && !_classifyInProgress)
+                    {
+                        <Button Variant="ButtonVariant.Primary"
+                                Icon="check-lg"
+                                OnClick="ConfirmApplyFromPreviewAsync"
+                                Disabled="_isApplying"
+                                data-testid="classify-preview-apply">
+                            @if (_isApplying)
+                            {
+                                <span class="spinner-border spinner-border-sm me-1" role="status"></span>
+                            }
+                            @L["ClassifyButtonApply"]
+                        </Button>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@* Apply Confirmation Dialog *@
+@if (_showApplyConfirm)
+{
+    <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);" data-testid="classify-apply-modal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">@L["ClassifyApplyTitle"]</h5>
+                    <button type="button" class="btn-close" @onclick="CloseModals" aria-label="@L["ClassifyButtonClose"]"></button>
+                </div>
+                <div class="modal-body">
+                    @if (_classifyInProgress)
+                    {
+                        <div class="d-flex align-items-center gap-2 text-muted">
+                            <span class="spinner-border spinner-border-sm" role="status"></span>
+                            <span>@L["ClassificationOngoing"]</span>
+                        </div>
+                    }
+                    else if (_lastResult is null)
+                    {
+                        <div class="alert alert-danger mb-0" role="alert">@L["ClassifyToastRequestFailed"]</div>
+                    }
+                    else if (!_lastResult.Success)
+                    {
+                        <div class="alert alert-danger mb-0" role="alert">
+                            @string.Format(L["ClassifyErrorPrefix"], _lastResult.Error ?? L["ClassifyServiceUnavailable"])
+                        </div>
+                    }
+                    else if (_lastResult.Labels.Count == 0)
+                    {
+                        <p class="mb-0">@L["ClassifyApplyConfirmEmpty"]</p>
+                    }
+                    else
+                    {
+                        <p class="mb-2">@L["ClassifyApplyConfirmWithLabels"]</p>
+                        <div class="d-flex flex-wrap gap-2" data-testid="classify-apply-labels">
+                            @foreach (var labelName in _lastResult.Labels)
+                            {
+                                <LabelPill Name="@labelName" Color="@LookupLabelColor(labelName)" />
+                            }
+                        </div>
+                    }
+                </div>
+                <div class="modal-footer">
+                    <Button Variant="ButtonVariant.Secondary" OnClick="CloseModals">@L["ButtonCancel"]</Button>
+                    @if (_lastResult is { Success: true } && !_classifyInProgress)
+                    {
+                        <Button Variant="ButtonVariant.Primary"
+                                Icon="check-lg"
+                                OnClick="ApplyConfirmedAsync"
+                                Disabled="_isApplying"
+                                data-testid="classify-apply-confirm">
+                            @if (_isApplying)
+                            {
+                                <span class="spinner-border spinner-border-sm me-1" role="status"></span>
+                            }
+                            @L["ButtonConfirm"]
+                        </Button>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@* No-Rules Help Dialog *@
+@if (_showNoRulesModal)
+{
+    <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);" data-testid="classify-no-rules-modal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">@L["ClassifyNoRulesTitle"]</h5>
+                    <button type="button" class="btn-close" @onclick="CloseModals" aria-label="@L["ClassifyButtonClose"]"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="mb-0">@L["ClassifyNoRulesMessage"]</p>
+                </div>
+                <div class="modal-footer">
+                    <Button Variant="ButtonVariant.Secondary" OnClick="CloseModals">@L["ClassifyButtonClose"]</Button>
+                    <Button Variant="ButtonVariant.Primary"
+                            Icon="gear"
+                            OnClick="GoToClassificationSettings"
+                            data-testid="classify-no-rules-settings">
+                        @L["ClassifyNoRulesGoToSettings"]
+                    </Button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
 @code {
     [Parameter]
     public Guid Id { get; set; }
@@ -142,6 +309,15 @@ else if (_message is not null)
     private string? _errorMessage;
     private string _selectedBodyFormat = "html";
     private bool _hasBothBodyFormats;
+
+    // Classify state
+    private ToolbarDropdownAction[] _toolbarDropdownActions = [];
+    private bool _showPreviewModal;
+    private bool _showApplyConfirm;
+    private bool _showNoRulesModal;
+    private bool _classifyInProgress;
+    private bool _isApplying;
+    private ClassifyMessageResponse? _lastResult;
 
     private IReadOnlyList<ToggleButtonItem> BodyFormatOptions =>
     [
@@ -173,6 +349,8 @@ else if (_message is not null)
 
                 BreadcrumbOverride.SetLastSegmentLabel(
                     $"{_message.FromAddress.Name} \u2014 {_message.Subject}");
+
+                RegisterToolbar();
             }
         }
         catch
@@ -185,7 +363,213 @@ else if (_message is not null)
         }
     }
 
-    public void Dispose() => BreadcrumbOverride.Clear();
+    private void RegisterToolbar()
+    {
+        var items = new[]
+        {
+            new DropdownButtonItem(
+                L["ClassifyMenuPreview"],
+                EventCallback.Factory.Create(this, OpenPreviewAsync),
+                Icon: "eye",
+                TestId: "classify-menu-preview"),
+            new DropdownButtonItem(
+                L["ClassifyMenuApplyNow"],
+                EventCallback.Factory.Create(this, OpenApplyConfirmAsync),
+                Icon: "check-lg",
+                TestId: "classify-menu-apply"),
+        };
+        _toolbarDropdownActions =
+        [
+            new ToolbarDropdownAction(
+                L["ClassifyToolbarLabel"],
+                ButtonVariant.Secondary,
+                items,
+                icon: "magic",
+                testId: "classify-dropdown",
+                menuTestId: "classify-menu"),
+        ];
+        ToolbarState.AddDropdownActions(_toolbarDropdownActions);
+    }
+
+    public void Dispose()
+    {
+        BreadcrumbOverride.Clear();
+        ToolbarState.RemoveDropdownActions(_toolbarDropdownActions);
+    }
+
+    private void CloseModals()
+    {
+        _showPreviewModal = false;
+        _showApplyConfirm = false;
+        _showNoRulesModal = false;
+    }
+
+    private async Task OpenPreviewAsync()
+    {
+        CloseModals();
+        _lastResult = null;
+        _classifyInProgress = true;
+        _showPreviewModal = true;
+        StateHasChanged();
+
+        var result = await ClassifyAsync(dryRun: true);
+        _classifyInProgress = false;
+
+        if (result is null)
+        {
+            // Network/server failure — keep modal open with error state, also toast.
+            Notifications.Add(L["ClassifyToastRequestFailed"], NotificationSeverity.Error);
+            StateHasChanged();
+            return;
+        }
+
+        // Skipped (no rules/labels) — close preview, show help dialog instead.
+        if (IsNoRulesResponse(result))
+        {
+            _showPreviewModal = false;
+            _showNoRulesModal = true;
+            StateHasChanged();
+            return;
+        }
+
+        _lastResult = result;
+        StateHasChanged();
+    }
+
+    private async Task OpenApplyConfirmAsync()
+    {
+        CloseModals();
+        _lastResult = null;
+        _classifyInProgress = true;
+        _showApplyConfirm = true;
+        StateHasChanged();
+
+        // Run a dry-run first so the user can see what will be applied.
+        var result = await ClassifyAsync(dryRun: true);
+        _classifyInProgress = false;
+
+        if (result is null)
+        {
+            Notifications.Add(L["ClassifyToastRequestFailed"], NotificationSeverity.Error);
+            StateHasChanged();
+            return;
+        }
+
+        if (IsNoRulesResponse(result))
+        {
+            _showApplyConfirm = false;
+            _showNoRulesModal = true;
+            StateHasChanged();
+            return;
+        }
+
+        _lastResult = result;
+        StateHasChanged();
+    }
+
+    private void ConfirmApplyFromPreviewAsync()
+    {
+        // From the preview modal: switch to the apply-confirm modal with the same result.
+        _showPreviewModal = false;
+        _showApplyConfirm = true;
+    }
+
+    private async Task ApplyConfirmedAsync()
+    {
+        _isApplying = true;
+        StateHasChanged();
+
+        var result = await ClassifyAsync(dryRun: false);
+        _isApplying = false;
+
+        if (result is null || !result.Success)
+        {
+            var msg = result?.Error is { Length: > 0 } e
+                ? string.Format(L["ClassifyErrorPrefix"], e)
+                : L["ClassifyToastRequestFailed"].Value;
+            Notifications.Add(msg, NotificationSeverity.Error);
+            return;
+        }
+
+        Notifications.Add(L["ClassifyToastApplied"], NotificationSeverity.Success);
+        CloseModals();
+
+        // Refresh the message to show the newly-applied labels.
+        await ReloadMessageAsync();
+    }
+
+    private async Task<ClassifyMessageResponse?> ClassifyAsync(bool dryRun)
+    {
+        try
+        {
+            var response = await Http.PostAsync(
+                $"/api/mail/messages/{Id}/classify?dryRun={(dryRun ? "true" : "false")}",
+                content: null);
+
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            return await response.Content.ReadFromJsonAsync<ClassifyMessageResponse>();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsNoRulesResponse(ClassifyMessageResponse result) =>
+        result.Success && result.Labels.Count == 0
+            && string.IsNullOrEmpty(result.RawResponse) && result.Prompt is null;
+
+    private async Task ReloadMessageAsync()
+    {
+        var response = await Http.GetAsync($"/api/mail/messages/{Id}");
+        if (response.IsSuccessStatusCode)
+        {
+            _message = await response.Content.ReadFromJsonAsync<MessageDetailResponse>();
+            StateHasChanged();
+        }
+    }
+
+    private string? LookupLabelColor(string labelName)
+    {
+        if (_message is null)
+            return null;
+
+        // Match case-insensitively against labels that the message already carries — the
+        // classify endpoint normalizes label names to lowercase, but message labels keep
+        // their original casing.
+        var match = _message.Labels.FirstOrDefault(
+            l => string.Equals(l.Name, labelName, StringComparison.OrdinalIgnoreCase));
+        return match?.Color;
+    }
+
+    private RenderFragment RenderPromptDetails(ClassifyMessageResponse result) => @<text>
+        @if (result.Prompt is not null)
+        {
+            <div class="mb-3">
+                <div class="text-muted small mb-1">@L["ClassifyPreviewSystemPromptHeading"]</div>
+                <pre class="feirb-prompt-pre" data-testid="classify-preview-system-prompt">@result.Prompt.System</pre>
+            </div>
+            <div class="mb-3">
+                <div class="text-muted small mb-1">@L["ClassifyPreviewUserPromptHeading"]</div>
+                <pre class="feirb-prompt-pre" data-testid="classify-preview-user-prompt">@result.Prompt.User</pre>
+            </div>
+        }
+        @if (!string.IsNullOrEmpty(result.RawResponse))
+        {
+            <div class="mb-0">
+                <div class="text-muted small mb-1">@L["ClassifyPreviewRawResponseHeading"]</div>
+                <pre class="feirb-prompt-pre" data-testid="classify-preview-raw-response">@result.RawResponse</pre>
+            </div>
+        }
+    </text>;
+
+    private void GoToClassificationSettings()
+    {
+        CloseModals();
+        Navigation.NavigateTo("/settings/classification");
+    }
 
     private static string FormatFileSize(long bytes)
     {

--- a/src/Feirb.Web/Pages/Mail/MessageDetail.razor
+++ b/src/Feirb.Web/Pages/Mail/MessageDetail.razor
@@ -397,8 +397,14 @@ else if (_message is not null)
         ToolbarState.RemoveDropdownActions(_toolbarDropdownActions);
     }
 
+    // Monotonic counter to guard against stale responses: every modal open and every
+    // explicit close increments this; in-flight classify calls capture the value at
+    // start and discard their result if the value has moved on by the time they resolve.
+    private int _classifyGeneration;
+
     private void CloseModals()
     {
+        _classifyGeneration++;
         _showPreviewModal = false;
         _showApplyConfirm = false;
         _showNoRulesModal = false;
@@ -407,18 +413,36 @@ else if (_message is not null)
     private async Task OpenPreviewAsync()
     {
         CloseModals();
+        var gen = ++_classifyGeneration;
         _lastResult = null;
         _classifyInProgress = true;
         _showPreviewModal = true;
         StateHasChanged();
 
         var result = await ClassifyAsync(dryRun: true);
+
+        // Discard if the user closed the modal or started another classify in the meantime.
+        if (gen != _classifyGeneration)
+            return;
+
         _classifyInProgress = false;
 
         if (result is null)
         {
             // Network/server failure — keep modal open with error state, also toast.
             Notifications.Add(L["ClassifyToastRequestFailed"], NotificationSeverity.Error);
+            StateHasChanged();
+            return;
+        }
+
+        // Backend unavailable or hard failure — close modal, show toast.
+        if (!result.Success)
+        {
+            _showPreviewModal = false;
+            var msg = !string.IsNullOrEmpty(result.Error)
+                ? string.Format(L["ClassifyErrorPrefix"], result.Error)
+                : L["ClassifyToastRequestFailed"].Value;
+            Notifications.Add(msg, NotificationSeverity.Error);
             StateHasChanged();
             return;
         }
@@ -439,6 +463,7 @@ else if (_message is not null)
     private async Task OpenApplyConfirmAsync()
     {
         CloseModals();
+        var gen = ++_classifyGeneration;
         _lastResult = null;
         _classifyInProgress = true;
         _showApplyConfirm = true;
@@ -446,11 +471,26 @@ else if (_message is not null)
 
         // Run a dry-run first so the user can see what will be applied.
         var result = await ClassifyAsync(dryRun: true);
+
+        if (gen != _classifyGeneration)
+            return;
+
         _classifyInProgress = false;
 
         if (result is null)
         {
             Notifications.Add(L["ClassifyToastRequestFailed"], NotificationSeverity.Error);
+            StateHasChanged();
+            return;
+        }
+
+        if (!result.Success)
+        {
+            _showApplyConfirm = false;
+            var msg = !string.IsNullOrEmpty(result.Error)
+                ? string.Format(L["ClassifyErrorPrefix"], result.Error)
+                : L["ClassifyToastRequestFailed"].Value;
+            Notifications.Add(msg, NotificationSeverity.Error);
             StateHasChanged();
             return;
         }
@@ -488,6 +528,24 @@ else if (_message is not null)
                 ? string.Format(L["ClassifyErrorPrefix"], e)
                 : L["ClassifyToastRequestFailed"].Value;
             Notifications.Add(msg, NotificationSeverity.Error);
+            return;
+        }
+
+        // Success can come back without an actual apply — e.g. the user had no rules/labels
+        // configured, so the service returned empty-labels-skipped. Route that to the help
+        // dialog instead of misleading the user with "applied".
+        if (!result.Applied)
+        {
+            CloseModals();
+            if (IsNoRulesResponse(result))
+            {
+                _showNoRulesModal = true;
+                StateHasChanged();
+            }
+            else
+            {
+                Notifications.Add(L["ClassifyToastRequestFailed"], NotificationSeverity.Warning);
+            }
             return;
         }
 
@@ -536,9 +594,10 @@ else if (_message is not null)
         if (_message is null)
             return null;
 
-        // Match case-insensitively against labels that the message already carries — the
-        // classify endpoint normalizes label names to lowercase, but message labels keep
-        // their original casing.
+        // Match case-insensitively against labels already on the message. Both the
+        // classify endpoint output and the stored label names are normalized to lowercase
+        // (see LabelEndpoints create/update), so an exact compare would also work — the
+        // case-insensitive compare is defensive against legacy or imported data.
         var match = _message.Labels.FirstOrDefault(
             l => string.Equals(l.Name, labelName, StringComparison.OrdinalIgnoreCase));
         return match?.Color;

--- a/src/Feirb.Web/Pages/Showcase/ShowcaseDropdownButton.razor
+++ b/src/Feirb.Web/Pages/Showcase/ShowcaseDropdownButton.razor
@@ -1,0 +1,110 @@
+@using Feirb.Web.Components.UI
+@inject IJSRuntime JS
+
+<InfoHeader Title="DropdownButton" Icon="caret-down-square" Subtitle="Trigger button that opens a small action menu on click" />
+
+<Card Class="mb-3 p-4">
+    <Heading Level="HeadingLevel.Small">Info</Heading>
+    <p>A trigger button (with optional icon and label) that reveals a list of action items below it. Use it whenever a single action would have multiple closely-related variants (e.g. <em>Preview</em> vs <em>Apply</em>) and you want to keep the toolbar/page header compact.</p>
+    <p class="text-muted mb-0">The menu closes on outside click, Escape, or after an item is selected. Selecting a disabled item is a no-op.</p>
+    <Table Size="TableSize.Small" Class="mt-3">
+        <TableHeader>
+            <TableColumn>Parameter</TableColumn>
+            <TableColumn>Type</TableColumn>
+            <TableColumn>Default</TableColumn>
+            <TableColumn>Description</TableColumn>
+        </TableHeader>
+        <TableBody>
+            <TableRow><TableCell><code>Label</code></TableCell><TableCell><code>string?</code></TableCell><TableCell><code>null</code></TableCell><TableCell>Text on the trigger button</TableCell></TableRow>
+            <TableRow><TableCell><code>Icon</code></TableCell><TableCell><code>string?</code></TableCell><TableCell><code>null</code></TableCell><TableCell>Bootstrap Icon name on the trigger</TableCell></TableRow>
+            <TableRow><TableCell><code>Variant</code></TableCell><TableCell><code>ButtonVariant</code></TableCell><TableCell><code>Primary</code></TableCell><TableCell>Trigger button variant</TableCell></TableRow>
+            <TableRow><TableCell><code>Size</code></TableCell><TableCell><code>ButtonSize</code></TableCell><TableCell><code>Medium</code></TableCell><TableCell>Trigger button size</TableCell></TableRow>
+            <TableRow><TableCell><code>Disabled</code></TableCell><TableCell><code>bool</code></TableCell><TableCell><code>false</code></TableCell><TableCell>Disables the trigger and prevents the menu from opening</TableCell></TableRow>
+            <TableRow><TableCell><code>Items</code></TableCell><TableCell><code>IReadOnlyList&lt;DropdownButtonItem&gt;</code></TableCell><TableCell>&#8212;</TableCell><TableCell>Menu items</TableCell></TableRow>
+            <TableRow><TableCell><code>TestId</code></TableCell><TableCell><code>string?</code></TableCell><TableCell><code>null</code></TableCell><TableCell><code>data-testid</code> on the trigger button</TableCell></TableRow>
+            <TableRow><TableCell><code>MenuTestId</code></TableCell><TableCell><code>string?</code></TableCell><TableCell><code>null</code></TableCell><TableCell><code>data-testid</code> on the menu container</TableCell></TableRow>
+        </TableBody>
+    </Table>
+</Card>
+
+<Card Class="mb-3 p-4">
+    <Heading Level="HeadingLevel.Small">Preview</Heading>
+    <div class="d-flex flex-wrap align-items-center gap-3 mb-3">
+        <label class="form-label mb-0">Variant:</label>
+        <select class="form-select form-select-sm w-auto" @bind="_variant">
+            <option value="@ButtonVariant.Primary">Primary</option>
+            <option value="@ButtonVariant.Secondary">Secondary</option>
+            <option value="@ButtonVariant.Danger">Danger</option>
+            <option value="@ButtonVariant.Warning">Warning</option>
+        </select>
+        <label class="form-label mb-0">Size:</label>
+        <select class="form-select form-select-sm w-auto" @bind="_size">
+            <option value="@ButtonSize.Small">Small</option>
+            <option value="@ButtonSize.Medium">Medium</option>
+            <option value="@ButtonSize.Large">Large</option>
+        </select>
+        <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="ddDisabled" @bind="_disabled" />
+            <label class="form-check-label" for="ddDisabled">Disabled</label>
+        </div>
+    </div>
+    <div class="showcase-preview-area">
+        <DropdownButton Label="Classify"
+                        Icon="magic"
+                        Variant="@_variant"
+                        Size="@_size"
+                        Disabled="@_disabled"
+                        Items="_items" />
+        <p class="text-muted mt-3 mb-0">Last action: <strong>@_lastAction</strong></p>
+    </div>
+</Card>
+
+<Card Class="p-4">
+    <Heading Level="HeadingLevel.Small">Code</Heading>
+    <pre><code class="language-xml" @ref="_codeElement"></code></pre>
+</Card>
+
+@code {
+    private ButtonVariant _variant = ButtonVariant.Primary;
+    private ButtonSize _size = ButtonSize.Medium;
+    private bool _disabled;
+    private string _lastAction = "(none)";
+    private ElementReference _codeElement;
+
+    private IReadOnlyList<DropdownButtonItem> _items = [];
+
+    protected override void OnInitialized()
+    {
+        _items =
+        [
+            new("Preview", EventCallback.Factory.Create(this, () => _lastAction = "Preview"), Icon: "eye"),
+            new("Apply Now", EventCallback.Factory.Create(this, () => _lastAction = "Apply Now"), Icon: "check-lg"),
+        ];
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        try { await JS.InvokeVoidAsync("highlightCode", _codeElement, CurrentCode); }
+        catch (JSException) { }
+    }
+
+    private string CurrentCode
+    {
+        get
+        {
+            var attrs = " Label=\"Classify\" Icon=\"magic\"";
+            if (_variant != ButtonVariant.Primary) attrs += $" Variant=\"ButtonVariant.{_variant}\"";
+            if (_size != ButtonSize.Medium) attrs += $" Size=\"ButtonSize.{_size}\"";
+            if (_disabled) attrs += " Disabled=\"true\"";
+            return "<DropdownButton" + attrs + " Items=\"_items\" />\n" +
+                   "\n" +
+                   "@code {\n" +
+                   "    private IReadOnlyList<DropdownButtonItem> _items =\n" +
+                   "    [\n" +
+                   "        new(\"Preview\", EventCallback.Factory.Create(this, OnPreview), Icon: \"eye\"),\n" +
+                   "        new(\"Apply Now\", EventCallback.Factory.Create(this, OnApply), Icon: \"check-lg\"),\n" +
+                   "    ];\n" +
+                   "}";
+        }
+    }
+}

--- a/src/Feirb.Web/Resources/SharedResources.de-DE.resx
+++ b/src/Feirb.Web/Resources/SharedResources.de-DE.resx
@@ -1857,4 +1857,67 @@
   <data name="ClassificationNotClassified" xml:space="preserve">
     <value>Nicht klassifiziert</value>
   </data>
+  <data name="ClassifyToolbarLabel" xml:space="preserve">
+    <value>Klassifizieren</value>
+  </data>
+  <data name="ClassifyMenuPreview" xml:space="preserve">
+    <value>Vorschau</value>
+  </data>
+  <data name="ClassifyMenuApplyNow" xml:space="preserve">
+    <value>Jetzt anwenden</value>
+  </data>
+  <data name="ClassifyPreviewTitle" xml:space="preserve">
+    <value>Klassifizierungs-Vorschau</value>
+  </data>
+  <data name="ClassifyApplyTitle" xml:space="preserve">
+    <value>Klassifizierung anwenden</value>
+  </data>
+  <data name="ClassifyNoRulesTitle" xml:space="preserve">
+    <value>Keine Klassifizierungsregeln</value>
+  </data>
+  <data name="ClassifyNoRulesMessage" xml:space="preserve">
+    <value>Keine Klassifizierungsregeln konfiguriert. Erstelle Regeln unter Einstellungen &gt; Klassifizierung.</value>
+  </data>
+  <data name="ClassifyNoRulesGoToSettings" xml:space="preserve">
+    <value>Zu den Klassifizierungs-Einstellungen</value>
+  </data>
+  <data name="ClassifyApplyConfirmWithLabels" xml:space="preserve">
+    <value>Folgende Labels werden angewendet:</value>
+  </data>
+  <data name="ClassifyApplyConfirmEmpty" xml:space="preserve">
+    <value>Der Klassifizierer hat keine Labels gefunden. Trotzdem anwenden, um diese Mail als klassifiziert zu markieren?</value>
+  </data>
+  <data name="ClassifyPreviewNoLabels" xml:space="preserve">
+    <value>Keine Labels passend.</value>
+  </data>
+  <data name="ClassifyPreviewLabelsHeading" xml:space="preserve">
+    <value>Erkannte Labels</value>
+  </data>
+  <data name="ClassifyPreviewSystemPromptHeading" xml:space="preserve">
+    <value>System-Prompt</value>
+  </data>
+  <data name="ClassifyPreviewUserPromptHeading" xml:space="preserve">
+    <value>User-Prompt</value>
+  </data>
+  <data name="ClassifyPreviewRawResponseHeading" xml:space="preserve">
+    <value>Roh-Antwort vom LLM</value>
+  </data>
+  <data name="ClassifyErrorPrefix" xml:space="preserve">
+    <value>Fehler: {0}</value>
+  </data>
+  <data name="ClassifyToastApplied" xml:space="preserve">
+    <value>Klassifizierung angewendet.</value>
+  </data>
+  <data name="ClassifyToastRequestFailed" xml:space="preserve">
+    <value>Die Nachricht konnte nicht klassifiziert werden. Bitte erneut versuchen.</value>
+  </data>
+  <data name="ClassifyButtonClose" xml:space="preserve">
+    <value>Schließen</value>
+  </data>
+  <data name="ClassifyButtonApply" xml:space="preserve">
+    <value>Anwenden</value>
+  </data>
+  <data name="ClassifyServiceUnavailable" xml:space="preserve">
+    <value>KI-Dienst nicht verfügbar. Bitte später erneut versuchen.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
+++ b/src/Feirb.Web/Resources/SharedResources.fr-FR.resx
@@ -1857,4 +1857,67 @@
   <data name="ClassificationNotClassified" xml:space="preserve">
     <value>Non classé</value>
   </data>
+  <data name="ClassifyToolbarLabel" xml:space="preserve">
+    <value>Classer</value>
+  </data>
+  <data name="ClassifyMenuPreview" xml:space="preserve">
+    <value>Aperçu</value>
+  </data>
+  <data name="ClassifyMenuApplyNow" xml:space="preserve">
+    <value>Appliquer maintenant</value>
+  </data>
+  <data name="ClassifyPreviewTitle" xml:space="preserve">
+    <value>Aperçu de la classification</value>
+  </data>
+  <data name="ClassifyApplyTitle" xml:space="preserve">
+    <value>Appliquer la classification</value>
+  </data>
+  <data name="ClassifyNoRulesTitle" xml:space="preserve">
+    <value>Aucune règle de classification</value>
+  </data>
+  <data name="ClassifyNoRulesMessage" xml:space="preserve">
+    <value>Aucune règle de classification configurée. Créez des règles dans Paramètres &gt; Classification.</value>
+  </data>
+  <data name="ClassifyNoRulesGoToSettings" xml:space="preserve">
+    <value>Aller aux paramètres de classification</value>
+  </data>
+  <data name="ClassifyApplyConfirmWithLabels" xml:space="preserve">
+    <value>Les libellés suivants seront appliqués :</value>
+  </data>
+  <data name="ClassifyApplyConfirmEmpty" xml:space="preserve">
+    <value>Le classifieur n'a trouvé aucun libellé. Appliquer quand même pour marquer ce message comme classé ?</value>
+  </data>
+  <data name="ClassifyPreviewNoLabels" xml:space="preserve">
+    <value>Aucun libellé correspondant.</value>
+  </data>
+  <data name="ClassifyPreviewLabelsHeading" xml:space="preserve">
+    <value>Libellés reconnus</value>
+  </data>
+  <data name="ClassifyPreviewSystemPromptHeading" xml:space="preserve">
+    <value>Prompt système</value>
+  </data>
+  <data name="ClassifyPreviewUserPromptHeading" xml:space="preserve">
+    <value>Prompt utilisateur</value>
+  </data>
+  <data name="ClassifyPreviewRawResponseHeading" xml:space="preserve">
+    <value>Réponse brute du LLM</value>
+  </data>
+  <data name="ClassifyErrorPrefix" xml:space="preserve">
+    <value>Erreur : {0}</value>
+  </data>
+  <data name="ClassifyToastApplied" xml:space="preserve">
+    <value>Classification appliquée.</value>
+  </data>
+  <data name="ClassifyToastRequestFailed" xml:space="preserve">
+    <value>Impossible de classer le message. Veuillez réessayer.</value>
+  </data>
+  <data name="ClassifyButtonClose" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
+  <data name="ClassifyButtonApply" xml:space="preserve">
+    <value>Appliquer</value>
+  </data>
+  <data name="ClassifyServiceUnavailable" xml:space="preserve">
+    <value>Service IA indisponible. Veuillez réessayer plus tard.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.it-IT.resx
+++ b/src/Feirb.Web/Resources/SharedResources.it-IT.resx
@@ -1857,4 +1857,67 @@
   <data name="ClassificationNotClassified" xml:space="preserve">
     <value>Non classificata</value>
   </data>
+  <data name="ClassifyToolbarLabel" xml:space="preserve">
+    <value>Classifica</value>
+  </data>
+  <data name="ClassifyMenuPreview" xml:space="preserve">
+    <value>Anteprima</value>
+  </data>
+  <data name="ClassifyMenuApplyNow" xml:space="preserve">
+    <value>Applica ora</value>
+  </data>
+  <data name="ClassifyPreviewTitle" xml:space="preserve">
+    <value>Anteprima classificazione</value>
+  </data>
+  <data name="ClassifyApplyTitle" xml:space="preserve">
+    <value>Applica classificazione</value>
+  </data>
+  <data name="ClassifyNoRulesTitle" xml:space="preserve">
+    <value>Nessuna regola di classificazione</value>
+  </data>
+  <data name="ClassifyNoRulesMessage" xml:space="preserve">
+    <value>Nessuna regola di classificazione configurata. Crea regole in Impostazioni &gt; Classificazione.</value>
+  </data>
+  <data name="ClassifyNoRulesGoToSettings" xml:space="preserve">
+    <value>Vai alle impostazioni di classificazione</value>
+  </data>
+  <data name="ClassifyApplyConfirmWithLabels" xml:space="preserve">
+    <value>Verranno applicate le seguenti etichette:</value>
+  </data>
+  <data name="ClassifyApplyConfirmEmpty" xml:space="preserve">
+    <value>Il classificatore non ha trovato etichette. Applicare comunque per contrassegnare questo messaggio come classificato?</value>
+  </data>
+  <data name="ClassifyPreviewNoLabels" xml:space="preserve">
+    <value>Nessuna etichetta corrispondente.</value>
+  </data>
+  <data name="ClassifyPreviewLabelsHeading" xml:space="preserve">
+    <value>Etichette riconosciute</value>
+  </data>
+  <data name="ClassifyPreviewSystemPromptHeading" xml:space="preserve">
+    <value>Prompt di sistema</value>
+  </data>
+  <data name="ClassifyPreviewUserPromptHeading" xml:space="preserve">
+    <value>Prompt utente</value>
+  </data>
+  <data name="ClassifyPreviewRawResponseHeading" xml:space="preserve">
+    <value>Risposta grezza dell'LLM</value>
+  </data>
+  <data name="ClassifyErrorPrefix" xml:space="preserve">
+    <value>Errore: {0}</value>
+  </data>
+  <data name="ClassifyToastApplied" xml:space="preserve">
+    <value>Classificazione applicata.</value>
+  </data>
+  <data name="ClassifyToastRequestFailed" xml:space="preserve">
+    <value>Impossibile classificare il messaggio. Riprovare.</value>
+  </data>
+  <data name="ClassifyButtonClose" xml:space="preserve">
+    <value>Chiudi</value>
+  </data>
+  <data name="ClassifyButtonApply" xml:space="preserve">
+    <value>Applica</value>
+  </data>
+  <data name="ClassifyServiceUnavailable" xml:space="preserve">
+    <value>Servizio IA non disponibile. Riprova più tardi.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Resources/SharedResources.resx
+++ b/src/Feirb.Web/Resources/SharedResources.resx
@@ -1857,4 +1857,67 @@
   <data name="ClassificationNotClassified" xml:space="preserve">
     <value>Not classified</value>
   </data>
+  <data name="ClassifyToolbarLabel" xml:space="preserve">
+    <value>Classify</value>
+  </data>
+  <data name="ClassifyMenuPreview" xml:space="preserve">
+    <value>Preview</value>
+  </data>
+  <data name="ClassifyMenuApplyNow" xml:space="preserve">
+    <value>Apply Now</value>
+  </data>
+  <data name="ClassifyPreviewTitle" xml:space="preserve">
+    <value>Classification Preview</value>
+  </data>
+  <data name="ClassifyApplyTitle" xml:space="preserve">
+    <value>Apply Classification</value>
+  </data>
+  <data name="ClassifyNoRulesTitle" xml:space="preserve">
+    <value>No classification rules</value>
+  </data>
+  <data name="ClassifyNoRulesMessage" xml:space="preserve">
+    <value>No classification rules configured. Create rules in Settings &gt; Classification.</value>
+  </data>
+  <data name="ClassifyNoRulesGoToSettings" xml:space="preserve">
+    <value>Go to Classification Settings</value>
+  </data>
+  <data name="ClassifyApplyConfirmWithLabels" xml:space="preserve">
+    <value>The following labels will be applied:</value>
+  </data>
+  <data name="ClassifyApplyConfirmEmpty" xml:space="preserve">
+    <value>The classifier did not match any labels. Apply anyway to mark this mail as classified?</value>
+  </data>
+  <data name="ClassifyPreviewNoLabels" xml:space="preserve">
+    <value>No labels matched.</value>
+  </data>
+  <data name="ClassifyPreviewLabelsHeading" xml:space="preserve">
+    <value>Recognized Labels</value>
+  </data>
+  <data name="ClassifyPreviewSystemPromptHeading" xml:space="preserve">
+    <value>System Prompt</value>
+  </data>
+  <data name="ClassifyPreviewUserPromptHeading" xml:space="preserve">
+    <value>User Prompt</value>
+  </data>
+  <data name="ClassifyPreviewRawResponseHeading" xml:space="preserve">
+    <value>Raw LLM Response</value>
+  </data>
+  <data name="ClassifyErrorPrefix" xml:space="preserve">
+    <value>Error: {0}</value>
+  </data>
+  <data name="ClassifyToastApplied" xml:space="preserve">
+    <value>Classification applied.</value>
+  </data>
+  <data name="ClassifyToastRequestFailed" xml:space="preserve">
+    <value>Could not classify the message. Please try again.</value>
+  </data>
+  <data name="ClassifyButtonClose" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="ClassifyButtonApply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="ClassifyServiceUnavailable" xml:space="preserve">
+    <value>AI service unavailable. Try again later.</value>
+  </data>
 </root>

--- a/src/Feirb.Web/Services/ToolbarStateService.cs
+++ b/src/Feirb.Web/Services/ToolbarStateService.cs
@@ -10,17 +10,47 @@ public sealed class ToolbarAction(string label, ButtonVariant variant, Func<Task
     public string? Icon { get; } = icon;
 }
 
+/// <summary>
+/// A dropdown-style toolbar entry that opens a small action menu when clicked.
+/// Items are <see cref="DropdownButtonItem"/> instances. Use this when a single
+/// toolbar action has two or three closely-related variants (e.g. "Preview" /
+/// "Apply Now") and you don't want to spend extra space on multiple buttons.
+/// </summary>
+public sealed class ToolbarDropdownAction(
+    string label,
+    ButtonVariant variant,
+    IReadOnlyList<DropdownButtonItem> items,
+    string? icon = null,
+    string? testId = null,
+    string? menuTestId = null)
+{
+    public string Label { get; } = label;
+    public ButtonVariant Variant { get; } = variant;
+    public IReadOnlyList<DropdownButtonItem> Items { get; } = items;
+    public string? Icon { get; } = icon;
+    public string? TestId { get; } = testId;
+    public string? MenuTestId { get; } = menuTestId;
+}
+
 public sealed class ToolbarStateService
 {
     private readonly List<ToolbarAction> _actions = [];
+    private readonly List<ToolbarDropdownAction> _dropdownActions = [];
 
     public IReadOnlyList<ToolbarAction> Actions => _actions;
+    public IReadOnlyList<ToolbarDropdownAction> DropdownActions => _dropdownActions;
 
     public event Action? OnChange;
 
     public void AddActions(IEnumerable<ToolbarAction> actions)
     {
         _actions.AddRange(actions);
+        OnChange?.Invoke();
+    }
+
+    public void AddDropdownActions(IEnumerable<ToolbarDropdownAction> actions)
+    {
+        _dropdownActions.AddRange(actions);
         OnChange?.Invoke();
     }
 
@@ -39,12 +69,28 @@ public sealed class ToolbarStateService
         }
     }
 
+    public void RemoveDropdownActions(IEnumerable<ToolbarDropdownAction> actions)
+    {
+        ArgumentNullException.ThrowIfNull(actions);
+        var changed = false;
+        foreach (var action in actions)
+        {
+            changed |= _dropdownActions.Remove(action);
+        }
+
+        if (changed)
+        {
+            OnChange?.Invoke();
+        }
+    }
+
     public void Clear()
     {
-        if (_actions.Count == 0)
+        if (_actions.Count == 0 && _dropdownActions.Count == 0)
             return;
 
         _actions.Clear();
+        _dropdownActions.Clear();
         OnChange?.Invoke();
     }
 }

--- a/src/Feirb.Web/wwwroot/css/app.css
+++ b/src/Feirb.Web/wwwroot/css/app.css
@@ -248,6 +248,77 @@ a:hover, .btn-link:hover {
     padding: 1rem;
 }
 
+/* Classify Preview prompt blocks */
+.feirb-prompt-pre {
+    background-color: var(--feirb-surface-container);
+    border: 1px solid var(--feirb-border-color);
+    border-radius: 0.5rem;
+    padding: 0.75rem 1rem;
+    font-size: 0.8125rem;
+    line-height: 1.4;
+    max-height: 16rem;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--feirb-on-surface);
+}
+
+/* Dropdown Button */
+.feirb-dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.feirb-dropdown-caret {
+    margin-left: 0.4rem;
+    transition: transform 0.15s ease;
+}
+
+.feirb-dropdown.open .feirb-dropdown-caret {
+    transform: rotate(180deg);
+}
+
+.feirb-dropdown-menu {
+    position: absolute;
+    top: calc(100% + 0.25rem);
+    right: 0;
+    min-width: 12rem;
+    background-color: var(--feirb-surface);
+    border: 1px solid var(--feirb-border-color);
+    border-radius: var(--bs-border-radius);
+    box-shadow: var(--feirb-shadow);
+    padding: 0.25rem;
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+}
+
+.feirb-dropdown-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.5rem 0.75rem;
+    border: none;
+    background: transparent;
+    color: var(--feirb-on-surface);
+    text-align: left;
+    font-size: 0.9375rem;
+    border-radius: calc(var(--bs-border-radius) - 0.5rem);
+    cursor: pointer;
+    width: 100%;
+}
+
+.feirb-dropdown-menu-item:hover:not(:disabled),
+.feirb-dropdown-menu-item:focus-visible:not(:disabled) {
+    background-color: var(--feirb-primary-container, var(--feirb-surface-container));
+    outline: none;
+}
+
+.feirb-dropdown-menu-item:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 /* Toggle Button Group */
 .feirb-toggle-group {
     display: inline-grid;

--- a/src/Feirb.Web/wwwroot/index.html
+++ b/src/Feirb.Web/wwwroot/index.html
@@ -59,6 +59,7 @@
     <script src="js/quill-interop.js"></script>
     <script src="js/toast-interop.js"></script>
     <script src="js/recipient-interop.js"></script>
+    <script src="js/dropdown-interop.js"></script>
     <script src="js/viewport.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>

--- a/src/Feirb.Web/wwwroot/js/dropdown-interop.js
+++ b/src/Feirb.Web/wwwroot/js/dropdown-interop.js
@@ -1,0 +1,26 @@
+// Closes a DropdownButton when the user clicks outside or presses Escape.
+// Returns a handle with a `detach()` method so .NET can clean up.
+window.feirbDropdown = {
+    attach: function (rootElement, dotNetRef) {
+        const onPointerDown = function (e) {
+            if (rootElement && !rootElement.contains(e.target)) {
+                dotNetRef.invokeMethodAsync('CloseAsync');
+            }
+        };
+        const onKeyDown = function (e) {
+            if (e.key === 'Escape') {
+                dotNetRef.invokeMethodAsync('CloseAsync');
+            }
+        };
+
+        document.addEventListener('pointerdown', onPointerDown, true);
+        document.addEventListener('keydown', onKeyDown, true);
+
+        return {
+            detach: function () {
+                document.removeEventListener('pointerdown', onPointerDown, true);
+                document.removeEventListener('keydown', onKeyDown, true);
+            }
+        };
+    }
+};

--- a/src/Feirb.Web/wwwroot/js/dropdown-interop.js
+++ b/src/Feirb.Web/wwwroot/js/dropdown-interop.js
@@ -2,14 +2,30 @@
 // Returns a handle with a `detach()` method so .NET can clean up.
 window.feirbDropdown = {
     attach: function (rootElement, dotNetRef) {
+        const safeClose = function () {
+            if (!dotNetRef) {
+                return;
+            }
+            try {
+                const promise = dotNetRef.invokeMethodAsync('CloseAsync');
+                if (promise && typeof promise.catch === 'function') {
+                    // Component disposed or circuit dropped — swallow silently to
+                    // avoid unhandled-promise-rejection noise in the browser console.
+                    promise.catch(function () { });
+                }
+            } catch (e) {
+                // dotNetRef may have been revoked already.
+            }
+        };
+
         const onPointerDown = function (e) {
             if (rootElement && !rootElement.contains(e.target)) {
-                dotNetRef.invokeMethodAsync('CloseAsync');
+                safeClose();
             }
         };
         const onKeyDown = function (e) {
             if (e.key === 'Escape') {
-                dotNetRef.invokeMethodAsync('CloseAsync');
+                safeClose();
             }
         };
 

--- a/tests/Feirb.Api.Tests/Endpoints/MessageEndpointsTests.cs
+++ b/tests/Feirb.Api.Tests/Endpoints/MessageEndpointsTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using Feirb.Api.Data;
 using Feirb.Api.Data.Entities;
+using Feirb.Api.Services;
 using Feirb.Shared.Auth;
 using Feirb.Shared.Mail;
 using Feirb.Shared.Settings;
@@ -16,12 +17,20 @@ namespace Feirb.Api.Tests.Endpoints;
 
 public class MessageEndpointsTests : IDisposable
 {
-    private readonly WebApplicationFactory<Program> _factory;
-    private readonly HttpClient _client;
+    private WebApplicationFactory<Program> _factory;
+    private HttpClient _client;
 
     public MessageEndpointsTests()
     {
         _factory = TestWebApplicationFactory.Create($"TestDb-{Guid.NewGuid()}");
+        _client = _factory.CreateClient();
+    }
+
+    private void RecreateFactoryWith(IClassificationService overrideService)
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        _factory = TestWebApplicationFactory.Create($"TestDb-{Guid.NewGuid()}", overrideService);
         _client = _factory.CreateClient();
     }
 
@@ -428,6 +437,290 @@ public class MessageEndpointsTests : IDisposable
             ClassifiedAt = DateTimeOffset.UtcNow,
         });
         await db.SaveChangesAsync();
+    }
+
+    // --- Classify endpoint tests ---
+
+    [Fact]
+    public async Task ClassifyMessage_Unauthenticated_ReturnsUnauthorizedAsync()
+    {
+        var response = await _client.PostAsync($"/api/mail/messages/{Guid.NewGuid()}/classify", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ClassifyMessage_NotFound_Returns404Async()
+    {
+        var tokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+        var response = await _client.PostAsync($"/api/mail/messages/{Guid.NewGuid()}/classify?dryRun=true", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ClassifyMessage_OtherUserMessage_Returns404Async()
+    {
+        var stub = new StubClassificationService(
+            new ClassificationDetailedResult(true, """["work"]""", null,
+                new ClassificationPrompt("sys", "user"), """["work"]"""));
+        RecreateFactoryWith(stub);
+
+        var adminTokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminTokens.AccessToken);
+
+        var mailboxId = await CreateMailboxAsync("Admin Box", "admin@test.com");
+        var ids = await SeedMessagesAsync(mailboxId, [("Hello", "from@test.com", DateTimeOffset.UtcNow)]);
+
+        await _client.PostAsJsonAsync("/api/auth/register", new RegisterRequest("user4", "user4@test.com", "Password123!"));
+        var loginResponse = await _client.PostAsJsonAsync("/api/auth/login", new LoginRequest("user4", "Password123!"));
+        var userTokens = await loginResponse.Content.ReadFromJsonAsync<TokenResponse>();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", userTokens!.AccessToken);
+
+        var response = await _client.PostAsync($"/api/mail/messages/{ids[0]}/classify?dryRun=true", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ClassifyMessage_DryRunDefault_ReturnsPreviewWithPromptAndRawResponseAsync()
+    {
+        var stub = new StubClassificationService(
+            new ClassificationDetailedResult(
+                Success: true,
+                Result: """["work","newsletter"]""",
+                Error: null,
+                Prompt: new ClassificationPrompt("system-prompt", "user-prompt"),
+                RawResponse: """["work","newsletter"]"""));
+        RecreateFactoryWith(stub);
+
+        var tokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+        var mailboxId = await CreateMailboxAsync("Test", "test@test.com");
+        var ids = await SeedMessagesAsync(mailboxId, [("Subject", "from@test.com", DateTimeOffset.UtcNow)]);
+
+        var response = await _client.PostAsync($"/api/mail/messages/{ids[0]}/classify", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<ClassifyMessageResponse>();
+        body.Should().NotBeNull();
+        body!.Success.Should().BeTrue();
+        body.Applied.Should().BeFalse();
+        body.Labels.Should().BeEquivalentTo(new[] { "work", "newsletter" });
+        body.Error.Should().BeNull();
+        body.Prompt.Should().NotBeNull();
+        body.Prompt!.System.Should().Be("system-prompt");
+        body.Prompt.User.Should().Be("user-prompt");
+        body.RawResponse.Should().Be("""["work","newsletter"]""");
+
+        // No ClassificationResult should have been persisted
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<FeirbDbContext>();
+        (await db.ClassificationResults.AnyAsync(r => r.CachedMessageId == ids[0])).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ClassifyMessage_ApplyMode_AppliesLabelsAndPersistsResultAsync()
+    {
+        var stub = new StubClassificationService(
+            new ClassificationDetailedResult(
+                Success: true,
+                Result: """["work"]""",
+                Error: null,
+                Prompt: new ClassificationPrompt("sys", "user"),
+                RawResponse: """["work"]"""));
+        RecreateFactoryWith(stub);
+
+        var tokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+        var mailboxId = await CreateMailboxAsync("Test", "test@test.com");
+        var ids = await SeedMessagesAsync(mailboxId, [("Subject", "from@test.com", DateTimeOffset.UtcNow)]);
+        await SeedLabelsForCurrentUserAsync(("work", "#FF0000"), ("personal", "#00FF00"));
+
+        var response = await _client.PostAsync($"/api/mail/messages/{ids[0]}/classify?dryRun=false", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<ClassifyMessageResponse>();
+        body!.Success.Should().BeTrue();
+        body.Applied.Should().BeTrue();
+        body.Labels.Should().BeEquivalentTo(new[] { "work" });
+        body.Prompt.Should().BeNull();
+        body.RawResponse.Should().BeNull();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<FeirbDbContext>();
+        var msg = await db.CachedMessages.Include(m => m.Labels).FirstAsync(m => m.Id == ids[0]);
+        msg.Labels.Should().ContainSingle().Which.Name.Should().Be("work");
+        (await db.ClassificationResults.AnyAsync(r => r.CachedMessageId == ids[0])).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ClassifyMessage_ApplyMode_RemovesQueueItemAsync()
+    {
+        var stub = new StubClassificationService(
+            new ClassificationDetailedResult(true, """["work"]""", null,
+                new ClassificationPrompt("sys", "user"), """["work"]"""));
+        RecreateFactoryWith(stub);
+
+        var tokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+        var mailboxId = await CreateMailboxAsync("Test", "test@test.com");
+        var ids = await SeedMessagesAsync(mailboxId, [("Subject", "from@test.com", DateTimeOffset.UtcNow)]);
+        await SeedLabelsForCurrentUserAsync(("work", "#FF0000"));
+        await SeedQueueItemAsync(ids[0], ClassificationQueueItemStatus.Failed);
+
+        var response = await _client.PostAsync($"/api/mail/messages/{ids[0]}/classify?dryRun=false", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<FeirbDbContext>();
+        (await db.ClassificationQueueItems.AnyAsync(q => q.CachedMessageId == ids[0])).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ClassifyMessage_NoRulesOrLabels_ReturnsEmptyLabelsAsync()
+    {
+        var stub = new StubClassificationService(ClassificationDetailedResult.Skipped);
+        RecreateFactoryWith(stub);
+
+        var tokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+        var mailboxId = await CreateMailboxAsync("Test", "test@test.com");
+        var ids = await SeedMessagesAsync(mailboxId, [("Subject", "from@test.com", DateTimeOffset.UtcNow)]);
+
+        var response = await _client.PostAsync($"/api/mail/messages/{ids[0]}/classify?dryRun=true", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<ClassifyMessageResponse>();
+        body!.Success.Should().BeTrue();
+        body.Labels.Should().BeEmpty();
+        body.Applied.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ClassifyMessage_AiUnavailable_ReturnsSkippedAsync()
+    {
+        // Service-level skipped (HttpRequestException etc.) is surfaced with success=true and empty labels
+        var stub = new StubClassificationService(ClassificationDetailedResult.Skipped);
+        RecreateFactoryWith(stub);
+
+        var tokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+        var mailboxId = await CreateMailboxAsync("Test", "test@test.com");
+        var ids = await SeedMessagesAsync(mailboxId, [("Subject", "from@test.com", DateTimeOffset.UtcNow)]);
+
+        var response = await _client.PostAsync($"/api/mail/messages/{ids[0]}/classify?dryRun=false", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<ClassifyMessageResponse>();
+        body!.Success.Should().BeTrue();
+        body.Labels.Should().BeEmpty();
+        body.Applied.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ClassifyMessage_HardFailure_ReturnsErrorAsync()
+    {
+        var stub = new StubClassificationService(
+            new ClassificationDetailedResult(
+                Success: false,
+                Result: null,
+                Error: "Failed to parse LLM response",
+                Prompt: new ClassificationPrompt("sys", "user"),
+                RawResponse: "garbage"));
+        RecreateFactoryWith(stub);
+
+        var tokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+        var mailboxId = await CreateMailboxAsync("Test", "test@test.com");
+        var ids = await SeedMessagesAsync(mailboxId, [("Subject", "from@test.com", DateTimeOffset.UtcNow)]);
+
+        var response = await _client.PostAsync($"/api/mail/messages/{ids[0]}/classify?dryRun=true", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<ClassifyMessageResponse>();
+        body!.Success.Should().BeFalse();
+        body.Error.Should().Contain("Failed to parse");
+        body.Labels.Should().BeEmpty();
+        body.Prompt.Should().NotBeNull();
+        body.RawResponse.Should().Be("garbage");
+    }
+
+    [Fact]
+    public async Task ClassifyMessage_AppliesLabelsAdditively_WhenAlreadyLabeledAsync()
+    {
+        var stub = new StubClassificationService(
+            new ClassificationDetailedResult(true, """["work"]""", null,
+                new ClassificationPrompt("sys", "user"), """["work"]"""));
+        RecreateFactoryWith(stub);
+
+        var tokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+        var mailboxId = await CreateMailboxAsync("Test", "test@test.com");
+        var ids = await SeedMessagesAsync(mailboxId, [("Subject", "from@test.com", DateTimeOffset.UtcNow)]);
+        await SeedLabelsForCurrentUserAsync(("work", "#FF0000"), ("existing", "#000000"));
+        await SeedLabelsOnMessageByNameAsync(ids[0], "existing");
+
+        var response = await _client.PostAsync($"/api/mail/messages/{ids[0]}/classify?dryRun=false", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<FeirbDbContext>();
+        var msg = await db.CachedMessages.Include(m => m.Labels).FirstAsync(m => m.Id == ids[0]);
+        msg.Labels.Select(l => l.Name).Should().BeEquivalentTo(new[] { "work", "existing" });
+    }
+
+    private async Task SeedLabelsForCurrentUserAsync(params (string Name, string Color)[] labels)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<FeirbDbContext>();
+        var user = await db.Users.FirstAsync();
+        foreach (var (name, color) in labels)
+        {
+            db.Labels.Add(new Label
+            {
+                Id = Guid.NewGuid(),
+                UserId = user.Id,
+                Name = name,
+                Color = color,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+        }
+
+        await db.SaveChangesAsync();
+    }
+
+    private async Task SeedLabelsOnMessageByNameAsync(Guid messageId, string labelName)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<FeirbDbContext>();
+        var message = await db.CachedMessages.Include(m => m.Labels).FirstAsync(m => m.Id == messageId);
+        var label = await db.Labels.FirstAsync(l => l.Name == labelName);
+        message.Labels.Add(label);
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class StubClassificationService(ClassificationDetailedResult result) : IClassificationService
+    {
+        public Task<ClassificationServiceResult> ClassifyAsync(CachedMessage message, CancellationToken cancellationToken = default) =>
+            Task.FromResult(result.IsSkipped
+                ? ClassificationServiceResult.Skipped
+                : new ClassificationServiceResult(result.Success, result.Result, result.Error));
+
+        public Task<ClassificationDetailedResult> ClassifyDetailedAsync(CachedMessage message, CancellationToken cancellationToken = default) =>
+            Task.FromResult(result);
     }
 
     private async Task<Guid> SeedMessageWithAttachmentAsync(Guid mailboxId)

--- a/tests/Feirb.Api.Tests/Endpoints/MessageEndpointsTests.cs
+++ b/tests/Feirb.Api.Tests/Endpoints/MessageEndpointsTests.cs
@@ -605,10 +605,13 @@ public class MessageEndpointsTests : IDisposable
     }
 
     [Fact]
-    public async Task ClassifyMessage_AiUnavailable_ReturnsSkippedAsync()
+    public async Task ClassifyMessage_AiUnavailable_ReturnsFailureAsync()
     {
-        // Service-level skipped (HttpRequestException etc.) is surfaced with success=true and empty labels
-        var stub = new StubClassificationService(ClassificationDetailedResult.Skipped);
+        // Backend unavailable (HttpRequestException / TaskCanceledException) must be
+        // distinguishable from "no rules configured" — surfaced as success=false with
+        // a localized error so the UI can show an error instead of help text.
+        var stub = new StubClassificationService(
+            ClassificationDetailedResult.BackendUnavailable("Classification service unavailable."));
         RecreateFactoryWith(stub);
 
         var tokens = await SetupAndLoginAsAdminAsync();
@@ -621,9 +624,10 @@ public class MessageEndpointsTests : IDisposable
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await response.Content.ReadFromJsonAsync<ClassifyMessageResponse>();
-        body!.Success.Should().BeTrue();
+        body!.Success.Should().BeFalse();
         body.Labels.Should().BeEmpty();
         body.Applied.Should().BeFalse();
+        body.Error.Should().NotBeNullOrEmpty();
     }
 
     [Fact]

--- a/tests/Feirb.Api.Tests/Feirb.Api.Tests.csproj
+++ b/tests/Feirb.Api.Tests/Feirb.Api.Tests.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/tests/Feirb.Api.Tests/Services/ClassificationJobTests.cs
+++ b/tests/Feirb.Api.Tests/Services/ClassificationJobTests.cs
@@ -311,6 +311,10 @@ public class ClassificationJobTests : IDisposable
         public Task<ClassificationServiceResult> ClassifyAsync(
             CachedMessage message, CancellationToken cancellationToken = default) =>
             Task.FromResult(new ClassificationServiceResult(true, """["TestLabel"]""", null));
+
+        public Task<ClassificationDetailedResult> ClassifyDetailedAsync(
+            CachedMessage message, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ClassificationDetailedResult(true, """["TestLabel"]""", null, null, null));
     }
 
     private sealed class FailingClassificationService : IClassificationService
@@ -318,6 +322,10 @@ public class ClassificationJobTests : IDisposable
         public Task<ClassificationServiceResult> ClassifyAsync(
             CachedMessage message, CancellationToken cancellationToken = default) =>
             Task.FromResult(new ClassificationServiceResult(false, null, "Classification failed"));
+
+        public Task<ClassificationDetailedResult> ClassifyDetailedAsync(
+            CachedMessage message, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ClassificationDetailedResult(false, null, "Classification failed", null, null));
     }
 
     private sealed class SkippingClassificationService : IClassificationService
@@ -325,6 +333,10 @@ public class ClassificationJobTests : IDisposable
         public Task<ClassificationServiceResult> ClassifyAsync(
             CachedMessage message, CancellationToken cancellationToken = default) =>
             Task.FromResult(ClassificationServiceResult.Skipped);
+
+        public Task<ClassificationDetailedResult> ClassifyDetailedAsync(
+            CachedMessage message, CancellationToken cancellationToken = default) =>
+            Task.FromResult(ClassificationDetailedResult.Skipped);
     }
 
     private sealed class EmptyArrayClassificationService : IClassificationService
@@ -332,5 +344,9 @@ public class ClassificationJobTests : IDisposable
         public Task<ClassificationServiceResult> ClassifyAsync(
             CachedMessage message, CancellationToken cancellationToken = default) =>
             Task.FromResult(new ClassificationServiceResult(true, "[]", null));
+
+        public Task<ClassificationDetailedResult> ClassifyDetailedAsync(
+            CachedMessage message, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ClassificationDetailedResult(true, "[]", null, null, null));
     }
 }

--- a/tests/Feirb.Api.Tests/Services/NoopClassificationServiceTests.cs
+++ b/tests/Feirb.Api.Tests/Services/NoopClassificationServiceTests.cs
@@ -7,7 +7,7 @@ namespace Feirb.Api.Tests.Services;
 public class NoopClassificationServiceTests
 {
     [Fact]
-    public async Task Classify_ReturnsSuccessWithPlaceholderResultAsync()
+    public async Task Classify_ReturnsSuccessWithEmptyLabelsArrayAsync()
     {
         var service = new NoopClassificationService();
         var message = new CachedMessage
@@ -25,7 +25,9 @@ public class NoopClassificationServiceTests
         var result = await service.ClassifyAsync(message);
 
         result.Success.Should().BeTrue();
-        result.Result.Should().Be("noop-classification");
+        // Must be a JSON array to match the contract ClassificationService enforces and
+        // that the classify endpoint persists into ClassificationResult.Result.
+        result.Result.Should().Be("[]");
         result.Error.Should().BeNull();
     }
 }

--- a/tests/Feirb.Api.Tests/TestWebApplicationFactory.cs
+++ b/tests/Feirb.Api.Tests/TestWebApplicationFactory.cs
@@ -2,6 +2,7 @@ using Feirb.Api.Data;
 using Feirb.Api.Services;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -11,11 +12,29 @@ namespace Feirb.Api.Tests;
 
 public static class TestWebApplicationFactory
 {
-    public static WebApplicationFactory<Program> Create(string dbName) =>
+    public static WebApplicationFactory<Program> Create(
+        string dbName,
+        IClassificationService? classificationServiceOverride = null) =>
         new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
         {
             builder.ConfigureServices(services =>
             {
+                if (classificationServiceOverride is not null)
+                {
+                    services.RemoveAll<IClassificationService>();
+                    services.AddScoped<IClassificationService>(_ => classificationServiceOverride);
+                }
+
+                // Replace IChatClient registrations (the Aspire/OllamaSharp client requires
+                // a real connection string that doesn't exist in tests). Tests that exercise
+                // classification provide their own IClassificationService stub above.
+                var chatClientDescriptors = services
+                    .Where(d => d.ServiceType == typeof(IChatClient))
+                    .ToList();
+                foreach (var d in chatClientDescriptors)
+                    services.Remove(d);
+                services.AddSingleton<IChatClient>(new NoopChatClient());
+
                 // Replace PostgreSQL with in-memory database
                 var dbDescriptors = services.Where(d =>
                     d.ServiceType == typeof(DbContextOptions<FeirbDbContext>) ||
@@ -47,6 +66,30 @@ public static class TestWebApplicationFactory
                 services.AddSingleton<ISchedulerFactory, NoOpSchedulerFactory>();
             });
         });
+
+    private sealed class NoopChatClient : IChatClient
+    {
+        public void Dispose() { }
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "[]")));
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            EmptyAsyncEnumerableAsync();
+
+        private static async IAsyncEnumerable<ChatResponseUpdate> EmptyAsyncEnumerableAsync()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
 
     private sealed class NoOpSchedulerFactory : ISchedulerFactory
     {

--- a/tests/bruno/05-mail/classify-message-not-found.bru
+++ b/tests/bruno/05-mail/classify-message-not-found.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Classify Message - Not Found
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/api/mail/messages/00000000-0000-0000-0000-000000000000/classify?dryRun=true
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+tests {
+  test("should return 404", function() {
+    expect(res.status).to.equal(404);
+  });
+}

--- a/tests/bruno/05-mail/classify-message-unauthorized.bru
+++ b/tests/bruno/05-mail/classify-message-unauthorized.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Classify Message - Unauthorized
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/api/mail/messages/00000000-0000-0000-0000-000000000000/classify
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 401", function() {
+    expect(res.status).to.equal(401);
+  });
+}

--- a/tests/playwright/tests/classify-message.spec.ts
+++ b/tests/playwright/tests/classify-message.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect } from "@playwright/test";
+
+const ADMIN_USERNAME = process.env.ADMIN_USERNAME ?? "admin-playwright";
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD ?? "TestPassword123!";
+
+async function login(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+
+  if (
+    page.url().includes("/login") ||
+    page.url().includes("/setup") ||
+    page.url().includes("/error")
+  ) {
+    await page.goto("/login");
+    await expect(page.locator("#username")).toBeVisible({ timeout: 10000 });
+    await page.locator("#username").fill(ADMIN_USERNAME);
+    await page.locator("#password").fill(ADMIN_PASSWORD);
+    await page.getByRole("button", { name: "Log In" }).click();
+    await expect(
+      page.getByLabel("breadcrumb").getByText("Dashboard"),
+    ).toBeVisible({ timeout: 15000 });
+  }
+}
+
+async function openFirstMessage(page: import("@playwright/test").Page) {
+  await page.goto("/mail/inbox");
+  await expect(page.locator(".spinner-border")).toBeHidden({ timeout: 10000 });
+
+  const firstCard = page.locator('[data-testid="mail-card"]').first();
+  await expect(firstCard).toBeVisible({ timeout: 10000 });
+  await firstCard.click();
+
+  await expect(page).toHaveURL(/\/mail\/inbox\/[0-9a-f-]+/);
+  await expect(page.locator(".spinner-border")).toBeHidden({ timeout: 10000 });
+}
+
+test.describe.serial("Classify single mail", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("toolbar exposes a Classify dropdown trigger", async ({ page }) => {
+    await openFirstMessage(page);
+
+    const trigger = page.locator('[data-testid="classify-dropdown"]');
+    await expect(trigger).toBeVisible();
+    await expect(trigger).toHaveAttribute("aria-haspopup", "menu");
+    await expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("clicking the Classify trigger opens a menu with Preview and Apply", async ({
+    page,
+  }) => {
+    await openFirstMessage(page);
+
+    await page.locator('[data-testid="classify-dropdown"]').click();
+
+    const menu = page.locator('[data-testid="classify-menu"]');
+    await expect(menu).toBeVisible();
+    await expect(
+      menu.locator('[data-testid="classify-menu-preview"]'),
+    ).toBeVisible();
+    await expect(
+      menu.locator('[data-testid="classify-menu-apply"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="classify-dropdown"]'),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  test("clicking outside the menu closes it", async ({ page }) => {
+    await openFirstMessage(page);
+
+    await page.locator('[data-testid="classify-dropdown"]').click();
+    await expect(page.locator('[data-testid="classify-menu"]')).toBeVisible();
+
+    // Click somewhere clearly outside the dropdown.
+    await page
+      .locator('[data-testid="message-headers"]')
+      .click({ position: { x: 5, y: 5 } });
+
+    await expect(page.locator('[data-testid="classify-menu"]')).toBeHidden();
+  });
+
+  test("Preview opens a modal that surfaces a result or a help/error state", async ({
+    page,
+  }) => {
+    await openFirstMessage(page);
+
+    await page.locator('[data-testid="classify-dropdown"]').click();
+    await page.locator('[data-testid="classify-menu-preview"]').click();
+
+    // Either the preview modal opens, or (when no rules are configured) the
+    // help-dialog opens. One of the two must be reachable from the menu.
+    const previewModal = page.locator('[data-testid="classify-preview-modal"]');
+    const noRulesModal = page.locator('[data-testid="classify-no-rules-modal"]');
+
+    await expect(previewModal.or(noRulesModal)).toBeVisible({ timeout: 30000 });
+
+    if (await previewModal.isVisible()) {
+      // Wait for the API call to finish — spinner disappears.
+      await expect(previewModal.locator(".spinner-border")).toBeHidden({
+        timeout: 30000,
+      });
+
+      // The modal must show either labels (or "no labels" message), or a
+      // visible error alert.
+      const labels = previewModal.locator(
+        '[data-testid="classify-preview-labels"], [data-testid="classify-preview-no-labels"], [data-testid="classify-preview-error"]',
+      );
+      await expect(labels.first()).toBeVisible();
+
+      await previewModal.getByRole("button", { name: /close/i }).click();
+      await expect(previewModal).toBeHidden();
+    } else {
+      // No-rules dialog must offer the help text and a deep link to settings.
+      await expect(
+        noRulesModal.locator('[data-testid="classify-no-rules-settings"]'),
+      ).toBeVisible();
+      await noRulesModal.getByRole("button", { name: /close/i }).click();
+      await expect(noRulesModal).toBeHidden();
+    }
+  });
+
+  test("Apply Now opens a confirmation dialog with Cancel/Confirm", async ({
+    page,
+  }) => {
+    await openFirstMessage(page);
+
+    await page.locator('[data-testid="classify-dropdown"]').click();
+    await page.locator('[data-testid="classify-menu-apply"]').click();
+
+    const applyModal = page.locator('[data-testid="classify-apply-modal"]');
+    const noRulesModal = page.locator('[data-testid="classify-no-rules-modal"]');
+
+    await expect(applyModal.or(noRulesModal)).toBeVisible({ timeout: 30000 });
+
+    if (await applyModal.isVisible()) {
+      await expect(applyModal.locator(".spinner-border")).toBeHidden({
+        timeout: 30000,
+      });
+
+      // Cancel must dismiss the dialog without firing an apply.
+      await applyModal
+        .getByRole("button", { name: /cancel|abbrechen|annuler|annulla/i })
+        .click();
+      await expect(applyModal).toBeHidden();
+    } else {
+      await noRulesModal.getByRole("button", { name: /close/i }).click();
+      await expect(noRulesModal).toBeHidden();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- New endpoint `POST /api/mail/messages/{id}/classify?dryRun=true` with two modes: dry-run preview (returns labels + materialized prompt + raw LLM response) and apply (persists labels and a `ClassificationResult`, drops any pending/failed queue item). Per-user authorization mirrors `GetMessage`: a foreign message returns 404.
- New shared UI primitive `DropdownButton` (with `DropdownButtonItem` record, showcase page at `/components-showcase/dropdown-button`, and a `component-library.md` entry) plus a `ToolbarDropdownAction` registration so detail pages can register dropdown-style toolbar actions.
- MessageDetail toolbar now exposes a Classify dropdown with Preview / Apply Now choices. Preview opens a modal showing recognized labels (as pills), the full LLM prompt and the raw LLM response. Apply Now opens a confirmation dialog. When no rules/labels are configured the API returns success with an empty result and the UI shows a help dialog with a deep link to `/settings/classification`.
- i18n strings added for all four locales (en-US, de-DE, fr-FR, it-IT).

## Implementation notes

- `IClassificationService` got a new `ClassifyDetailedAsync` method that returns prompt + raw response. The existing `ClassifyAsync` is now a thin wrapper so the background job and the new endpoint share a single classification path.
- The modals follow the inline-modal pattern from `Admin/Users.razor`. A reusable `Modal` primitive is intentionally not introduced here — that's tracked separately on #258.
- Tests: xUnit `MessageEndpointsTests` got 9 new cases covering both modes, the no-rules skip path, AI-unavailable fallback, hard failures, additive label application and per-user authorization. `TestWebApplicationFactory` now stubs `IChatClient` with a noop so endpoints that resolve `IClassificationService` don't fail when the Aspire/Ollama connection is absent. Bruno smoke tests cover unauthorized + not-found. Playwright tests exercise the dropdown trigger, menu open/close, outside-click dismissal, preview modal lifecycle, and apply-confirmation dialog.

Closes #231.

## Test plan

- [x] `dotnet build Feirb.sln` clean
- [x] `dotnet test` green (426 / 426 — 110 Web + 316 Api)
- [x] `dotnet format --verify-no-changes` clean
- [ ] Manual smoke (dev-harness): open a seeded message, Preview shows the prompt and raw response, Apply Now applies labels and the message reload reflects them
- [ ] Playwright `classify-message.spec.ts` against the dev environment

## Hard constraint check

- No emojis in commits / PR
- No client-side filtering — endpoint returns exactly what the UI needs
- Foreign message ID returns 404 (covered by `ClassifyMessage_OtherUserMessage_Returns404Async`)
- Modal primitive not introduced (deferred to #258)