### PR TITLE
chore: allow Write/Edit in agent worktrees for background subagents

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -111,7 +111,9 @@
       "mcp__playwright__browser_wait_for",
       "mcp__postgres__query",
       "mcp__postgres__list_tables",
-      "mcp__postgres__describe_table"
+      "mcp__postgres__describe_table",
+      "Write(**/.claude/worktrees/**)",
+      "Edit(**/.claude/worktrees/**)"
     ],
     "deny": [
       "Bash(git push --force:*)",


### PR DESCRIPTION
## Summary
- Add path-scoped \`Write(**/.claude/worktrees/**)\` and \`Edit(**/.claude/worktrees/**)\` to the project settings allowlist so background agents launched via the Agent tool can actually create and modify files in their isolated worktree.
- Without these rules subagents can read but not write, which blocks any agent-driven feature implementation.

## Why the scope is safe
- Limited to \`.claude/worktrees/**\` — the main checkout is unaffected.
- Worktrees are git-isolated copies, all changes land on a branch that is reviewed via PR before merging anywhere.

## Validation
- PR #272 (single-mail classify feature) was implemented end-to-end by a background agent with these rules in place.

## Test plan
- [ ] Launch a small background agent that creates a file in its worktree — verify no permission prompt