### PR TITLE
chore(deps): bump vulnerable packages to clear NU1902/NU1904

### DIFF
--- a/src/Feirb.Api/Endpoints/MailTestEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/MailTestEndpoints.cs
@@ -77,7 +77,7 @@ public static class MailTestEndpoints
 
             try
             {
-                if (request.RequiresAuth)
+                if (request.RequiresAuth && !string.IsNullOrEmpty(request.Username) && !string.IsNullOrEmpty(request.Password))
                     await client.AuthenticateAsync(request.Username, request.Password);
             }
             catch (AuthenticationException ex)

--- a/src/Feirb.Api/Endpoints/SetupEndpoints.cs
+++ b/src/Feirb.Api/Endpoints/SetupEndpoints.cs
@@ -75,7 +75,7 @@ public static class SetupEndpoints
             using var client = new SmtpClient();
             var tlsOptions = TlsModeConverter.ToSecureSocketOptions(request.TlsMode);
             await client.ConnectAsync(request.Host, request.Port, tlsOptions);
-            if (request.RequiresAuth)
+            if (request.RequiresAuth && !string.IsNullOrEmpty(request.Username) && !string.IsNullOrEmpty(request.Password))
                 await client.AuthenticateAsync(request.Username, request.Password);
             await client.DisconnectAsync(quit: true);
             return Results.Ok(new TestSmtpResponse(true, null));

--- a/src/Feirb.Api/Feirb.Api.csproj
+++ b/src/Feirb.Api/Feirb.Api.csproj
@@ -15,11 +15,11 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
     <PackageReference Include="CommunityToolkit.Aspire.OllamaSharp" Version="13.1.1" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
-    <PackageReference Include="MailKit" Version="4.15.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.6" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Feirb.Api/Services/ImapSyncService.cs
+++ b/src/Feirb.Api/Services/ImapSyncService.cs
@@ -51,7 +51,7 @@ public class ImapSyncService(
             await client.ConnectAsync(mailbox.ImapHost, mailbox.ImapPort, tlsOptions, cancellationToken);
             await client.AuthenticateAsync(mailbox.ImapUsername, password, cancellationToken);
 
-            var inbox = client.Inbox;
+            var inbox = client.Inbox ?? throw new InvalidOperationException("IMAP server did not expose an Inbox folder");
             await inbox.OpenAsync(FolderAccess.ReadOnly, cancellationToken);
 
             var lastSeenUid = await GetLastSeenUidAsync(db, mailboxId, cancellationToken);

--- a/src/Feirb.ServiceDefaults/Feirb.ServiceDefaults.csproj
+++ b/src/Feirb.ServiceDefaults/Feirb.ServiceDefaults.csproj
@@ -12,11 +12,11 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Feirb.Web/Feirb.Web.csproj
+++ b/src/Feirb.Web/Feirb.Web.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="CronExpressionDescriptor" Version="2.45.0" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />

--- a/tests/Feirb.Api.Tests/Feirb.Api.Tests.csproj
+++ b/tests/Feirb.Api.Tests/Feirb.Api.Tests.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />


### PR DESCRIPTION
## Summary

CI on `main` (and every PR branch off it) is currently failing at restore due to advisories that were published after the last green build (2026-05-04). This PR bumps the affected packages to versions that clear the advisories.

| Package | Before | After | Advisory |
|---|---|---|---|
| MailKit | 4.15.1 | 4.16.0 | GHSA-9j88-vvj5-vhgr |
| OpenTelemetry.Exporter.OpenTelemetryProtocol | 1.14.0 | 1.15.3 | GHSA-4625-4j76-fww9, GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933 |
| OpenTelemetry.Extensions.Hosting | 1.14.0 | 1.15.3 | GHSA-g94r-2vxg-569j |
| OpenTelemetry.Instrumentation.AspNetCore | 1.14.0 | 1.15.2 | GHSA-g94r-2vxg-569j |
| OpenTelemetry.Instrumentation.Http | 1.14.0 | 1.15.1 | GHSA-g94r-2vxg-569j |
| OpenTelemetry.Instrumentation.Runtime | 1.14.0 | 1.15.1 | GHSA-g94r-2vxg-569j |
| Microsoft.AspNetCore.* / EntityFrameworkCore.* | 10.0.6 | 10.0.7 | GHSA-9mv3-2cwr-p262 (critical) |

MailKit 4.16 tightened `IMailService.AuthenticateAsync` parameter annotations to non-nullable strings and `IMailStore.Inbox` to nullable, so three call sites needed null/empty guards:

- `SetupEndpoints.TestSmtpAsync` — guard on `request.Username`/`request.Password`
- `MailTestEndpoints` (TestImapAsync second auth call) — same guard
- `ImapSyncService.SyncAsync` — null check on `client.Inbox`

## Test plan

- [x] `dotnet restore Feirb.sln` — no NU1902/NU1904
- [x] `dotnet build Feirb.sln` — 0 errors
- [x] `dotnet test Feirb.sln` — 416/416 green (Web 110, Api 306)
- [ ] Smoke: SMTP/IMAP test connection works in /setup
- [ ] Smoke: IMAP sync job processes a mailbox