### PR TITLE
refactor(api): guard DatabaseSeeder against production environments (#264)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ This seeds the database with:
 
 The seeding is idempotent — it checks whether the data already exists and skips if so.
 
+> **Production safety:** Seeding is blocked when `ASPNETCORE_ENVIRONMENT=Production`, even if `FEIRB_SEED_DATA=true` is set. Seeded accounts use well-known credentials and must never reach a production deployment.
+
 ## Component Showcase
 
 Feirb includes a built-in component playground at `/components-showcase` for viewing, interacting with, and documenting all UI primitives. No authentication required — just start the app and navigate to the route.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -80,6 +80,8 @@ When started via `.claude/skills/dev-harness/start.sh --seeding` (or with `FEIRB
 
 The seeding is idempotent — it checks whether the data already exists and skips if so.
 
+> **Production safety:** `DatabaseSeeder` refuses to run when `ASPNETCORE_ENVIRONMENT=Production`, even if `FEIRB_SEED_DATA=true` is set. Seeded accounts use well-known credentials and are intended for development and testing only. Attempting to seed in Production raises an exception and stops application startup.
+
 ## Development Workflow
 
 ### Branching

--- a/src/Feirb.Api/Data/DatabaseSeeder.cs
+++ b/src/Feirb.Api/Data/DatabaseSeeder.cs
@@ -10,11 +10,19 @@ internal static class DatabaseSeeder
     private const string _smtpPasswordPurpose = "MailboxSmtpPassword";
     private const string _imapSyncJobType = "imap-sync";
 
-    public static async Task SeedAsync(FeirbDbContext db, ILogger logger, IDataProtectionProvider dataProtection, IConfiguration configuration)
+    public static async Task SeedAsync(FeirbDbContext db, ILogger logger, IDataProtectionProvider dataProtection, IConfiguration configuration, IHostEnvironment environment)
     {
         ArgumentNullException.ThrowIfNull(db);
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(dataProtection);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        // Defense-in-depth: refuse to seed in Production even if FEIRB_SEED_DATA=true.
+        // Seeded accounts use trivially guessable credentials and must never reach prod.
+        if (environment.IsProduction())
+            throw new InvalidOperationException(
+                "DatabaseSeeder.SeedAsync must not run in Production environment. " +
+                "Seeded accounts use well-known credentials and are intended for development/testing only.");
 
         var seeded = false;
 

--- a/src/Feirb.Api/Program.cs
+++ b/src/Feirb.Api/Program.cs
@@ -118,7 +118,7 @@ using (var scope = app.Services.CreateScope())
     {
         var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("DatabaseSeeder");
         var dataProtection = scope.ServiceProvider.GetRequiredService<IDataProtectionProvider>();
-        await DatabaseSeeder.SeedAsync(db, logger, dataProtection, app.Configuration);
+        await DatabaseSeeder.SeedAsync(db, logger, dataProtection, app.Configuration, app.Environment);
     }
 }
 

--- a/tests/Feirb.Api.Tests/Data/DatabaseSeederTests.cs
+++ b/tests/Feirb.Api.Tests/Data/DatabaseSeederTests.cs
@@ -5,6 +5,8 @@ using FluentAssertions;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Feirb.Api.Tests.Data;
@@ -30,12 +32,23 @@ public class DatabaseSeederTests
     private static IConfiguration CreateConfiguration() =>
         new ConfigurationBuilder().Build();
 
+    private static IHostEnvironment CreateEnvironment(string? environmentName = null) =>
+        new TestHostEnvironment { EnvironmentName = environmentName ?? Environments.Development };
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Development;
+        public string ApplicationName { get; set; } = "Feirb.Api.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+
     [Fact]
     public async Task SeedAsync_EmptyDatabase_CreatesUsersMailboxesAndSmtpSettingsAsync()
     {
         using var db = CreateInMemoryContext();
 
-        await DatabaseSeeder.SeedAsync(db, CreateLogger(), CreateDataProtection(), CreateConfiguration());
+        await DatabaseSeeder.SeedAsync(db, CreateLogger(), CreateDataProtection(), CreateConfiguration(), CreateEnvironment());
 
         var users = await db.Users.OrderBy(u => u.Username).ToListAsync();
         users.Should().HaveCount(2);
@@ -96,7 +109,7 @@ public class DatabaseSeederTests
         });
         await db.SaveChangesAsync();
 
-        await DatabaseSeeder.SeedAsync(db, CreateLogger(), CreateDataProtection(), CreateConfiguration());
+        await DatabaseSeeder.SeedAsync(db, CreateLogger(), CreateDataProtection(), CreateConfiguration(), CreateEnvironment());
 
         var users = await db.Users.ToListAsync();
         users.Should().HaveCount(2);
@@ -116,7 +129,7 @@ public class DatabaseSeederTests
         });
         await db.SaveChangesAsync();
 
-        await DatabaseSeeder.SeedAsync(db, CreateLogger(), CreateDataProtection(), CreateConfiguration());
+        await DatabaseSeeder.SeedAsync(db, CreateLogger(), CreateDataProtection(), CreateConfiguration(), CreateEnvironment());
 
         var settings = await db.SmtpSettings.ToListAsync();
         settings.Should().HaveCount(1);
@@ -129,8 +142,8 @@ public class DatabaseSeederTests
         using var db = CreateInMemoryContext();
         var dp = CreateDataProtection();
 
-        await DatabaseSeeder.SeedAsync(db, CreateLogger(), dp, CreateConfiguration());
-        await DatabaseSeeder.SeedAsync(db, CreateLogger(), dp, CreateConfiguration());
+        await DatabaseSeeder.SeedAsync(db, CreateLogger(), dp, CreateConfiguration(), CreateEnvironment());
+        await DatabaseSeeder.SeedAsync(db, CreateLogger(), dp, CreateConfiguration(), CreateEnvironment());
 
         (await db.Users.CountAsync()).Should().Be(2);
         (await db.Mailboxes.CountAsync()).Should().Be(2);
@@ -144,12 +157,50 @@ public class DatabaseSeederTests
         var dp = CreateDataProtection();
 
         // First seed creates everything
-        await DatabaseSeeder.SeedAsync(db, CreateLogger(), dp, CreateConfiguration());
+        await DatabaseSeeder.SeedAsync(db, CreateLogger(), dp, CreateConfiguration(), CreateEnvironment());
 
         // Second seed should not duplicate mailboxes
-        await DatabaseSeeder.SeedAsync(db, CreateLogger(), dp, CreateConfiguration());
+        await DatabaseSeeder.SeedAsync(db, CreateLogger(), dp, CreateConfiguration(), CreateEnvironment());
 
         var mailboxes = await db.Mailboxes.ToListAsync();
         mailboxes.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task SeedAsync_ProductionEnvironment_ThrowsAndSeedsNothingAsync()
+    {
+        using var db = CreateInMemoryContext();
+
+        var act = async () => await DatabaseSeeder.SeedAsync(
+            db,
+            CreateLogger(),
+            CreateDataProtection(),
+            CreateConfiguration(),
+            CreateEnvironment(Environments.Production));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Production*");
+
+        (await db.Users.CountAsync()).Should().Be(0);
+        (await db.Mailboxes.CountAsync()).Should().Be(0);
+        (await db.SmtpSettings.CountAsync()).Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData("Development")]
+    [InlineData("Staging")]
+    [InlineData("Testing")]
+    public async Task SeedAsync_NonProductionEnvironments_SeedsSuccessfullyAsync(string environmentName)
+    {
+        using var db = CreateInMemoryContext();
+
+        await DatabaseSeeder.SeedAsync(
+            db,
+            CreateLogger(),
+            CreateDataProtection(),
+            CreateConfiguration(),
+            CreateEnvironment(environmentName));
+
+        (await db.Users.CountAsync()).Should().Be(2);
     }
 }


### PR DESCRIPTION
## Summary

- Defense-in-depth: `DatabaseSeeder.SeedAsync` now refuses to run when `ASPNETCORE_ENVIRONMENT=Production`, even if `FEIRB_SEED_DATA=true` is set.
- Seeded accounts use well-known credentials (`admin` / `alice` with email-as-password) and must never reach a production deployment — this guard closes the misconfiguration window.

## Changes

- `DatabaseSeeder.SeedAsync` takes `IHostEnvironment` and throws `InvalidOperationException` when `environment.IsProduction()`.
- `Program.cs` updated to pass `app.Environment`.
- New tests:
  - `SeedAsync_ProductionEnvironment_ThrowsAndSeedsNothingAsync` — verifies the guard throws and nothing is written.
  - `SeedAsync_NonProductionEnvironments_SeedsSuccessfullyAsync` — theory covering `Development`, `Staging`, `Testing`.
- README and `docs/SETUP.md` document the guarantee.

## Test plan

- [x] `dotnet build Feirb.sln` — 0 errors
- [x] `dotnet test Feirb.sln` — 430/430 green (was 416; +14 includes the 4 new cases here)
- [x] `dotnet format Feirb.sln --verify-no-changes` — clean
- [ ] Manual: start Aspire with `FEIRB_SEED_DATA=true` in Development — verify seeding still works
- [ ] Manual smoke: set `ASPNETCORE_ENVIRONMENT=Production` + `FEIRB_SEED_DATA=true` — verify startup fails with the guard message

Closes #264