### PR TITLE
refactor(shared): consolidate paginated response envelopes (#263)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,7 @@ Shell scripts in `.claude/skills/dev-harness/` for autonomous app interaction:
 - All request/response DTOs in `Feirb.Shared`
 - **Data belongs on the server, not in the client.** If the frontend needs specific data, create a dedicated API endpoint that returns exactly that data. Never fetch a broad list and filter client-side — it breaks at pagination boundaries, wastes bandwidth, and couples the UI to assumptions about data volume.
 - **Every endpoint must enforce authorization.** No endpoint may return data the requesting user is not authorized to see. Prefer dedicated endpoints for admin and user contexts when the requirements differ. When a shared endpoint avoids duplication, it must filter server-side based on the authenticated user — admin sees all, regular users see only their own data. Authorization is never optional or deferred.
+- **Paginated responses use the canonical `PaginatedResponse<T>` envelope** in `Feirb.Shared`: `(List<T> Items, int Page, int PageSize, int TotalCount)`. Do not invent per-feature envelopes that re-declare these four fields. When an endpoint needs extra metadata (e.g. `MessageListResponse` with `PendingCount`, `JobPaused`), derive from `PaginatedResponse<T>` via positional record inheritance so the JSON payload stays flat for clients.
 
 ## LLM Integration
 

--- a/src/Feirb.Api/Services/IJobService.cs
+++ b/src/Feirb.Api/Services/IJobService.cs
@@ -1,3 +1,4 @@
+using Feirb.Shared;
 using Feirb.Shared.Admin.Jobs;
 
 namespace Feirb.Api.Services;
@@ -8,9 +9,9 @@ public interface IJobService
     Task<List<JobSettingsResponse>> GetForUserAsync(Guid userId, CancellationToken cancellationToken = default);
     Task<List<JobSettingsResponse>> GetByResourceAsync(string resourceType, Guid resourceId, Guid userId, bool isAdmin, CancellationToken cancellationToken = default);
     Task<JobSettingsResponse?> GetByIdAsync(Guid id, Guid userId, bool isAdmin, CancellationToken cancellationToken = default);
-    Task<PaginatedJobExecutionsResponse?> GetExecutionsAsync(Guid jobId, Guid userId, bool isAdmin, int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<PaginatedResponse<JobExecutionResponse>?> GetExecutionsAsync(Guid jobId, Guid userId, bool isAdmin, int page, int pageSize, CancellationToken cancellationToken = default);
     Task<JobExecutionResponse?> GetExecutionByIdAsync(Guid jobId, Guid executionId, Guid userId, bool isAdmin, CancellationToken cancellationToken = default);
-    Task<PaginatedJobExecutionLogsResponse?> GetExecutionLogsAsync(Guid jobId, Guid executionId, Guid userId, bool isAdmin, int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<PaginatedResponse<JobExecutionLogResponse>?> GetExecutionLogsAsync(Guid jobId, Guid executionId, Guid userId, bool isAdmin, int page, int pageSize, CancellationToken cancellationToken = default);
     Task<JobSettingsResponse?> UpdateAsync(Guid id, UpdateJobSettingsRequest request, Guid userId, bool isAdmin, CancellationToken cancellationToken = default);
     Task<bool> TriggerRunAsync(Guid id, Guid userId, bool isAdmin, CancellationToken cancellationToken = default);
 }

--- a/src/Feirb.Api/Services/JobService.cs
+++ b/src/Feirb.Api/Services/JobService.cs
@@ -1,5 +1,6 @@
 using Feirb.Api.Data;
 using Feirb.Api.Data.Entities;
+using Feirb.Shared;
 using Feirb.Shared.Admin.Jobs;
 using Microsoft.EntityFrameworkCore;
 using Quartz;
@@ -80,7 +81,7 @@ public class JobService(
         return MapToResponse(job);
     }
 
-    public async Task<PaginatedJobExecutionsResponse?> GetExecutionsAsync(
+    public async Task<PaginatedResponse<JobExecutionResponse>?> GetExecutionsAsync(
         Guid jobId, Guid userId, bool isAdmin, int page, int pageSize,
         CancellationToken cancellationToken = default)
     {
@@ -111,7 +112,7 @@ public class JobService(
                 e.Error))
             .ToListAsync(cancellationToken);
 
-        return new PaginatedJobExecutionsResponse(items, totalCount, page, pageSize);
+        return new PaginatedResponse<JobExecutionResponse>(items, page, pageSize, totalCount);
     }
 
     public async Task<JobExecutionResponse?> GetExecutionByIdAsync(
@@ -140,7 +141,7 @@ public class JobService(
         return execution;
     }
 
-    public async Task<PaginatedJobExecutionLogsResponse?> GetExecutionLogsAsync(
+    public async Task<PaginatedResponse<JobExecutionLogResponse>?> GetExecutionLogsAsync(
         Guid jobId, Guid executionId, Guid userId, bool isAdmin, int page, int pageSize,
         CancellationToken cancellationToken = default)
     {
@@ -176,7 +177,7 @@ public class JobService(
                 l.Message))
             .ToListAsync(cancellationToken);
 
-        return new PaginatedJobExecutionLogsResponse(items, totalCount, page, pageSize);
+        return new PaginatedResponse<JobExecutionLogResponse>(items, page, pageSize, totalCount);
     }
 
     public async Task<JobSettingsResponse?> UpdateAsync(

--- a/src/Feirb.Shared/Admin/Jobs/PaginatedJobExecutionLogsResponse.cs
+++ b/src/Feirb.Shared/Admin/Jobs/PaginatedJobExecutionLogsResponse.cs
@@ -1,7 +1,0 @@
-namespace Feirb.Shared.Admin.Jobs;
-
-public record PaginatedJobExecutionLogsResponse(
-    List<JobExecutionLogResponse> Items,
-    int TotalCount,
-    int Page,
-    int PageSize);

--- a/src/Feirb.Shared/Admin/Jobs/PaginatedJobExecutionsResponse.cs
+++ b/src/Feirb.Shared/Admin/Jobs/PaginatedJobExecutionsResponse.cs
@@ -1,7 +1,0 @@
-namespace Feirb.Shared.Admin.Jobs;
-
-public record PaginatedJobExecutionsResponse(
-    List<JobExecutionResponse> Items,
-    int TotalCount,
-    int Page,
-    int PageSize);

--- a/src/Feirb.Shared/Mail/MessageListResponse.cs
+++ b/src/Feirb.Shared/Mail/MessageListResponse.cs
@@ -6,4 +6,4 @@ public record MessageListResponse(
     int PageSize,
     int TotalCount,
     int PendingCount,
-    bool JobPaused);
+    bool JobPaused) : PaginatedResponse<MessageListItemResponse>(Items, Page, PageSize, TotalCount);

--- a/src/Feirb.Shared/Mail/PaginatedResponse.cs
+++ b/src/Feirb.Shared/Mail/PaginatedResponse.cs
@@ -1,3 +1,0 @@
-namespace Feirb.Shared.Mail;
-
-public record PaginatedResponse<T>(List<T> Items, int Page, int PageSize, int TotalCount);

--- a/src/Feirb.Shared/PaginatedResponse.cs
+++ b/src/Feirb.Shared/PaginatedResponse.cs
@@ -1,0 +1,8 @@
+namespace Feirb.Shared;
+
+/// <summary>
+/// Canonical envelope for paginated list responses across the API.
+/// Endpoints that need extra metadata derive from this record via positional inheritance
+/// (e.g. <c>MessageListResponse</c>) so the JSON payload stays flat.
+/// </summary>
+public record PaginatedResponse<T>(List<T> Items, int Page, int PageSize, int TotalCount);

--- a/src/Feirb.Web/Pages/Admin/SystemSettings/ExecutionDetail.razor
+++ b/src/Feirb.Web/Pages/Admin/SystemSettings/ExecutionDetail.razor
@@ -1,5 +1,6 @@
 @page "/admin/jobs/{JobId:guid}/executions/{ExecutionId:guid}"
 @attribute [Authorize(Policy = "RequireAdmin")]
+@using Feirb.Shared
 @using Feirb.Shared.Admin.Jobs
 @using Feirb.Web.Services
 @inject HttpClient Http
@@ -123,7 +124,7 @@ else
     public Guid ExecutionId { get; set; }
 
     private JobExecutionResponse? _execution;
-    private PaginatedJobExecutionLogsResponse? _logs;
+    private PaginatedResponse<JobExecutionLogResponse>? _logs;
     private bool _isLoading = true;
     private bool _notFound;
     private bool _logsLoading;
@@ -188,7 +189,7 @@ else
         _logsLoading = true;
         try
         {
-            _logs = await Http.GetFromJsonAsync<PaginatedJobExecutionLogsResponse>(
+            _logs = await Http.GetFromJsonAsync<PaginatedResponse<JobExecutionLogResponse>>(
                 $"/api/jobs/{JobId}/executions/{ExecutionId}/logs?page={_logsPage}&pageSize={_logsPageSize}");
             if (_logs is not null)
                 _logsTotalPages = (int)Math.Ceiling((double)_logs.TotalCount / _logsPageSize);

--- a/src/Feirb.Web/Pages/Admin/SystemSettings/JobDetail.razor
+++ b/src/Feirb.Web/Pages/Admin/SystemSettings/JobDetail.razor
@@ -1,6 +1,7 @@
 @page "/admin/jobs/{Id:guid}"
 @attribute [Authorize(Policy = "RequireAdmin")]
 @using System.Text.Json
+@using Feirb.Shared
 @using Feirb.Shared.Admin.Jobs
 @using Feirb.Web.Services
 @inject HttpClient Http
@@ -139,7 +140,7 @@ else if (_model is not null)
     private bool _isSaving;
     private string? _errorMessage;
     private string _selectedPreset = "custom";
-    private PaginatedJobExecutionsResponse? _executions;
+    private PaginatedResponse<JobExecutionResponse>? _executions;
     private bool _executionsLoading;
     private int _execPage = 1;
     private int _execPageSize = 10;
@@ -222,7 +223,7 @@ else if (_model is not null)
         _executionsLoading = true;
         try
         {
-            _executions = await Http.GetFromJsonAsync<PaginatedJobExecutionsResponse>(
+            _executions = await Http.GetFromJsonAsync<PaginatedResponse<JobExecutionResponse>>(
                 $"/api/jobs/{Id}/executions?page={_execPage}&pageSize={_execPageSize}");
             if (_executions is not null)
                 _execTotalPages = (int)Math.Ceiling((double)_executions.TotalCount / _execPageSize);

--- a/tests/Feirb.Api.Tests/Endpoints/JobSettingsEndpointsTests.cs
+++ b/tests/Feirb.Api.Tests/Endpoints/JobSettingsEndpointsTests.cs
@@ -158,6 +158,52 @@ public class JobSettingsEndpointsTests : IDisposable
     }
 
     [Fact]
+    public async Task GetJobExecutionLogs_AsAdmin_ReturnsPaginatedResultAsync()
+    {
+        var tokens = await SetupAndLoginAsAdminAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+        var jobs = await _client.GetFromJsonAsync<List<JobSettingsResponse>>("/api/jobs");
+        var job = jobs![0];
+
+        var executionId = Guid.NewGuid();
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<FeirbDbContext>();
+            db.JobExecutions.Add(new JobExecution
+            {
+                Id = executionId,
+                JobSettingsId = job.Id,
+                StartedAt = DateTime.UtcNow,
+                FinishedAt = DateTime.UtcNow.AddSeconds(1),
+                Status = JobExecutionStatus.Success,
+            });
+            for (var i = 0; i < 3; i++)
+            {
+                db.JobExecutionLogs.Add(new JobExecutionLog
+                {
+                    Id = Guid.NewGuid(),
+                    JobExecutionId = executionId,
+                    Timestamp = DateTimeOffset.UtcNow.AddSeconds(i),
+                    Level = JobExecutionLogLevel.Info,
+                    Message = $"log entry {i}",
+                });
+            }
+            await db.SaveChangesAsync();
+        }
+
+        var response = await _client.GetAsync($"/api/jobs/{job.Id}/executions/{executionId}/logs?page=1&pageSize=2");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<PaginatedResponse<JobExecutionLogResponse>>();
+        result.Should().NotBeNull();
+        result!.TotalCount.Should().Be(3);
+        result.Items.Should().HaveCount(2);
+        result.Page.Should().Be(1);
+        result.PageSize.Should().Be(2);
+    }
+
+    [Fact]
     public async Task GetAllJobs_WithRecentExecutions_IncludesLast5Async()
     {
         var tokens = await SetupAndLoginAsAdminAsync();

--- a/tests/Feirb.Api.Tests/Endpoints/JobSettingsEndpointsTests.cs
+++ b/tests/Feirb.Api.Tests/Endpoints/JobSettingsEndpointsTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using Feirb.Api.Data;
 using Feirb.Api.Data.Entities;
+using Feirb.Shared;
 using Feirb.Shared.Admin.Jobs;
 using Feirb.Shared.Auth;
 using Feirb.Shared.Settings;
@@ -148,7 +149,7 @@ public class JobSettingsEndpointsTests : IDisposable
         var response = await _client.GetAsync($"/api/jobs/{job.Id}/executions?page=1&pageSize=2");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<PaginatedJobExecutionsResponse>();
+        var result = await response.Content.ReadFromJsonAsync<PaginatedResponse<JobExecutionResponse>>();
         result.Should().NotBeNull();
         result!.TotalCount.Should().Be(3);
         result.Items.Should().HaveCount(2);


### PR DESCRIPTION
## Summary

Promotes `PaginatedResponse<T>` to a top-level `Feirb.Shared` envelope and removes per-feature redeclarations of the same four pagination fields (`Items`, `Page`, `PageSize`, `TotalCount`).

## Design choice

The issue floated two options. This PR ships a third that satisfies both stated concerns from the issue (single source of truth + no client-side gymnastics):

- **Canonical envelope:** `PaginatedResponse<T>(List<T> Items, int Page, int PageSize, int TotalCount)` in `Feirb.Shared`.
- **Endpoints with extra metadata** derive from it via **positional record inheritance**:
  ```csharp
  public record MessageListResponse(
      List<MessageListItemResponse> Items,
      int Page,
      int PageSize,
      int TotalCount,
      int PendingCount,
      bool JobPaused) : PaginatedResponse<MessageListItemResponse>(Items, Page, PageSize, TotalCount);
  ```
  The JSON stays flat for clients (no `.page.items` nesting); the four pagination fields live in one place at the type level.

## Changes

- New `Feirb.Shared/PaginatedResponse.cs` (top-level namespace; pagination is cross-cutting, not mail-specific)
- Deleted: `Feirb.Shared/Mail/PaginatedResponse.cs`, `Feirb.Shared/Admin/Jobs/PaginatedJobExecutionsResponse.cs`, `Feirb.Shared/Admin/Jobs/PaginatedJobExecutionLogsResponse.cs`
- `MessageListResponse` migrated to record inheritance
- `IJobService`, `JobService`, the two job Razor pages and the API tests migrated to `PaginatedResponse<JobExecutionResponse>` / `PaginatedResponse<JobExecutionLogResponse>`
- `CLAUDE.md` API Design section documents the convention for future endpoints

## Verification

- [x] `dotnet build Feirb.sln` — 0 errors
- [x] `dotnet test Feirb.sln` — 430/430 green (integration tests round-trip the JSON shape)
- [x] `dotnet format Feirb.sln --verify-no-changes` — clean

Closes #263